### PR TITLE
SimpleScalarSeparateChainingHashTable for fast-path join & grouping

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -553,6 +553,9 @@ void ExecutionGenerator::convertHashJoin(const P::HashJoinPtr &physical_plan) {
       query_context_proto_->join_hash_tables_size();
   S::HashTable *hash_table_proto = query_context_proto_->add_join_hash_tables();
 
+  // SimplifyHashTableImplTypeProto() switches the hash table implementation
+  // from SeparateChaining to SimpleScalarSeparateChaining when there is a
+  // single scalar key type with a reversible hash function.
   hash_table_proto->set_hash_table_impl_type(
       SimplifyHashTableImplTypeProto(
           HashTableImplTypeProtoFromString(FLAGS_join_hashtable_type),
@@ -1037,6 +1040,9 @@ void ExecutionGenerator::convertAggregate(
   aggr_state_proto->set_estimated_num_entries(cost_model_->estimateCardinality(physical_plan));
 
   if (!group_by_types.empty()) {
+    // SimplifyHashTableImplTypeProto() switches the hash table implementation
+    // from SeparateChaining to SimpleScalarSeparateChaining when there is a
+    // single scalar key type with a reversible hash function.
     aggr_state_proto->set_hash_table_impl_type(
         SimplifyHashTableImplTypeProto(
             HashTableImplTypeProtoFromString(FLAGS_aggregate_hashtable_type),

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -436,6 +436,7 @@ target_link_libraries(HashJoinOperator_unittest
                       quickstep_relationaloperators_RelationalOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_HashTable_proto
+                      quickstep_storage_HashTableBase
                       quickstep_storage_InsertDestination
                       quickstep_storage_InsertDestination_proto
                       quickstep_storage_StorageBlock

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -170,6 +170,7 @@ add_library(quickstep_storage_HashTable ../empty_src.cpp HashTable.hpp)
 add_library(quickstep_storage_HashTable_proto ${storage_HashTable_proto_srcs})
 add_library(quickstep_storage_HashTableBase ../empty_src.cpp HashTableBase.hpp)
 add_library(quickstep_storage_HashTableFactory HashTableFactory.cpp HashTableFactory.hpp)
+add_library(quickstep_storage_HashTableKeyManager ../empty_src.cpp HashTableKeyManager.hpp)
 add_library(quickstep_storage_IndexSubBlock ../empty_src.cpp IndexSubBlock.hpp)
 add_library(quickstep_storage_InsertDestination InsertDestination.cpp InsertDestination.hpp)
 add_library(quickstep_storage_InsertDestinationInterface
@@ -516,7 +517,6 @@ target_link_libraries(quickstep_storage_HashTable
                       quickstep_threading_SpinSharedMutex
                       quickstep_types_Type
                       quickstep_types_TypedValue
-                      quickstep_types_operations_comparisons_ComparisonUtil
                       quickstep_utility_HashPair
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_HashTableBase
@@ -533,6 +533,14 @@ target_link_libraries(quickstep_storage_HashTableFactory
                       quickstep_storage_SeparateChainingHashTable
                       quickstep_storage_TupleReference
                       quickstep_types_TypeFactory
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_storage_HashTableKeyManager
+                      glog
+                      quickstep_storage_HashTableBase
+                      quickstep_storage_StorageConstants
+                      quickstep_types_Type
+                      quickstep_types_TypedValue
+                      quickstep_types_operations_comparisons_ComparisonUtil
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_IndexSubBlock
                       quickstep_catalog_CatalogTypedefs
@@ -571,6 +579,7 @@ target_link_libraries(quickstep_storage_InsertDestination_proto
                       ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_storage_LinearOpenAddressingHashTable
                       quickstep_storage_HashTable
+                      quickstep_storage_HashTableKeyManager
                       quickstep_storage_StorageBlob
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageConstants
@@ -621,6 +630,8 @@ target_link_libraries(quickstep_storage_PreloaderThread
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_SeparateChainingHashTable
                       quickstep_storage_HashTable
+                      quickstep_storage_HashTableBase
+                      quickstep_storage_HashTableKeyManager
                       quickstep_storage_StorageBlob
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageConstants
@@ -808,6 +819,7 @@ target_link_libraries(quickstep_storage
                       quickstep_storage_HashTable_proto
                       quickstep_storage_HashTableBase
                       quickstep_storage_HashTableFactory
+                      quickstep_storage_HashTableKeyManager
                       quickstep_storage_IndexSubBlock
                       quickstep_storage_InsertDestination
                       quickstep_storage_InsertDestinationInterface

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -190,6 +190,9 @@ add_library(quickstep_storage_PackedRowStoreValueAccessor
             PackedRowStoreValueAccessor.hpp)
 add_library(quickstep_storage_PreloaderThread PreloaderThread.cpp PreloaderThread.hpp)
 add_library(quickstep_storage_SeparateChainingHashTable ../empty_src.cpp SeparateChainingHashTable.hpp)
+add_library(quickstep_storage_SimpleScalarSeparateChainingHashTable
+            SimpleScalarSeparateChainingHashTable.cpp
+            SimpleScalarSeparateChainingHashTable.hpp)
 add_library(quickstep_storage_SplitRowStoreTupleStorageSubBlock
             SplitRowStoreTupleStorageSubBlock.cpp
             SplitRowStoreTupleStorageSubBlock.hpp)
@@ -531,8 +534,11 @@ target_link_libraries(quickstep_storage_HashTableFactory
                       quickstep_storage_HashTableBase
                       quickstep_storage_LinearOpenAddressingHashTable
                       quickstep_storage_SeparateChainingHashTable
+                      quickstep_storage_SimpleScalarSeparateChainingHashTable
                       quickstep_storage_TupleReference
+                      quickstep_types_Type
                       quickstep_types_TypeFactory
+                      quickstep_types_TypedValue
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_HashTableKeyManager
                       glog
@@ -632,6 +638,20 @@ target_link_libraries(quickstep_storage_SeparateChainingHashTable
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
                       quickstep_storage_HashTableKeyManager
+                      quickstep_storage_StorageBlob
+                      quickstep_storage_StorageBlockInfo
+                      quickstep_storage_StorageConstants
+                      quickstep_storage_StorageManager
+                      quickstep_threading_SpinSharedMutex
+                      quickstep_types_Type
+                      quickstep_types_TypedValue
+                      quickstep_utility_Alignment
+                      quickstep_utility_Macros
+                      quickstep_utility_PrimeNumber)
+target_link_libraries(quickstep_storage_SimpleScalarSeparateChainingHashTable
+                      glog
+                      quickstep_storage_HashTable
+                      quickstep_storage_HashTableBase
                       quickstep_storage_StorageBlob
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageConstants
@@ -829,6 +849,7 @@ target_link_libraries(quickstep_storage
                       quickstep_storage_PackedRowStoreValueAccessor
                       quickstep_storage_PreloaderThread
                       quickstep_storage_SeparateChainingHashTable
+                      quickstep_storage_SimpleScalarSeparateChainingHashTable
                       quickstep_storage_SplitRowStoreTupleStorageSubBlock
                       quickstep_storage_SplitRowStoreValueAccessor
                       quickstep_storage_StorageBlob
@@ -861,6 +882,16 @@ elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
 endif()
 
 # Tests:
+include(CheckTypeSize)
+CHECK_TYPE_SIZE("size_t" SIZEOF_SIZE_T)
+if (SIZEOF_SIZE_T GREATER 7)
+  set(QUICKSTEP_LONG_HASH_REVERSIBLE 1)
+endif()
+configure_file (
+  "${CMAKE_CURRENT_SOURCE_DIR}/tests/StorageTestConfig.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/tests/StorageTestConfig.h"
+)
+
 add_library(quickstep_storage_tests_FileManager_unittest_common
             ../empty_src.cpp
             "${CMAKE_CURRENT_SOURCE_DIR}/tests/FileManager_unittest_common.hpp")
@@ -1153,6 +1184,17 @@ target_link_libraries(SeparateChainingHashTable_unittest
                       quickstep_storage_tests_HashTable_unittest_common
                       ${LIBS})
 add_test(SeparateChainingHashTable_unittest SeparateChainingHashTable_unittest)
+
+add_executable(SimpleScalarSeparateChainingHashTable_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/SimpleScalarSeparateChainingHashTable_unittest.cpp")
+target_link_libraries(SimpleScalarSeparateChainingHashTable_unittest
+                      gtest
+                      gtest_main
+                      quickstep_storage_SimpleScalarSeparateChainingHashTable
+                      quickstep_storage_tests_HashTable_unittest_common
+                      ${LIBS})
+add_test(SimpleScalarSeparateChainingHashTable_unittest
+         SimpleScalarSeparateChainingHashTable_unittest)
 
 add_executable(SplitRowStoreTupleStorageSubBlock_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp")

--- a/storage/HashTable.proto
+++ b/storage/HashTable.proto
@@ -1,5 +1,5 @@
 //   Copyright 2011-2015 Quickstep Technologies LLC.
-//   Copyright 2015 Pivotal Software, Inc.
+//   Copyright 2015-2016 Pivotal Software, Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import "types/Type.proto";
 enum HashTableImplType {
   LINEAR_OPEN_ADDRESSING = 0;
   SEPARATE_CHAINING = 1;
+  SIMPLE_SCALAR_SEPARATE_CHAINING = 2;
 }
 
 // NOTE(chasseur): This proto describes the run-time parameters for a resizable

--- a/storage/HashTableBase.hpp
+++ b/storage/HashTableBase.hpp
@@ -1,5 +1,5 @@
 /**
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #ifndef QUICKSTEP_STORAGE_HASH_TABLE_BASE_HPP_
 #define QUICKSTEP_STORAGE_HASH_TABLE_BASE_HPP_
 
+#include <cstddef>
+
 #include "utility/Macros.hpp"
 
 namespace quickstep {
@@ -33,6 +35,16 @@ namespace quickstep {
 enum class HashTableImplType {
   kLinearOpenAddressing,
   kSeparateChaining
+};
+
+/**
+ * @brief Used internally by HashTables to keep track of pre-allocated
+ *        resources used in putValueAccessor() and
+ *        putValueAccessorCompositeKey().
+ **/
+struct HashTablePreallocationState {
+  std::size_t bucket_position;
+  std::size_t variable_length_key_position;
 };
 
 /**

--- a/storage/HashTableBase.hpp
+++ b/storage/HashTableBase.hpp
@@ -34,7 +34,8 @@ namespace quickstep {
  **/
 enum class HashTableImplType {
   kLinearOpenAddressing,
-  kSeparateChaining
+  kSeparateChaining,
+  kSimpleScalarSeparateChaining
 };
 
 /**

--- a/storage/HashTableKeyManager.hpp
+++ b/storage/HashTableKeyManager.hpp
@@ -1,0 +1,513 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_STORAGE_HASH_TABLE_KEY_MANAGER_HPP_
+#define QUICKSTEP_STORAGE_HASH_TABLE_KEY_MANAGER_HPP_
+
+#include <atomic>
+#include <cstddef>
+#include <vector>
+
+#include "storage/HashTableBase.hpp"
+#include "storage/StorageConstants.hpp"
+#include "types/Type.hpp"
+#include "types/TypedValue.hpp"
+#include "types/operations/comparisons/ComparisonUtil.hpp"
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+/** \addtogroup Storage
+ *  @{
+ */
+
+/**
+ * @brief Helper object that manages key storage on behalf of a HashTable
+ *        implementation.
+ *
+ * @tparam serializable Whether the HashTable can safely be saved to and
+ *         loaded from disk. If false, out of band memory may be used to store
+ *         variable length keys.
+ * @tparam force_key_copy If true, inserted keys are always copied into
+ *         HashTable memory. If false, pointers to external values may be
+ *         stored instead. force_key_copy should be true if the hash table will
+ *         outlive the external key values which are inserted into it. Note
+ *         that if serializable is true and force_key_copy is false, then
+ *         relative offsets will be used instead of absolute pointers to keys,
+ *         meaning that the pointed-to keys must be serialized and deserialized
+ *         in exactly the same relative byte order (e.g. as part of the same
+ *         StorageBlock), and keys must not change position relative to the
+ *         HashTable (beware TupleStorageSubBlocks that may self-reorganize
+ *         when modified).
+ **/
+template <bool serializable, bool force_key_copy>
+class HashTableKeyManager {
+ public:
+  /**
+   * @brief Constructor.
+   *
+   * @param key_types A vector of pointers to the Types of key components for
+   *        a HashTable. This is stored as a reference, not copied, so it must
+   *        remain valid as long as this HashTableKeyManager will be used.
+   * @param key_start_in_bucket The position in the HashTable's buckets where
+   *        storage for keys begins, measured as the number of bytes from the
+   *        start of the bucket.
+   **/
+  HashTableKeyManager(const std::vector<const Type*> &key_types,
+                      const std::size_t key_start_in_bucket);
+
+  /**
+   * @return The size (in bytes) of fixed (in-bucket) key storage.
+   **/
+  inline std::size_t getFixedKeySize() const {
+    return fixed_key_size_;
+  }
+
+  /**
+   * @return The total estimated size (in bytes) of variable-length key
+   *         components stored out-of-line.
+   **/
+  inline std::size_t getEstimatedVariableKeySize() const {
+    return estimated_variable_key_size_;
+  }
+
+  /**
+   * @return A vector of bools indicating which key components are stored
+   *         inline in buckets.
+   **/
+  inline const std::vector<bool>* getKeyInline() const {
+    return &key_inline_;
+  }
+
+  /**
+   * @brief Set information about out-of-line variable length key storage for
+   *        a HashTable.
+   *
+   * @param variable_length_key_storage The location in memory of
+   *        variable-length key storage for the HashTable.
+   * @param variable_length_key_storage_size The size (in bytes) of the region
+   *        at variable_length_key_storage.
+   * @param variable_length_bytes_allocated A pointer to an atomic variable
+   *        that counts how many bytes of variable-length storage have actually
+   *        been allocated to store keys.
+   **/
+  void setVariableLengthStorageInfo(
+      void *variable_length_key_storage,
+      const std::size_t variable_length_key_storage_size,
+      std::atomic<std::size_t> *variable_length_bytes_allocated) {
+    variable_length_key_storage_ = variable_length_key_storage;
+    variable_length_key_storage_size_ = variable_length_key_storage_size;
+    variable_length_bytes_allocated_ = variable_length_bytes_allocated;
+    next_variable_length_key_offset_.store(
+        variable_length_bytes_allocated_->load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
+  }
+
+  /**
+   * @return A pointer to the variable-length key storage region for the
+   *         HashTable.
+   **/
+  inline const void* getVariableLengthKeyStorage() const {
+    return variable_length_key_storage_;
+  }
+
+  /**
+   * @return The size (in bytes) of the HashTable's variable-length key storage
+   *         region.
+   **/
+  inline std::size_t getVariableLengthKeyStorageSize() const {
+    return variable_length_key_storage_size_;
+  }
+
+  /**
+   * @brief Get a pointer to a component of a key in a particular bucket.
+   *
+   * @param bucket A pointer to a bucket in the HashTable.
+   * @param component_idx The index of the desired key component (0 for single
+   *        scalar keys).
+   * @return A pointer to the key component specified by component_idx in
+   *         bucket.
+   **/
+  inline const void* getKeyComponent(
+      const void *bucket,
+      const std::size_t component_idx) const;
+
+  /**
+   * @brief Get a component of a key in a particular bucket as a TypedValue.
+   *
+   * @note Unlike getKeyComponent(), this method also determines the size in
+   *       bytes of the key component in order to construct the TypedValue.
+   *
+   * @param bucket A pointer to a bucket in the HashTable.
+   * @param component_idx The index of the desired key component (0 for single
+   *        scalar keys).
+   * @return The key component specified by component_idx in bucket as a
+   *         TypedValue.
+   **/
+  inline TypedValue getKeyComponentTyped(
+      const void *bucket,
+      const std::size_t component_idx) const;
+
+  /**
+   * @brief Check whether a key is actually equal to a scalar key stored in a
+   *        HashTable bucket.
+   *
+   * @param key The key to check.
+   * @param bucket The bucket whose key should be checked.
+   * @return Whether the keys are equal.
+   **/
+  inline bool scalarKeyCollisionCheck(const TypedValue &key,
+                                      const void *bucket) const;
+
+  /**
+   * @brief Check whether a composite key is actually equal to the composite
+   *        key stored in a HashTable bucket.
+   *
+   * @param key The composite key to check.
+   * @param bucket The bucket whose key should be checked.
+   * @return Whether all the key components are equal.
+   **/
+  inline bool compositeKeyCollisionCheck(const std::vector<TypedValue> &key,
+                                         const void *bucket) const;
+
+  /**
+   * @brief Write a key component into a bucket.
+   *
+   * @note If the key component is variable-length, then
+   *       allocateVariableLengthKeyStorage() should have been called first
+   *       (either directly or by HashTable::preallocateForBulkInsert()) to
+   *       reserve out-of-line variable storage.
+   *
+   * @param component The key component to write.
+   * @param component_idx The index of the key component (0 for single scalar
+   *        keys).
+   * @param bucket A pointer to the bucket in the HashTable to write the key
+   *        to.
+   * @param prealloc_state If non-null, variable length key components will be
+   *        located in preallocated variable-length storage. 
+   **/
+  inline void writeKeyComponentToBucket(
+      const TypedValue &component,
+      const std::size_t component_idx,
+      void *bucket,
+      HashTablePreallocationState *prealloc_state);
+
+  /**
+   * @brief Reserve storage for variable-length key components.
+   *
+   * @note This can be undone by calling deallocateVariableLengthKeyStorage().
+   * @note Allocated storage is actually used by calling
+   *       writeKeyComponentToBucket() for variable-length key components.
+   *
+   * @param required_bytes The size of the variable-length key storage to
+   *        reserve.
+   * @return true if allocation was successful, false if not enough unreserved
+   *         space was available.
+   **/
+  inline bool allocateVariableLengthKeyStorage(
+      const std::size_t required_bytes);
+
+  /**
+   * @brief Release (undo) a reservation of storage for variable-length key
+   *        components previously made by allocateVariableLengthKeyStorage().
+   *
+   * @param bytes The size of the variable-length key storage reservation to
+   *        release.
+   **/
+  inline void deallocateVariableLengthKeyStorage(const std::size_t bytes);
+
+  /**
+   * @return The current "next" offset to be used when actually writing
+   *         variable-length keys.
+   **/
+  inline std::size_t getNextVariableLengthKeyOffset() const {
+    return next_variable_length_key_offset_.load(std::memory_order_relaxed);
+  }
+
+  /**
+   * @brief Increment the "next" offset to be used when writing variable-length
+   *        keys.
+   *
+   * @note This is intended mainly for use by preallocateForBulkInsert() to
+   *       allocate a contiguous region of variable-length storage all in one
+   *       go.
+   *
+   * @param bytes The number of bytes to increment the offset by.
+   * @return The original value of the "next" offset.
+   **/
+  inline std::size_t incrementNextVariableLengthKeyOffset(
+      const std::size_t bytes) {
+    return next_variable_length_key_offset_.fetch_add(
+        bytes,
+        std::memory_order_relaxed);
+  }
+
+  /**
+   * @brief Reset the "next" offset for writing variable-length keys to zero.
+   *
+   * @warning This should only be used when clearing a HashTable, as it will
+   *          cause any previously written variable-length keys to be
+   *          overwritten.
+   **/
+  inline void zeroNextVariableLengthKeyOffset() {
+    next_variable_length_key_offset_.store(0, std::memory_order_relaxed);
+  }
+
+ private:
+  const std::vector<const Type*> &key_types_;
+  std::size_t fixed_key_size_;
+  std::size_t estimated_variable_key_size_;
+  std::vector<std::size_t> key_offsets_;
+  std::vector<bool> key_inline_;
+
+  void *variable_length_key_storage_;
+  std::size_t variable_length_key_storage_size_;
+  std::atomic<std::size_t> *variable_length_bytes_allocated_;
+  // This is separate from '*variable_length_bytes_allocated_', because we
+  // allocate storage for variable-length keys up-front but defer actually
+  // copying them until we find an empty bucket.
+  alignas(kCacheLineBytes) std::atomic<std::size_t>
+      next_variable_length_key_offset_;
+
+  DISALLOW_COPY_AND_ASSIGN(HashTableKeyManager);
+};
+
+/** @} */
+
+// ----------------------------------------------------------------------------
+// Implementations of template class methods follow.
+
+template <bool serializable, bool force_key_copy>
+HashTableKeyManager<serializable, force_key_copy>::HashTableKeyManager(
+    const std::vector<const Type*> &key_types,
+    const std::size_t key_start_in_bucket)
+    : key_types_(key_types),
+      fixed_key_size_(0),
+      estimated_variable_key_size_(0),
+      variable_length_key_storage_(nullptr),
+      variable_length_key_storage_size_(0),
+      variable_length_bytes_allocated_(nullptr),
+      next_variable_length_key_offset_(0) {
+  DCHECK(!key_types_.empty());
+
+  for (const Type *subkey_type : key_types_) {
+    key_offsets_.push_back(key_start_in_bucket + fixed_key_size_);
+
+    if (force_key_copy) {
+      if (subkey_type->isVariableLength()) {
+        // An offset into the variable length storage region, paired with a length.
+        fixed_key_size_ += sizeof(std::size_t) * 2;
+        estimated_variable_key_size_ += subkey_type->estimateAverageByteLength();
+        key_inline_.push_back(false);
+      } else {
+        fixed_key_size_ += subkey_type->maximumByteLength();
+        key_inline_.push_back(true);
+      }
+    } else {
+      constexpr std::size_t ptr_size = serializable ? sizeof(std::ptrdiff_t)
+                                                    : sizeof(const void*);
+      if ((!subkey_type->isVariableLength())
+          && (subkey_type->maximumByteLength() <= ptr_size + sizeof(std::size_t))) {
+        fixed_key_size_ += subkey_type->maximumByteLength();
+        key_inline_.push_back(true);
+      } else {
+        // A pointer to external memory, paired with a length.
+        fixed_key_size_ += ptr_size + sizeof(std::size_t);
+        key_inline_.push_back(false);
+      }
+    }
+  }
+}
+
+template <bool serializable, bool force_key_copy>
+inline const void* HashTableKeyManager<serializable, force_key_copy>
+    ::getKeyComponent(const void *bucket,
+                      const std::size_t component_idx) const {
+  DCHECK_LT(component_idx, key_offsets_.size());
+
+  const void *base_key_ptr = static_cast<const char*>(bucket)
+                             + key_offsets_[component_idx];
+  if (key_inline_[component_idx]) {
+    // Component is inline.
+    return base_key_ptr;
+  } else if (force_key_copy) {
+    // Component is copied into variable-length region.
+    DCHECK(key_types_[component_idx]->isVariableLength());
+    return static_cast<const char*>(variable_length_key_storage_)
+           + *static_cast<const std::size_t*>(base_key_ptr);
+  } else if (serializable) {
+    // Relative pointer.
+    return static_cast<const char*>(base_key_ptr)
+           + *static_cast<const std::ptrdiff_t*>(base_key_ptr);
+  } else {
+    // Absolute pointer.
+    return *static_cast<const void* const*>(base_key_ptr);
+  }
+}
+
+template <bool serializable, bool force_key_copy>
+inline TypedValue HashTableKeyManager<serializable, force_key_copy>
+    ::getKeyComponentTyped(const void *bucket,
+                           const std::size_t component_idx) const {
+  DCHECK_LT(component_idx, key_offsets_.size());
+
+  const Type &key_type = *(key_types_[component_idx]);
+  const void *base_key_ptr = static_cast<const char*>(bucket)
+                             + key_offsets_[component_idx];
+  if (key_inline_[component_idx]) {
+    // Component is inline.
+    DCHECK(!key_type.isVariableLength());
+    return key_type.makeValue(base_key_ptr,
+                              key_type.maximumByteLength());
+  } else if (force_key_copy) {
+    // Component is copied into variable-length region.
+    DCHECK(key_type.isVariableLength());
+    return key_type.makeValue(static_cast<const char*>(variable_length_key_storage_)
+                                  + *static_cast<const std::size_t*>(base_key_ptr),
+                              *(static_cast<const std::size_t*>(base_key_ptr) + 1));
+  } else if (serializable) {
+    // Relative pointer.
+    return key_type.makeValue(
+        static_cast<const char*>(base_key_ptr)
+            + *static_cast<const std::ptrdiff_t*>(base_key_ptr),
+        key_type.isVariableLength() ? *(static_cast<const std::size_t*>(base_key_ptr) + 1)
+                                    : key_type.maximumByteLength());
+  } else {
+    // Absolute pointer.
+    return key_type.makeValue(
+        *static_cast<const void* const*>(base_key_ptr),
+        key_type.isVariableLength() ? *(static_cast<const std::size_t*>(base_key_ptr) + 1)
+                                    : key_type.maximumByteLength());
+  }
+}
+
+template <bool serializable, bool force_key_copy>
+inline bool HashTableKeyManager<serializable, force_key_copy>
+    ::scalarKeyCollisionCheck(const TypedValue &key,
+                              const void *bucket) const {
+  return CheckUntypedValuesEqual(*key_types_.front(),
+                                 key.getDataPtr(),
+                                 getKeyComponent(bucket, 0));
+}
+
+template <bool serializable, bool force_key_copy>
+inline bool HashTableKeyManager<serializable, force_key_copy>
+    ::compositeKeyCollisionCheck(const std::vector<TypedValue> &key,
+                                 const void *bucket) const {
+  DCHECK_EQ(key_types_.size(), key.size());
+
+  // Check key components one-by-one.
+  for (std::size_t idx = 0;
+       idx < key_types_.size();
+       ++idx) {
+    if (!CheckUntypedValuesEqual(*key_types_[idx],
+                                 key[idx].getDataPtr(),
+                                 getKeyComponent(bucket, idx))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <bool serializable, bool force_key_copy>
+inline void HashTableKeyManager<serializable, force_key_copy>
+    ::writeKeyComponentToBucket(const TypedValue &component,
+                                const std::size_t component_idx,
+                                void *bucket,
+                                HashTablePreallocationState *prealloc_state) {
+  void *key_ptr = static_cast<char*>(bucket) + key_offsets_[component_idx];
+  if (key_inline_[component_idx]) {
+    // Copy key component directly into bucket.
+    component.copyInto(key_ptr);
+  } else if (force_key_copy) {
+    // Copy key into variable-length storage region and store its offset and
+    // length.
+    DCHECK(key_types_[component_idx]->isVariableLength());
+    const std::size_t component_size = component.getDataSize();
+    const std::size_t variable_length_key_pos
+        = (prealloc_state == nullptr)
+            ? next_variable_length_key_offset_.fetch_add(component_size,
+                                                         std::memory_order_relaxed)
+            : prealloc_state->variable_length_key_position;
+    if (prealloc_state != nullptr) {
+      prealloc_state->variable_length_key_position += component_size;
+    }
+    DCHECK_LE(variable_length_key_pos + component_size,
+              variable_length_key_storage_size_);
+
+    component.copyInto(static_cast<char*>(variable_length_key_storage_)
+                       + variable_length_key_pos);
+    *static_cast<std::size_t*>(key_ptr) = variable_length_key_pos;
+    *(static_cast<std::size_t*>(key_ptr) + 1) = component_size;
+  } else if (serializable) {
+    // Store a relative pointer. We assume that we are pointing to memory
+    // that is serialized together with the HashTable, i.e. as part of the same
+    // StorageBlock. See comments regarding the 'force_key_copy' parameter in
+    // storage/HashTable.hpp for more details.
+    DCHECK(component.isReference());
+    *static_cast<std::ptrdiff_t*>(key_ptr) = static_cast<const char*>(component.getDataPtr())
+                                             - static_cast<const char*>(key_ptr);
+    if (key_types_[component_idx]->isVariableLength()) {
+      // Also store length if variable-length.
+      *(static_cast<std::size_t*>(key_ptr) + 1) = component.getDataSize();
+    }
+  } else {
+    // Store an absolute pointer.
+    *static_cast<const void**>(key_ptr) = component.getDataPtr();
+    if (key_types_[component_idx]->isVariableLength()) {
+      // Also store length if variable-length.
+      *(static_cast<std::size_t*>(key_ptr) + 1) = component.getDataSize();
+    }
+  }
+}
+
+template <bool serializable, bool force_key_copy>
+inline bool HashTableKeyManager<serializable, force_key_copy>
+    ::allocateVariableLengthKeyStorage(const std::size_t required_bytes) {
+  if (required_bytes == 0) {
+    return true;
+  }
+
+  const std::size_t original_variable_length_bytes_allocated
+      = variable_length_bytes_allocated_->fetch_add(required_bytes,
+                                                    std::memory_order_relaxed);
+  if (original_variable_length_bytes_allocated + required_bytes
+      > variable_length_key_storage_size_) {
+    // Release the memory we tried to allocate.
+    variable_length_bytes_allocated_->fetch_sub(required_bytes,
+                                                std::memory_order_relaxed);
+    return false;
+  } else {
+    return true;
+  }
+}
+
+template <bool serializable, bool force_key_copy>
+inline void HashTableKeyManager<serializable, force_key_copy>
+    ::deallocateVariableLengthKeyStorage(const std::size_t bytes) {
+  if (bytes == 0) {
+    return;
+  }
+  variable_length_bytes_allocated_->fetch_sub(bytes,
+                                              std::memory_order_relaxed);
+}
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_STORAGE_HASH_TABLE_KEY_MANAGER_HPP_

--- a/storage/SimpleScalarSeparateChainingHashTable.cpp
+++ b/storage/SimpleScalarSeparateChainingHashTable.cpp
@@ -1,0 +1,27 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "storage/SimpleScalarSeparateChainingHashTable.hpp"
+
+#include <vector>
+
+namespace quickstep {
+namespace simple_scalar_separate_chaining_hash_table_detail {
+
+const std::vector<bool> kKeyInlineGlobal(1, true);
+
+}  // namespace simple_scalar_separate_chaining_hash_table_detail
+}  // namespace quickstep

--- a/storage/SimpleScalarSeparateChainingHashTable.hpp
+++ b/storage/SimpleScalarSeparateChainingHashTable.hpp
@@ -1,0 +1,1062 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_STORAGE_SIMPLE_SCALAR_SEPARATE_CHAINING_HASH_TABLE_HPP_
+#define QUICKSTEP_STORAGE_SIMPLE_SCALAR_SEPARATE_CHAINING_HASH_TABLE_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "storage/HashTable.hpp"
+#include "storage/HashTableBase.hpp"
+#include "storage/StorageConstants.hpp"
+#include "storage/StorageBlob.hpp"
+#include "storage/StorageBlockInfo.hpp"
+#include "storage/StorageManager.hpp"
+#include "threading/SpinSharedMutex.hpp"
+#include "types/Type.hpp"
+#include "types/TypedValue.hpp"
+#include "utility/Alignment.hpp"
+#include "utility/Macros.hpp"
+#include "utility/PrimeNumber.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+/** \addtogroup Storage
+ *  @{
+ */
+
+/**
+ * @brief A lean simplified version of SeparateChainingHashTable that only
+ *        works for scalar (non-composite) keys that have a reversible hash
+ *        function.
+ **/
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+class SimpleScalarSeparateChainingHashTable : public HashTable<ValueT,
+                                                               resizable,
+                                                               serializable,
+                                                               force_key_copy,
+                                                               allow_duplicate_keys> {
+ public:
+  SimpleScalarSeparateChainingHashTable(const std::vector<const Type*> &key_types,
+                                        const std::size_t num_entries,
+                                        StorageManager *storage_manager);
+
+  SimpleScalarSeparateChainingHashTable(const std::vector<const Type*> &key_types,
+                                        void *hash_table_memory,
+                                        const std::size_t hash_table_memory_size,
+                                        const bool new_hash_table,
+                                        const bool hash_table_memory_zeroed);
+
+  // Delegating constructors for single scalar keys.
+  SimpleScalarSeparateChainingHashTable(const Type &key_type,
+                                        const std::size_t num_entries,
+                                        StorageManager *storage_manager)
+      : SimpleScalarSeparateChainingHashTable(std::vector<const Type*>(1, &key_type),
+                                              num_entries,
+                                              storage_manager) {
+  }
+
+  SimpleScalarSeparateChainingHashTable(const Type &key_type,
+                                        void *hash_table_memory,
+                                        const std::size_t hash_table_memory_size,
+                                        const bool new_hash_table,
+                                        const bool hash_table_memory_zeroed)
+      : SimpleScalarSeparateChainingHashTable(std::vector<const Type*>(1, &key_type),
+                                              hash_table_memory,
+                                              hash_table_memory_size,
+                                              new_hash_table,
+                                              hash_table_memory_zeroed) {
+  }
+
+  ~SimpleScalarSeparateChainingHashTable() override {
+    DestroyValues(buckets_,
+                  header_->buckets_allocated.load(std::memory_order_relaxed));
+  }
+
+  void clear() override;
+
+  std::size_t numEntries() const override {
+    return header_->buckets_allocated.load(std::memory_order_relaxed);
+  }
+
+  const ValueT* getSingle(const TypedValue &key) const override;
+
+  const ValueT* getSingleCompositeKey(const std::vector<TypedValue> &key) const override {
+    DCHECK_EQ(1u, key.size());
+    return getSingle(key.front());
+  }
+
+  void getAll(const TypedValue &key,
+              std::vector<const ValueT*> *values) const override;
+
+  void getAllCompositeKey(const std::vector<TypedValue> &key,
+                          std::vector<const ValueT*> *values) const override {
+    DCHECK_EQ(1u, key.size());
+    return getAll(key.front(), values);
+  }
+
+ protected:
+  HashTablePutResult putInternal(const TypedValue &key,
+                                 const std::size_t variable_key_size,
+                                 const ValueT &value,
+                                 HashTablePreallocationState *prealloc_state) override;
+
+  HashTablePutResult putCompositeKeyInternal(
+      const std::vector<TypedValue> &key,
+      const std::size_t variable_key_size,
+      const ValueT &value,
+      HashTablePreallocationState *prealloc_state) override {
+    DCHECK_EQ(1u, key.size());
+    return putInternal(key.front(), variable_key_size, value, prealloc_state);
+  }
+
+  ValueT* upsertInternal(const TypedValue &key,
+                         const std::size_t variable_key_size,
+                         const ValueT &initial_value) override;
+
+  ValueT* upsertCompositeKeyInternal(const std::vector<TypedValue> &key,
+                                     const std::size_t variable_key_size,
+                                     const ValueT &initial_value) override {
+    DCHECK_EQ(1u, key.size());
+    return upsertInternal(key.front(), variable_key_size, initial_value);
+  }
+
+  bool getNextEntry(TypedValue *key,
+                    const ValueT **value,
+                    std::size_t *entry_num) const override;
+
+  bool getNextEntryCompositeKey(std::vector<TypedValue> *key,
+                                const ValueT **value,
+                                std::size_t *entry_num) const override {
+    key->resize(1);
+    return getNextEntry(&(key->front()), value, entry_num);
+  }
+
+  bool getNextEntryForKey(const TypedValue &key,
+                          const std::size_t hash_code,
+                          const ValueT **value,
+                          std::size_t *entry_num) const override;
+
+  bool getNextEntryForCompositeKey(const std::vector<TypedValue> &key,
+                                   const std::size_t hash_code,
+                                   const ValueT **value,
+                                   std::size_t *entry_num) const override {
+    DCHECK_EQ(1u, key.size());
+    return getNextEntryForKey(key.front(), hash_code, value, entry_num);
+  }
+
+  void resize(const std::size_t extra_buckets,
+              const std::size_t extra_variable_storage,
+              const std::size_t retry_num = 0) override;
+
+  bool preallocateForBulkInsert(const std::size_t total_entries,
+                                const std::size_t total_variable_key_size,
+                                HashTablePreallocationState *prealloc_state) override;
+
+ private:
+  struct Header {
+    std::size_t num_slots;
+    std::size_t num_buckets;
+    alignas(kCacheLineBytes)
+        std::atomic<std::size_t> buckets_allocated;
+  };
+
+  struct Bucket {
+    std::atomic<std::size_t> next;
+    std::size_t hash;
+    ValueT value;
+  };
+
+  // If ValueT is not trivially destructible, invoke its destructor for all
+  // values held in the specified buckets (including those in "empty" buckets
+  // that were default constructed). If ValueT is trivially destructible, this
+  // is a no-op.
+  static void DestroyValues(Bucket *buckets,
+                            const std::size_t num_buckets);
+
+  // Attempt to find an empty bucket to insert 'hash_code' into, starting after
+  // '*bucket' in the chain (or, if '*bucket' is NULL, starting from the slot
+  // array). Returns true and stores SIZE_T_MAX in '*pending_chain_ptr' if an
+  // empty bucket is found. Returns false if 'allow_duplicate_keys' is false
+  // and a hash collision is found. Returns false and sets '*bucket' to NULL if
+  // there are no more empty buckets in the hash table.
+  inline bool locateBucketForInsertion(const std::size_t hash_code,
+                                       Bucket **bucket,
+                                       std::atomic<std::size_t> **pending_chain_ptr,
+                                       std::size_t *pending_chain_ptr_finish_value,
+                                       HashTablePreallocationState *prealloc_state);
+
+  // Determine whether it is actually necessary to resize this hash table.
+  // Checks that there is at least one unallocated bucket.
+  inline bool isFull() const {
+    return header_->buckets_allocated.load(std::memory_order_relaxed)
+           >= header_->num_buckets;
+  }
+
+  // Cache the TypeID of the key.
+  const TypeID key_type_id_;
+
+  // In-memory structure is as follows:
+  //   - SimpleScalarSeparateChainingHashTable::Header
+  //   - Array of slots, interpreted as follows:
+  //       - 0 = Points to nothing (empty)
+  //       - SIZE_T_MAX = Pending (some thread is starting a chain from this
+  //         slot and will overwrite it soon)
+  //       - Anything else = The number of the first bucket in the chain for
+  //         this slot PLUS ONE (i.e. subtract one to get the actual bucket
+  //         number).
+  //   - Array of buckets, each of which is:
+  //       - atomic size_t "next" pointer, interpreted the same as slots above.
+  //       - size_t hash value
+  //       - ValueT value slot
+  Header *header_;
+
+  std::atomic<std::size_t> *slots_;
+  Bucket *buckets_;
+
+  DISALLOW_COPY_AND_ASSIGN(SimpleScalarSeparateChainingHashTable);
+};
+
+/** @} */
+
+namespace simple_scalar_separate_chaining_hash_table_detail {
+
+// Always has a single element 'true'.
+extern const std::vector<bool> kKeyInlineGlobal;
+
+}  // namespace simple_scalar_separate_chaining_hash_table_detail
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+SimpleScalarSeparateChainingHashTable<ValueT,
+                                      resizable,
+                                      serializable,
+                                      force_key_copy,
+                                      allow_duplicate_keys>
+    ::SimpleScalarSeparateChainingHashTable(const std::vector<const Type*> &key_types,
+                                            const std::size_t num_entries,
+                                            StorageManager *storage_manager)
+        : HashTable<ValueT, resizable, serializable, force_key_copy, allow_duplicate_keys>(
+              key_types,
+              num_entries,
+              storage_manager,
+              false,
+              true,
+              true),
+          key_type_id_(key_types.front()->getTypeID()) {
+  DCHECK_EQ(1u, key_types.size());
+  DCHECK(TypedValue::HashIsReversible(key_type_id_));
+
+  // Give base HashTable information about what key components are stored
+  // inline (SimpleScalarSeparateChainingHashTable ALWAYS stores keys inline).
+  this->setKeyInline(&simple_scalar_separate_chaining_hash_table_detail::kKeyInlineGlobal);
+
+  // Pick out a prime number of slots and calculate storage requirements.
+  std::size_t num_slots_tmp = get_next_prime_number(num_entries * kHashTableLoadFactor);
+  std::size_t required_memory = sizeof(Header)
+                                + num_slots_tmp * sizeof(std::atomic<std::size_t>)
+                                + (num_slots_tmp / kHashTableLoadFactor) * sizeof(Bucket);
+  std::size_t num_storage_slots = this->storage_manager_->SlotsNeededForBytes(required_memory);
+  if (num_storage_slots == 0) {
+    LOG(FATAL)
+        << "Storage requirement for SimpleScalarSeparateChainingHashTable "
+           "exceeds maximum allocation size.";
+  }
+
+  // Get a StorageBlob to hold the hash table.
+  const block_id blob_id = this->storage_manager_->createBlob(num_storage_slots);
+  this->blob_ = this->storage_manager_->getBlobMutable(blob_id);
+
+  void *aligned_memory_start = this->blob_->getMemoryMutable();
+  std::size_t available_memory = num_storage_slots * kSlotSizeBytes;
+  if (align(alignof(Header),
+            sizeof(Header),
+            aligned_memory_start,
+            available_memory)
+          == nullptr) {
+    // With current values from StorageConstants.hpp, this should be
+    // impossible. A blob is at least 1 MB, while a Header has alignment
+    // requirement of just kCacheLineBytes (64 bytes).
+    LOG(FATAL)
+        << "StorageBlob used to hold resizable "
+           "SimpleScalarSeparateChainingHashTable is too small to meet "
+           "requirements of SimpleScalarSeparateChainingHashTable::Header.";
+  } else if (aligned_memory_start != this->blob_->getMemoryMutable()) {
+    // This should also be impossible, since the StorageManager allocates slots
+    // aligned to kCacheLineBytes.
+    LOG(WARNING)
+        << "StorageBlob memory adjusted by "
+        << (num_storage_slots * kSlotSizeBytes - available_memory)
+        << " bytes to meet alignment requirement for "
+        << "SimpleScalarSeparateChainingHashTable::Header.";
+  }
+
+  // Locate the header.
+  header_ = static_cast<Header*>(aligned_memory_start);
+  aligned_memory_start = static_cast<char*>(aligned_memory_start) + sizeof(Header);
+  available_memory -= sizeof(Header);
+
+  // Recompute the number of slots & buckets using the actual available memory.
+  // Most likely, we got some extra free bucket space due to "rounding up" to
+  // the storage blob's size. It's also possible (though very unlikely) that we
+  // will wind up with fewer buckets than we initially wanted because of screwy
+  // alignment requirements for ValueT.
+  std::size_t num_buckets_tmp
+      = available_memory / (kHashTableLoadFactor * sizeof(std::atomic<std::size_t>)
+                            + sizeof(Bucket));
+  num_slots_tmp = get_previous_prime_number(num_buckets_tmp * kHashTableLoadFactor);
+  num_buckets_tmp = num_slots_tmp / kHashTableLoadFactor;
+  DCHECK_GT(num_slots_tmp, 0u);
+  DCHECK_GT(num_buckets_tmp, 0u);
+
+  // Locate the slot array.
+  slots_ = static_cast<std::atomic<std::size_t>*>(aligned_memory_start);
+  aligned_memory_start = static_cast<char*>(aligned_memory_start)
+                         + sizeof(std::atomic<std::size_t>) * num_slots_tmp;
+  available_memory -= sizeof(std::atomic<std::size_t>) * num_slots_tmp;
+
+  // Locate the buckets.
+  void* buckets_addr = aligned_memory_start;
+  // Extra-paranoid: If ValueT has an alignment requirement greater than that
+  // of std::atomic<std::size_t>, we may need to adjust the start of the bucket
+  // array.
+  if (align(alignof(Bucket),
+            sizeof(Bucket),
+            buckets_addr,
+            available_memory)
+          == nullptr) {
+    LOG(FATAL) << "StorageBlob used to hold resizable "
+                  "SimpleScalarSeparateChainingHashTable is too small to meet "
+                  "alignment requirements of buckets.";
+  } else if (buckets_ != aligned_memory_start) {
+    LOG(WARNING) << "Bucket array start position adjusted to meet alignment "
+                    "requirement for SimpleScalarSeparateChainingHashTable's "
+                    "value type.";
+    if (num_buckets_tmp * sizeof(Bucket) > available_memory) {
+      --num_buckets_tmp;
+    }
+  }
+  buckets_ = static_cast<Bucket*>(buckets_addr);
+
+  // Fill in the header.
+  header_->num_slots = num_slots_tmp;
+  header_->num_buckets = num_buckets_tmp;
+  header_->buckets_allocated.store(0, std::memory_order_relaxed);
+
+  // There is probably some left over available memory in the blob at this
+  // point. Although we could allocate some extra buckets from that space,
+  // doing so would cause us to violate kHashTableLoadFactor. Instead, we
+  // respect kHashTableLoadFactor and prefer to resize when we run out of
+  // allocated buckets.
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+SimpleScalarSeparateChainingHashTable<ValueT,
+                                      resizable,
+                                      serializable,
+                                      force_key_copy,
+                                      allow_duplicate_keys>
+    ::SimpleScalarSeparateChainingHashTable(const std::vector<const Type*> &key_types,
+                                            void *hash_table_memory,
+                                            const std::size_t hash_table_memory_size,
+                                            const bool new_hash_table,
+                                            const bool hash_table_memory_zeroed)
+        : HashTable<ValueT, resizable, serializable, force_key_copy, allow_duplicate_keys>(
+              key_types,
+              hash_table_memory,
+              hash_table_memory_size,
+              new_hash_table,
+              hash_table_memory_zeroed,
+              false,
+              true,
+              true),
+          key_type_id_(key_types.front()->getTypeID()) {
+  DCHECK_EQ(1u, key_types.size());
+  DCHECK(TypedValue::HashIsReversible(key_type_id_));
+
+  // Give base HashTable information about what key components are stored
+  // inline (SimpleScalarSeparateChainingHashTable ALWAYS stores keys inline).
+  this->setKeyInline(&simple_scalar_separate_chaining_hash_table_detail::kKeyInlineGlobal);
+
+  // FIXME(chasseur): If we are reconstituting a HashTable using a block of
+  // memory whose start was aligned differently than the memory block that was
+  // originally used (modulo alignof(Header)), we could wind up with all of our
+  // data structures misaligned. If memory is inside a
+  // StorageBlock/StorageBlob, this will never occur, since the StorageManager
+  // always allocates slots aligned to kCacheLineBytes. Similarly, this isn't
+  // a problem for memory inside any other allocation aligned to at least
+  // alignof(Header) == kCacheLineBytes.
+
+  void *aligned_memory_start = this->hash_table_memory_;
+  std::size_t available_memory = this->hash_table_memory_size_;
+
+  if (align(alignof(Header),
+            sizeof(Header),
+            aligned_memory_start,
+            available_memory)
+          == nullptr) {
+    LOG(FATAL) << "Attempted to create a non-resizable "
+               << "SimpleScalarSeparateChainingHashTable with "
+               << available_memory << " bytes of memory at "
+               << aligned_memory_start << " which either can not fit a "
+               << "SimpleScalarSeparateChainingHashTable::Header or meet its "
+               << "alignment requirement.";
+  } else if (aligned_memory_start != this->hash_table_memory_) {
+    // In general, we could get memory of any alignment, although at least
+    // cache-line aligned would be nice.
+    LOG(WARNING) << "StorageBlob memory adjusted by "
+                 << (this->hash_table_memory_size_ - available_memory)
+                 << " bytes to meet alignment requirement for "
+                 << "SimpleScalarSeparateChainingHashTable::Header.";
+  }
+
+  header_ = static_cast<Header*>(aligned_memory_start);
+  aligned_memory_start = static_cast<char*>(aligned_memory_start) + sizeof(Header);
+  available_memory -= sizeof(Header);
+
+  if (new_hash_table) {
+    std::size_t estimated_bucket_capacity
+        = available_memory / (kHashTableLoadFactor * sizeof(std::atomic<std::size_t>)
+                              + sizeof(Bucket));
+    std::size_t num_slots = get_previous_prime_number(estimated_bucket_capacity * kHashTableLoadFactor);
+
+    // Fill in the header.
+    header_->num_slots = num_slots;
+    header_->num_buckets = num_slots / kHashTableLoadFactor;
+    header_->buckets_allocated.store(0, std::memory_order_relaxed);
+  }
+
+  // Locate the slot array.
+  slots_ = static_cast<std::atomic<std::size_t>*>(aligned_memory_start);
+  aligned_memory_start = static_cast<char*>(aligned_memory_start)
+                         + sizeof(std::atomic<std::size_t>) * header_->num_slots;
+  available_memory -= sizeof(std::atomic<std::size_t>) * header_->num_slots;
+
+  if (new_hash_table && !hash_table_memory_zeroed) {
+    std::memset(slots_, 0x0, sizeof(std::atomic<std::size_t>) * header_->num_slots);
+  }
+
+  // Locate the buckets.
+  void* buckets_addr = aligned_memory_start;
+  // Extra-paranoid: sizeof(Header) should almost certainly be a multiple of
+  // alignof(Bucket), unless ValueT has some members with seriously big
+  // (> kCacheLineBytes) alignment requirements specified using alignas().
+  if (align(alignof(Bucket),
+            sizeof(Bucket),
+            buckets_addr,
+            available_memory)
+          == nullptr) {
+    LOG(FATAL)
+        << "Attempted to create a non-resizable "
+        << "SimpleScalarSeparateChainingHashTable with "
+        << this->hash_table_memory_size_ << " bytes of memory at "
+        << this->hash_table_memory_ << ", which can hold an aligned "
+        << "SimpleScalarSeparateChainingHashTable::Header but does not have "
+        << "enough remaining space for even a single hash bucket.";
+  } else if (buckets_addr != aligned_memory_start) {
+    LOG(WARNING)
+        << "Bucket array start position adjusted to meet alignment requirement "
+        << "for SimpleScalarSeparateChainingHashTable's value type.";
+    if (header_->num_buckets * sizeof(Bucket) > available_memory) {
+      DCHECK(new_hash_table);
+      --(header_->num_buckets);
+    }
+  }
+  buckets_ = static_cast<Bucket*>(buckets_addr);
+
+  // Make sure "next" pointers in buckets are zeroed-out.
+  if (new_hash_table && !hash_table_memory_zeroed) {
+    std::memset(buckets_, 0x0, header_->num_buckets * sizeof(Bucket));
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+void SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                           allow_duplicate_keys>
+    ::clear() {
+  const std::size_t used_buckets = header_->buckets_allocated.load(std::memory_order_relaxed);
+  // Destroy existing values, if necessary.
+  DestroyValues(buckets_, used_buckets);
+
+  // Zero-out slot array.
+  std::memset(slots_, 0x0, sizeof(std::atomic<std::size_t>) * header_->num_slots);
+
+  // Zero-out used buckets.
+  std::memset(static_cast<void*>(buckets_), 0x0, sizeof(Bucket) * used_buckets);
+
+  header_->buckets_allocated.store(0, std::memory_order_relaxed);
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+const ValueT* SimpleScalarSeparateChainingHashTable<ValueT,
+                                                    resizable,
+                                                    serializable,
+                                                    force_key_copy,
+                                                    allow_duplicate_keys>
+    ::getSingle(const TypedValue &key) const {
+  DCHECK(!allow_duplicate_keys);
+  DCHECK(key.isPlausibleInstanceOf(this->key_types_.front()->getSignature()));
+
+  const std::size_t hash_code = key.getHashScalarLiteral();
+  std::size_t bucket_ref = slots_[hash_code % header_->num_slots].load(std::memory_order_relaxed);
+  while (bucket_ref != 0) {
+    DCHECK_NE(bucket_ref, std::numeric_limits<std::size_t>::max());
+
+    const Bucket &bucket = buckets_[bucket_ref - 1];
+    if (bucket.hash == hash_code) {
+      // Match located.
+      return &(bucket.value);
+    }
+    bucket_ref = bucket.next.load(std::memory_order_relaxed);
+  }
+
+  // Reached the end of the chain and didn't find a match.
+  return nullptr;
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+void SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                           allow_duplicate_keys>
+    ::getAll(const TypedValue &key, std::vector<const ValueT*> *values) const {
+  DCHECK(key.isPlausibleInstanceOf(this->key_types_.front()->getSignature()));
+
+  const std::size_t hash_code = key.getHashScalarLiteral();
+  std::size_t bucket_ref = slots_[hash_code % header_->num_slots].load(std::memory_order_relaxed);
+  while (bucket_ref != 0) {
+    DCHECK_NE(bucket_ref, std::numeric_limits<std::size_t>::max());
+    const Bucket &bucket = buckets_[bucket_ref - 1];
+    if (bucket.hash == hash_code) {
+      // Match located.
+      values->push_back(&(bucket.value));
+      if (!allow_duplicate_keys) {
+        return;
+      }
+    }
+    bucket_ref = bucket.next.load(std::memory_order_relaxed);
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+HashTablePutResult
+    SimpleScalarSeparateChainingHashTable<ValueT,
+                                          resizable,
+                                          serializable,
+                                          force_key_copy,
+                                          allow_duplicate_keys>
+        ::putInternal(const TypedValue &key,
+                      const std::size_t variable_key_size,
+                      const ValueT &value,
+                      HashTablePreallocationState *prealloc_state) {
+  DEBUG_ASSERT(key.isPlausibleInstanceOf(this->key_types_.front()->getSignature()));
+
+  if (prealloc_state == nullptr) {
+    // Early check for a free bucket.
+    if (header_->buckets_allocated.load(std::memory_order_relaxed) >= header_->num_buckets) {
+      return HashTablePutResult::kOutOfSpace;
+    }
+  }
+
+  const std::size_t hash_code = key.getHashScalarLiteral();
+  Bucket *bucket = nullptr;
+  std::atomic<std::size_t> *pending_chain_ptr;
+  std::size_t pending_chain_ptr_finish_value;
+  if (locateBucketForInsertion(hash_code,
+                               &bucket,
+                               &pending_chain_ptr,
+                               &pending_chain_ptr_finish_value,
+                               prealloc_state)) {
+    // Found an empty bucket.
+    // Write the hash, which can be reversed to recover the key.
+    bucket->hash = hash_code;
+
+    // Store the value by using placement new with ValueT's copy constructor.
+    new(&(bucket->value)) ValueT(value);
+
+    // Update the previous chain pointer to point to the new bucket.
+    pending_chain_ptr->store(pending_chain_ptr_finish_value, std::memory_order_release);
+
+    // We're all done.
+    return HashTablePutResult::kOK;
+  } else if (bucket == nullptr) {
+    // Ran out of buckets.
+    DCHECK(prealloc_state == nullptr);
+    return HashTablePutResult::kOutOfSpace;
+  } else {
+    // Collision found, and duplicates aren't allowed.
+    DCHECK(!allow_duplicate_keys);
+    DCHECK(prealloc_state == nullptr);
+    return HashTablePutResult::kDuplicateKey;
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+ValueT* SimpleScalarSeparateChainingHashTable<ValueT,
+                                              resizable,
+                                              serializable,
+                                              force_key_copy,
+                                              allow_duplicate_keys>
+    ::upsertInternal(const TypedValue &key,
+                     const std::size_t variable_key_size,
+                     const ValueT &initial_value) {
+  DCHECK(!allow_duplicate_keys);
+  DCHECK(key.isPlausibleInstanceOf(this->key_types_.front()->getSignature()));
+  DCHECK_EQ(0u, variable_key_size);
+
+  const std::size_t hash_code = key.getHashScalarLiteral();
+  Bucket *bucket = nullptr;
+  std::atomic<std::size_t> *pending_chain_ptr;
+  std::size_t pending_chain_ptr_finish_value;
+  if (locateBucketForInsertion(hash_code,
+                               &bucket,
+                               &pending_chain_ptr,
+                               &pending_chain_ptr_finish_value,
+                               nullptr)) {
+    // Inserting into an empty bucket.
+    // Write the hash, which can be reversed to recover the key.
+    bucket->hash = hash_code;
+
+    // Copy the supplied 'initial_value into place.
+    new(&(bucket->value)) ValueT(initial_value);
+
+    // Update the previous chain pointer to point to the new bucket.
+    pending_chain_ptr->store(pending_chain_ptr_finish_value, std::memory_order_release);
+
+    // Return the value.
+    return &(bucket->value);
+  } else if (bucket == nullptr) {
+    // Ran out of buckets.
+    return nullptr;
+  } else {
+    // Found an already-existing entry for this key.
+    return &(bucket->value);
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+bool SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                           allow_duplicate_keys>
+    ::getNextEntry(TypedValue *key, const ValueT **value, std::size_t *entry_num) const {
+  if (*entry_num < header_->buckets_allocated.load(std::memory_order_relaxed)) {
+    const Bucket &bucket = buckets_[*entry_num];
+    // Reconstruct key by reversing hash.
+    *key = TypedValue(key_type_id_, bucket.hash);
+    *value = &(bucket.value);
+    ++(*entry_num);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+bool SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                             allow_duplicate_keys>
+    ::getNextEntryForKey(const TypedValue &key,
+                         const std::size_t hash_code,
+                         const ValueT **value,
+                         std::size_t *entry_num) const {
+  DCHECK(key.isPlausibleInstanceOf(this->key_types_.front()->getSignature()));
+
+  if (*entry_num == 0) {
+    *entry_num = slots_[hash_code % header_->num_slots].load(std::memory_order_relaxed);
+  } else if (*entry_num == std::numeric_limits<std::size_t>::max()) {
+    return false;
+  }
+
+  while (*entry_num != 0) {
+    DCHECK_NE(*entry_num, std::numeric_limits<std::size_t>::max());
+    const Bucket &bucket = buckets_[*entry_num - 1];
+    *entry_num = bucket.next.load(std::memory_order_relaxed);
+    if (bucket.hash == hash_code) {
+      // Match located.
+      *value = &(bucket.value);
+      if (*entry_num == 0) {
+        // If this is the last bucket in the chain, prevent the next call from
+        // starting over again.
+        *entry_num = std::numeric_limits<std::size_t>::max();
+      }
+      return true;
+    }
+  }
+
+  // Reached the end of the chain.
+  return false;
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+void SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                             allow_duplicate_keys>
+    ::resize(const std::size_t extra_buckets,
+             const std::size_t extra_variable_storage,
+             const std::size_t retry_num) {
+  DCHECK(resizable);
+  DCHECK_EQ(0u, extra_variable_storage);
+
+  // A retry should never be necessary with this implementation of HashTable.
+  // Separate chaining ensures that any resized hash table with more buckets
+  // than the original table will be able to hold more entries than the
+  // original.
+  DCHECK_EQ(0u, retry_num);
+
+  SpinSharedMutexExclusiveLock<true> write_lock(this->resize_shared_mutex_);
+
+  // Recheck whether the hash table is still full. Note that multiple threads
+  // might wait to rebuild this hash table simultaneously. Only the first one
+  // should do the rebuild.
+  if (!isFull()) {
+    return;
+  }
+
+  // Approximately double the number of buckets and slots.
+  //
+  // TODO(chasseur): It may be worth it to more than double the number of
+  // buckets here so that we can maintain a good, sparse fill factor for a
+  // longer time as more values are inserted. Such behavior should take into
+  // account kHashTableLoadFactor.
+  std::size_t resized_num_slots = get_next_prime_number(
+      (header_->num_buckets + extra_buckets / 2) * kHashTableLoadFactor * 2);
+
+  const std::size_t resized_memory_required
+      = sizeof(Header)
+        + resized_num_slots * sizeof(std::atomic<std::size_t>)
+        + (resized_num_slots / kHashTableLoadFactor) * sizeof(Bucket);
+  const std::size_t resized_storage_slots
+      = this->storage_manager_->SlotsNeededForBytes(resized_memory_required);
+  if (resized_storage_slots == 0) {
+    LOG(FATAL) << "Storage requirement for resized "
+                  "SimpleScalarSeparateChainingHashTable exceeds maximum "
+                  "allocation size.";
+  }
+
+  // Get a new StorageBlob to hold the resized hash table.
+  const block_id resized_blob_id = this->storage_manager_->createBlob(resized_storage_slots);
+  MutableBlobReference resized_blob = this->storage_manager_->getBlobMutable(resized_blob_id);
+
+  // Locate data structures inside the new StorageBlob.
+  void *aligned_memory_start = resized_blob->getMemoryMutable();
+  std::size_t available_memory = resized_storage_slots * kSlotSizeBytes;
+  if (align(alignof(Header),
+            sizeof(Header),
+            aligned_memory_start,
+            available_memory)
+          == nullptr) {
+    // Should be impossible, as noted in constructor.
+    LOG(FATAL) << "StorageBlob used to hold resized "
+                  "SimpleScalarSeparateChainingHashTable is too small to meet "
+                  "alignment requirements of Header.";
+  } else if (aligned_memory_start != resized_blob->getMemoryMutable()) {
+    // Again, should be impossible.
+    LOG(WARNING) << "StorageBlob memory adjusted by "
+                 << (resized_num_slots * kSlotSizeBytes - available_memory)
+                 << " bytes to meet alignment requirement for "
+                 << "SimpleScalarSeparateChainingHashTable::Header.";
+  }
+
+  Header *resized_header = static_cast<Header*>(aligned_memory_start);
+  aligned_memory_start = static_cast<char*>(aligned_memory_start) + sizeof(Header);
+  available_memory -= sizeof(Header);
+
+  // As in constructor, recompute the number of slots and buckets using the
+  // actual available memory.
+  std::size_t resized_num_buckets
+      = (available_memory - extra_variable_storage)
+        / (kHashTableLoadFactor * sizeof(std::atomic<std::size_t>)+ sizeof(Bucket));
+  resized_num_slots = get_previous_prime_number(resized_num_buckets * kHashTableLoadFactor);
+  resized_num_buckets = resized_num_slots / kHashTableLoadFactor;
+
+  // Locate slot array.
+  std::atomic<std::size_t> *resized_slots = static_cast<std::atomic<std::size_t>*>(aligned_memory_start);
+  aligned_memory_start = static_cast<char*>(aligned_memory_start)
+                         + sizeof(std::atomic<std::size_t>) * resized_num_slots;
+  available_memory -= sizeof(std::atomic<std::size_t>) * resized_num_slots;
+
+  // As in constructor, we will be extra paranoid and use align() to locate the
+  // start of the array of buckets, as well.
+  void *resized_buckets_addr = aligned_memory_start;
+  if (align(alignof(Bucket),
+            sizeof(Bucket),
+            resized_buckets_addr,
+            available_memory)
+          == nullptr) {
+    LOG(FATAL)
+        << "StorageBlob used to hold resized "
+           "SimpleScalarSeparateChainingHashTable is too small to meet "
+           "alignment requirements of buckets.";
+  } else if (resized_buckets_addr != aligned_memory_start) {
+    LOG(WARNING)
+        << "Bucket array start position adjusted from " << aligned_memory_start
+        << " to " << resized_buckets_addr
+        << " to meet requirement for SimpleScalarSeparateChainingHashTable's "
+        << "value type.";
+    if (resized_num_buckets * sizeof(Bucket) > available_memory) {
+      --resized_num_buckets;
+    }
+  }
+  Bucket *resized_buckets = static_cast<Bucket*>(resized_buckets_addr);
+
+  const std::size_t original_buckets_used = header_->buckets_allocated.load(std::memory_order_relaxed);
+
+  // Initialize the header.
+  resized_header->num_slots = resized_num_slots;
+  resized_header->num_buckets = resized_num_buckets;
+  resized_header->buckets_allocated.store(original_buckets_used, std::memory_order_relaxed);
+
+  // Bulk-copy buckets. This is safe because:
+  //     1. The "next" pointers will be adjusted when rebuilding chains below.
+  //     2. The hash codes will stay the same.
+  //     3. If values are not trivially copyable, then we invoke ValueT's copy
+  //        or move constructor with placement new.
+  std::memcpy(static_cast<void*>(resized_buckets),
+              static_cast<const void*>(buckets_),
+              original_buckets_used * sizeof(Bucket));
+
+  // TODO(chasseur): std::is_trivially_copyable is not yet implemented in
+  // GCC 4.8.3, so we assume we need to invoke ValueT's copy or move
+  // constructor, even though the plain memcpy above could suffice for many
+  // possible ValueTs.
+  for (std::size_t bucket_num = 0; bucket_num < original_buckets_used; ++bucket_num) {
+    // Use a move constructor if available to avoid a deep-copy, since resizes
+    // always succeed.
+    new (&(resized_buckets[bucket_num].value)) ValueT(std::move(buckets_[bucket_num].value));
+  }
+
+  // Destroy values in the original hash table, if neccesary,
+  DestroyValues(buckets_,
+                original_buckets_used);
+
+  // Make resized structures active.
+  std::swap(this->blob_, resized_blob);
+  header_ = resized_header;
+  slots_ = resized_slots;
+  buckets_ = resized_buckets;
+
+  // Drop the old blob.
+  const block_id old_blob_id = resized_blob->getID();
+  resized_blob.release();
+  this->storage_manager_->deleteBlockOrBlobFile(old_blob_id);
+
+  // Rebuild chains.
+  for (std::size_t bucket_num = 0; bucket_num < original_buckets_used; ++bucket_num) {
+    Bucket &bucket = buckets_[bucket_num];
+    const std::size_t slot_number = bucket.hash % header_->num_slots;
+    std::size_t slot_ptr_value = 0;
+    if (slots_[slot_number].compare_exchange_strong(slot_ptr_value,
+                                                    bucket_num + 1,
+                                                    std::memory_order_relaxed)) {
+      // This bucket is the first in the chain for this block, so reset its
+      // next pointer to zero.
+      bucket.next.store(0, std::memory_order_relaxed);
+    } else {
+      // A chain already exists starting from this slot, so put this bucket at
+      // the head.
+      bucket.next.store(slot_ptr_value, std::memory_order_relaxed);
+      slots_[slot_number].store(bucket_num + 1, std::memory_order_relaxed);
+    }
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+bool SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                           allow_duplicate_keys>
+    ::preallocateForBulkInsert(const std::size_t total_entries,
+                               const std::size_t total_variable_key_size,
+                               HashTablePreallocationState *prealloc_state) {
+  DCHECK(allow_duplicate_keys);
+  DCHECK_EQ(0u, total_variable_key_size);
+
+  // We use load then compare-exchange here instead of simply fetch-add,
+  // because if multiple threads are simultaneously trying to allocate more
+  // than one bucket and exceed 'header_->num_buckets', their respective
+  // rollbacks might happen in such an order that some bucket ranges get
+  // skipped, while others might get double-allocated later.
+  std::size_t original_buckets_allocated = header_->buckets_allocated.load(std::memory_order_relaxed);
+  std::size_t buckets_post_allocation = original_buckets_allocated + total_entries;
+  while ((buckets_post_allocation <= header_->num_buckets)
+         && !header_->buckets_allocated.compare_exchange_weak(original_buckets_allocated,
+                                                              buckets_post_allocation,
+                                                              std::memory_order_relaxed)) {
+    buckets_post_allocation = original_buckets_allocated + total_entries;
+  }
+
+  if (buckets_post_allocation > header_->num_buckets) {
+    return false;
+  }
+
+  prealloc_state->bucket_position = original_buckets_allocated;
+  return true;
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+void SimpleScalarSeparateChainingHashTable<ValueT,
+                                           resizable,
+                                           serializable,
+                                           force_key_copy,
+                                           allow_duplicate_keys>
+    ::DestroyValues(Bucket *hash_buckets,
+                    const std::size_t num_buckets) {
+  if (!std::is_trivially_destructible<ValueT>::value) {
+    for (std::size_t bucket_num = 0;
+         bucket_num < num_buckets;
+         ++bucket_num) {
+      hash_buckets[bucket_num].value.~ValueT();
+    }
+  }
+}
+
+template <typename ValueT,
+          bool resizable,
+          bool serializable,
+          bool force_key_copy,
+          bool allow_duplicate_keys>
+inline bool SimpleScalarSeparateChainingHashTable<ValueT,
+                                                  resizable,
+                                                  serializable,
+                                                  force_key_copy,
+                                                  allow_duplicate_keys>
+    ::locateBucketForInsertion(const std::size_t hash_code,
+                               Bucket **bucket,
+                               std::atomic<std::size_t> **pending_chain_ptr,
+                               std::size_t *pending_chain_ptr_finish_value,
+                               HashTablePreallocationState *prealloc_state) {
+  DCHECK((prealloc_state == nullptr) || allow_duplicate_keys);
+  if (*bucket == nullptr) {
+    *pending_chain_ptr = &(slots_[hash_code % header_->num_slots]);
+  } else {
+    *pending_chain_ptr = &((*bucket)->next);
+  }
+  for (;;) {
+    std::size_t existing_chain_ptr = 0;
+    if ((*pending_chain_ptr)->compare_exchange_strong(existing_chain_ptr,
+                                                      std::numeric_limits<std::size_t>::max(),
+                                                      std::memory_order_acq_rel)) {
+      // Got to the end of the chain. Allocate a new bucket.
+      const std::size_t allocated_bucket_num
+          = (prealloc_state == nullptr)
+              ? header_->buckets_allocated.fetch_add(1, std::memory_order_relaxed)
+              : (prealloc_state->bucket_position)++;
+      if (allocated_bucket_num >= header_->num_buckets) {
+        // Ran out of buckets.
+        DCHECK(prealloc_state == nullptr);
+        header_->buckets_allocated.fetch_sub(1, std::memory_order_relaxed);
+        (*pending_chain_ptr)->store(0, std::memory_order_release);
+        *bucket = nullptr;
+        return false;
+      } else {
+        *bucket = buckets_ + allocated_bucket_num;
+        *pending_chain_ptr_finish_value = allocated_bucket_num + 1;
+        return true;
+      }
+    }
+    // Spin until the real "next" pointer is available.
+    while (existing_chain_ptr == std::numeric_limits<std::size_t>::max()) {
+      existing_chain_ptr = (*pending_chain_ptr)->load(std::memory_order_acquire);
+    }
+    if (existing_chain_ptr == 0) {
+      // Other thread had to roll back, so try again.
+      continue;
+    }
+    // Chase the next pointer.
+    *bucket = buckets_ + (existing_chain_ptr - 1);
+    *pending_chain_ptr = &((*bucket)->next);
+    if (!allow_duplicate_keys) {
+      if ((*bucket)->hash == hash_code) {
+        return false;
+      }
+    }
+  }
+}
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_STORAGE_SIMPLE_SCALAR_SEPARATE_CHAINING_HASH_TABLE_HPP_

--- a/storage/SimpleScalarSeparateChainingHashTable.hpp
+++ b/storage/SimpleScalarSeparateChainingHashTable.hpp
@@ -51,6 +51,17 @@ namespace quickstep {
  * @brief A lean simplified version of SeparateChainingHashTable that only
  *        works for scalar (non-composite) keys that have a reversible hash
  *        function.
+ *
+ * The simplified code in this version of HashTable is mostly made possible by
+ * the fact that the key Type has a reversible hash function. i.e. The original
+ * key can always be recovered from the hash value, and the hash-function is
+ * collision-free (although it is still possible for different hashes to have
+ * the same remainder modulo the number of slots in the HashTable and wind up
+ * in the same slot). So, this HashTable implementation only stores hash codes
+ * and not copies of the original keys. Besides saving space, this also means
+ * that all code for managing variable-length and/or composite keys can can be
+ * omitted, and that exact equality of hash codes (a simple integer comparison)
+ * can always be used to detect if keys collide.
  **/
 template <typename ValueT,
           bool resizable,

--- a/storage/tests/HashTable_unittest_common.hpp
+++ b/storage/tests/HashTable_unittest_common.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -1130,15 +1130,27 @@ class HashTableTest : public ::testing::Test {
 };
 TYPED_TEST_CASE_P(HashTableTest);
 
+template <typename HashTableImpl> using HashTableTestLongOnly
+    = HashTableTest<HashTableImpl>;
+TYPED_TEST_CASE_P(HashTableTestLongOnly);
+
 // Alias for tests which only apply to resizable hash tables.
 template <typename HashTableImpl> using ResizableHashTableTest
     = HashTableTest<HashTableImpl>;
 TYPED_TEST_CASE_P(ResizableHashTableTest);
 
+template <typename HashTableImpl> using ResizableHashTableTestLongOnly
+    = HashTableTest<HashTableImpl>;
+TYPED_TEST_CASE_P(ResizableHashTableTestLongOnly);
+
 // Alias for tests which only apply to non-resizable hash tables.
 template <typename HashTableImpl> using NonResizableHashTableTest
     = HashTableTest<HashTableImpl>;
 TYPED_TEST_CASE_P(NonResizableHashTableTest);
+
+template <typename HashTableImpl> using NonResizableHashTableTestLongOnly
+    = HashTableTest<HashTableImpl>;
+TYPED_TEST_CASE_P(NonResizableHashTableTestLongOnly);
 
 // Alias for tests which only apply to hash tables which do not allow duplicate
 // keys.
@@ -1146,11 +1158,19 @@ template <typename HashTableImpl> using DuplicateKeysForbiddenHashTableTest
     = HashTableTest<HashTableImpl>;
 TYPED_TEST_CASE_P(DuplicateKeysForbiddenHashTableTest);
 
+template <typename HashTableImpl> using DuplicateKeysForbiddenHashTableTestLongOnly
+    = HashTableTest<HashTableImpl>;
+TYPED_TEST_CASE_P(DuplicateKeysForbiddenHashTableTestLongOnly);
+
 // Alias for tests which only apply to hash tables which are fixed-size and
 // serializable.
 template <typename HashTableImpl> using FixedSizeSerializableHashTableTest
     = HashTableTest<HashTableImpl>;
 TYPED_TEST_CASE_P(FixedSizeSerializableHashTableTest);
+
+template <typename HashTableImpl> using FixedSizeSerializableHashTableTestLongOnly
+    = HashTableTest<HashTableImpl>;
+TYPED_TEST_CASE_P(FixedSizeSerializableHashTableTestLongOnly);
 
 // We use a separate test fixture here, since the regular HashTableTest assumes
 // that HashTableImpl::value_type is TestHashPayload.
@@ -1300,7 +1320,11 @@ class NonTriviallyDestructibleValueHashTableTest : public ::testing::Test {
 };
 TYPED_TEST_CASE_P(NonTriviallyDestructibleValueHashTableTest);
 
-TYPED_TEST_P(HashTableTest, LongKeyPutAndGetTest) {
+template <typename HashTableImpl> using NonTriviallyDestructibleValueHashTableTestLongOnly
+    = NonTriviallyDestructibleValueHashTableTest<HashTableImpl>;
+TYPED_TEST_CASE_P(NonTriviallyDestructibleValueHashTableTestLongOnly);
+
+TYPED_TEST_P(HashTableTestLongOnly, LongKeyPutAndGetTest) {
   this->runScalarKeyPutAndGetTest(TypeID::kLong);
 }
 
@@ -1431,7 +1455,7 @@ TYPED_TEST_P(HashTableTest, SpecialHashesPutAndGetTest) {
   values.clear();
 }
 
-TYPED_TEST_P(HashTableTest, LongKeyPutDuplicateKeysTest) {
+TYPED_TEST_P(HashTableTestLongOnly, LongKeyPutDuplicateKeysTest) {
   this->runDuplicateScalarKeysPutAndGetTest(TypeID::kLong);
 }
 
@@ -1563,7 +1587,7 @@ TYPED_TEST_P(HashTableTest, CompositeKeyPutDuplicateKeysTest) {
   }
 }
 
-TYPED_TEST_P(HashTableTest, LongKeyPutAndGetFromValueAccessorTest) {
+TYPED_TEST_P(HashTableTestLongOnly, LongKeyPutAndGetFromValueAccessorTest) {
   this->runScalarKeyPutAndGetFromValueAccessorTest(TypeID::kLong);
 }
 
@@ -1619,7 +1643,7 @@ TYPED_TEST_P(HashTableTest, CompositeKeyPutAndGetFromValueAccessorTest) {
   }
 }
 
-TYPED_TEST_P(HashTableTest, LongKeyThreadedPutTest) {
+TYPED_TEST_P(HashTableTestLongOnly, LongKeyThreadedPutTest) {
   this->runScalarKeyThreadedPutTest(TypeID::kLong, false);
 }
 
@@ -1635,7 +1659,7 @@ TYPED_TEST_P(HashTableTest, CompositeKeyThreadedPutTest) {
   this->runCompositeKeyThreadedPutTest(false);
 }
 
-TYPED_TEST_P(HashTableTest, LongKeyClearTest) {
+TYPED_TEST_P(HashTableTestLongOnly, LongKeyClearTest) {
   this->runScalarKeyClearTest(TypeID::kLong);
 }
 
@@ -1676,7 +1700,7 @@ TYPED_TEST_P(HashTableTest, CompositeKeyClearTest) {
   EXPECT_EQ(0u, visitor.internal_map().size());
 }
 
-TYPED_TEST_P(ResizableHashTableTest, LongKeyResizeTest) {
+TYPED_TEST_P(ResizableHashTableTestLongOnly, LongKeyResizeTest) {
   this->runScalarKeyResizeTest(TypeID::kLong);
 }
 
@@ -1718,7 +1742,7 @@ TYPED_TEST_P(ResizableHashTableTest, CompositeKeyResizeTest) {
   }
 }
 
-TYPED_TEST_P(ResizableHashTableTest, LongKeyThreadedResizeTest) {
+TYPED_TEST_P(ResizableHashTableTestLongOnly, LongKeyThreadedResizeTest) {
   this->runScalarKeyThreadedPutTest(TypeID::kLong, true);
 }
 
@@ -1734,7 +1758,7 @@ TYPED_TEST_P(ResizableHashTableTest, CompositeKeyThreadedResizeTest) {
   this->runCompositeKeyThreadedPutTest(true);
 }
 
-TYPED_TEST_P(NonResizableHashTableTest, LongKeyExhaustSpaceTest) {
+TYPED_TEST_P(NonResizableHashTableTestLongOnly, LongKeyExhaustSpaceTest) {
   this->runScalarKeyExhaustSpaceTest(TypeID::kLong);
 }
 
@@ -1785,7 +1809,7 @@ TYPED_TEST_P(NonResizableHashTableTest, CompositeKeyExhaustSpaceTest) {
   EXPECT_TRUE(failed_matches.empty());
 }
 
-TYPED_TEST_P(DuplicateKeysForbiddenHashTableTest, LongKeyUpsertTest) {
+TYPED_TEST_P(DuplicateKeysForbiddenHashTableTestLongOnly, LongKeyUpsertTest) {
   this->runScalarKeyUpsertTest(TypeID::kLong);
 }
 
@@ -1829,7 +1853,7 @@ TYPED_TEST_P(DuplicateKeysForbiddenHashTableTest, CompositeKeyUpsertTest) {
   }
 }
 
-TYPED_TEST_P(DuplicateKeysForbiddenHashTableTest, LongKeyUpsertValueAccessorTest) {
+TYPED_TEST_P(DuplicateKeysForbiddenHashTableTestLongOnly, LongKeyUpsertValueAccessorTest) {
   this->runScalarKeyUpsertValueAccessorTest(TypeID::kLong);
 }
 
@@ -1872,7 +1896,7 @@ TYPED_TEST_P(DuplicateKeysForbiddenHashTableTest, CompositeKeyUpsertValueAccesso
   }
 }
 
-TYPED_TEST_P(FixedSizeSerializableHashTableTest, LongKeySerializationTest) {
+TYPED_TEST_P(FixedSizeSerializableHashTableTestLongOnly, LongKeySerializationTest) {
   this->runScalarKeySerializationTest(TypeID::kLong);
 }
 
@@ -1975,7 +1999,7 @@ TYPED_TEST_P(FixedSizeSerializableHashTableTest, CompositeKeySerializationTest) 
   EXPECT_TRUE(nonexistent_matches.empty());
 }
 
-TYPED_TEST_P(NonTriviallyDestructibleValueHashTableTest, LongKeyDestroyValueTest) {
+TYPED_TEST_P(NonTriviallyDestructibleValueHashTableTestLongOnly, LongKeyDestroyValueTest) {
   this->runScalarKeyDestroyValueTest(TypeID::kLong);
 }
 
@@ -2007,63 +2031,75 @@ TYPED_TEST_P(NonTriviallyDestructibleValueHashTableTest, CompositeKeyDestroyValu
   EXPECT_EQ(kNumSampleKeys, destruct_count.load(std::memory_order_relaxed));
 }
 
-REGISTER_TYPED_TEST_CASE_P(HashTableTest,
+REGISTER_TYPED_TEST_CASE_P(HashTableTestLongOnly,
                            LongKeyPutAndGetTest,
+                           LongKeyPutDuplicateKeysTest,
+                           LongKeyPutAndGetFromValueAccessorTest,
+                           LongKeyThreadedPutTest,
+                           LongKeyClearTest);
+
+REGISTER_TYPED_TEST_CASE_P(HashTableTest,
                            CharKeyPutAndGetTest,
                            VarCharKeyPutAndGetTest,
                            CompositeKeyPutAndGetTest,
                            SpecialHashesPutAndGetTest,
-                           LongKeyPutDuplicateKeysTest,
                            CharKeyPutDuplicateKeysTest,
                            VarCharKeyPutDuplicateKeysTest,
                            CompositeKeyPutDuplicateKeysTest,
-                           LongKeyPutAndGetFromValueAccessorTest,
                            CharKeyPutAndGetFromValueAccessorTest,
                            VarCharKeyPutAndGetFromValueAccessorTest,
                            CompositeKeyPutAndGetFromValueAccessorTest,
-                           LongKeyThreadedPutTest,
                            CharKeyThreadedPutTest,
                            VarCharKeyThreadedPutTest,
                            CompositeKeyThreadedPutTest,
-                           LongKeyClearTest,
                            CharKeyClearTest,
                            VarCharKeyClearTest,
                            CompositeKeyClearTest);
 
-REGISTER_TYPED_TEST_CASE_P(ResizableHashTableTest,
+REGISTER_TYPED_TEST_CASE_P(ResizableHashTableTestLongOnly,
                            LongKeyResizeTest,
+                           LongKeyThreadedResizeTest);
+
+REGISTER_TYPED_TEST_CASE_P(ResizableHashTableTest,
                            CharKeyResizeTest,
                            VarCharKeyResizeTest,
                            CompositeKeyResizeTest,
-                           LongKeyThreadedResizeTest,
                            CharKeyThreadedResizeTest,
                            VarCharKeyThreadedResizeTest,
                            CompositeKeyThreadedResizeTest);
 
+REGISTER_TYPED_TEST_CASE_P(NonResizableHashTableTestLongOnly,
+                           LongKeyExhaustSpaceTest);
+
 REGISTER_TYPED_TEST_CASE_P(NonResizableHashTableTest,
-                           LongKeyExhaustSpaceTest,
                            CharKeyExhaustSpaceTest,
                            VarCharKeyExhaustSpaceTest,
                            CompositeKeyExhaustSpaceTest);
 
-REGISTER_TYPED_TEST_CASE_P(DuplicateKeysForbiddenHashTableTest,
+REGISTER_TYPED_TEST_CASE_P(DuplicateKeysForbiddenHashTableTestLongOnly,
                            LongKeyUpsertTest,
+                           LongKeyUpsertValueAccessorTest);
+
+REGISTER_TYPED_TEST_CASE_P(DuplicateKeysForbiddenHashTableTest,
                            CharKeyUpsertTest,
                            VarCharKeyUpsertTest,
                            CompositeKeyUpsertTest,
-                           LongKeyUpsertValueAccessorTest,
                            CharKeyUpsertValueAccessorTest,
                            VarCharKeyUpsertValueAccessorTest,
                            CompositeKeyUpsertValueAccessorTest);
 
+REGISTER_TYPED_TEST_CASE_P(FixedSizeSerializableHashTableTestLongOnly,
+                           LongKeySerializationTest);
+
 REGISTER_TYPED_TEST_CASE_P(FixedSizeSerializableHashTableTest,
-                           LongKeySerializationTest,
                            CharKeySerializationTest,
                            VarCharKeySerializationTest,
                            CompositeKeySerializationTest);
 
+REGISTER_TYPED_TEST_CASE_P(NonTriviallyDestructibleValueHashTableTestLongOnly,
+                           LongKeyDestroyValueTest);
+
 REGISTER_TYPED_TEST_CASE_P(NonTriviallyDestructibleValueHashTableTest,
-                           LongKeyDestroyValueTest,
                            CharKeyDestroyValueTest,
                            VarCharKeyDestroyValueTest,
                            CompositeKeyDestroyValueTest);
@@ -2072,102 +2108,221 @@ REGISTER_TYPED_TEST_CASE_P(NonTriviallyDestructibleValueHashTableTest,
 
 // Macro to automatically instantiate tests for all the different flavors of
 // the specificied HashTable implementation template.
-#define QUICKSTEP_TEST_HASHTABLE_IMPL(HashTableImpl)                \
-namespace quickstep {                                               \
-                                                                    \
-typedef ::testing::Types<                                           \
-    HashTableImpl<TestHashPayload, false, false, false, false>,     \
-    HashTableImpl<TestHashPayload, false, false, false, true>,      \
-    HashTableImpl<TestHashPayload, false, false, true, false>,      \
-    HashTableImpl<TestHashPayload, false, false, true, true>,       \
-    HashTableImpl<TestHashPayload, false, true, false, false>,      \
-    HashTableImpl<TestHashPayload, false, true, false, true>,       \
-    HashTableImpl<TestHashPayload, false, true, true, false>,       \
-    HashTableImpl<TestHashPayload, false, true, true, true>,        \
-    HashTableImpl<TestHashPayload, true, false, false, false>,      \
-    HashTableImpl<TestHashPayload, true, false, false, true>,       \
-    HashTableImpl<TestHashPayload, true, false, true, false>,       \
-    HashTableImpl<TestHashPayload, true, false, true, true>,        \
-    HashTableImpl<TestHashPayload, true, true, true, false>,        \
-    HashTableImpl<TestHashPayload, true, true, true, true>>         \
-        _CommonTestTypes;                                           \
-INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                        \
-                              HashTableTest,                        \
-                              _CommonTestTypes);                    \
-                                                                    \
-typedef ::testing::Types<                                           \
-    HashTableImpl<TestHashPayload, true, false, false, false>,      \
-    HashTableImpl<TestHashPayload, true, false, false, true>,       \
-    HashTableImpl<TestHashPayload, true, false, true, false>,       \
-    HashTableImpl<TestHashPayload, true, false, true, true>,        \
-    HashTableImpl<TestHashPayload, true, true, true, false>,        \
-    HashTableImpl<TestHashPayload, true, true, true, true>>         \
-        _ResizableTestTypes;                                        \
-INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                        \
-                              ResizableHashTableTest,               \
-                              _ResizableTestTypes);                 \
-                                                                    \
-typedef ::testing::Types<                                           \
-    HashTableImpl<TestHashPayload, false, false, false, false>,     \
-    HashTableImpl<TestHashPayload, false, false, false, true>,      \
-    HashTableImpl<TestHashPayload, false, false, true, false>,      \
-    HashTableImpl<TestHashPayload, false, false, true, true>,       \
-    HashTableImpl<TestHashPayload, false, true, false, false>,      \
-    HashTableImpl<TestHashPayload, false, true, false, true>,       \
-    HashTableImpl<TestHashPayload, false, true, true, false>,       \
-    HashTableImpl<TestHashPayload, false, true, true, true>>        \
-        _NonResizableTestTypes;                                     \
-INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                        \
-                              NonResizableHashTableTest,            \
-                              _NonResizableTestTypes);              \
-                                                                    \
-typedef ::testing::Types<                                           \
-    HashTableImpl<TestHashPayload, false, false, false, false>,     \
-    HashTableImpl<TestHashPayload, false, false, true, false>,      \
-    HashTableImpl<TestHashPayload, false, true, false, false>,      \
-    HashTableImpl<TestHashPayload, false, true, true, false>,       \
-    HashTableImpl<TestHashPayload, true, false, false, false>,      \
-    HashTableImpl<TestHashPayload, true, false, true, false>,       \
-    HashTableImpl<TestHashPayload, true, true, true, false>>        \
-        _DuplicateKeysForbiddenTypes;                               \
-INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                        \
-                              DuplicateKeysForbiddenHashTableTest,  \
-                              _DuplicateKeysForbiddenTypes);        \
-                                                                    \
-typedef ::testing::Types<                                           \
-    HashTableImpl<TestHashPayload, false, true, false, false>,      \
-    HashTableImpl<TestHashPayload, false, true, false, true>,       \
-    HashTableImpl<TestHashPayload, false, true, true, false>,       \
-    HashTableImpl<TestHashPayload, false, true, true, true>>        \
-        _FixedSizeSerializableTestTypes;                            \
-INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                        \
-                              FixedSizeSerializableHashTableTest,   \
-                              _FixedSizeSerializableTestTypes);     \
-                                                                    \
-typedef ::testing::Types<                                           \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  false, false, false, false>,                      \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  false, false, false, true>,                       \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  false, false, true, false>,                       \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  false, false, true, true>,                        \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  true, false, false, false>,                       \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  true, false, false, true>,                        \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  true, false, true, false>,                        \
-    HashTableImpl<NonTriviallyDestructibleTestHashPayload,          \
-                  true, false, true, true>>                         \
-        _NonTriviallyDestructibleNonSerializableTestTypes;          \
-INSTANTIATE_TYPED_TEST_CASE_P(                                      \
-    HashTableImpl,                                                  \
-    NonTriviallyDestructibleValueHashTableTest,                     \
-    _NonTriviallyDestructibleNonSerializableTestTypes);             \
-                                                                    \
-}  /* namespace quickstep */                                        \
+#define QUICKSTEP_TEST_HASHTABLE_IMPL(HashTableImpl)                        \
+namespace quickstep {                                                       \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, false, false, false>,             \
+    HashTableImpl<TestHashPayload, false, false, false, true>,              \
+    HashTableImpl<TestHashPayload, false, false, true, false>,              \
+    HashTableImpl<TestHashPayload, false, false, true, true>,               \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, true>,               \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, false, true, true, true>,                \
+    HashTableImpl<TestHashPayload, true, false, false, false>,              \
+    HashTableImpl<TestHashPayload, true, false, false, true>,               \
+    HashTableImpl<TestHashPayload, true, false, true, false>,               \
+    HashTableImpl<TestHashPayload, true, false, true, true>,                \
+    HashTableImpl<TestHashPayload, true, true, true, false>,                \
+    HashTableImpl<TestHashPayload, true, true, true, true>>                 \
+        _CommonTestTypes;                                                   \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              HashTableTestLongOnly,                        \
+                              _CommonTestTypes);                            \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              HashTableTest,                                \
+                              _CommonTestTypes);                            \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, true, false, false, false>,              \
+    HashTableImpl<TestHashPayload, true, false, false, true>,               \
+    HashTableImpl<TestHashPayload, true, false, true, false>,               \
+    HashTableImpl<TestHashPayload, true, false, true, true>,                \
+    HashTableImpl<TestHashPayload, true, true, true, false>,                \
+    HashTableImpl<TestHashPayload, true, true, true, true>>                 \
+        _ResizableTestTypes;                                                \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              ResizableHashTableTestLongOnly,               \
+                              _ResizableTestTypes);                         \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              ResizableHashTableTest,                       \
+                              _ResizableTestTypes);                         \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, false, false, false>,             \
+    HashTableImpl<TestHashPayload, false, false, false, true>,              \
+    HashTableImpl<TestHashPayload, false, false, true, false>,              \
+    HashTableImpl<TestHashPayload, false, false, true, true>,               \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, true>,               \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, false, true, true, true>>                \
+        _NonResizableTestTypes;                                             \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              NonResizableHashTableTestLongOnly,            \
+                              _NonResizableTestTypes);                      \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              NonResizableHashTableTest,                    \
+                              _NonResizableTestTypes);                      \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, false, false, false>,             \
+    HashTableImpl<TestHashPayload, false, false, true, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, true, false, false, false>,              \
+    HashTableImpl<TestHashPayload, true, false, true, false>,               \
+    HashTableImpl<TestHashPayload, true, true, true, false>>                \
+        _DuplicateKeysForbiddenTypes;                                       \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              DuplicateKeysForbiddenHashTableTestLongOnly,  \
+                              _DuplicateKeysForbiddenTypes);                \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              DuplicateKeysForbiddenHashTableTest,          \
+                              _DuplicateKeysForbiddenTypes);                \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, true>,               \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, false, true, true, true>>                \
+        _FixedSizeSerializableTestTypes;                                    \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              FixedSizeSerializableHashTableTestLongOnly,   \
+                              _FixedSizeSerializableTestTypes);             \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              FixedSizeSerializableHashTableTest,           \
+                              _FixedSizeSerializableTestTypes);             \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, false, false>,                              \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, false, true>,                               \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, true, false>,                               \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, true, true>,                                \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, false, false>,                               \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, false, true>,                                \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, true, false>,                                \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, true, true>>                                 \
+        _NonTriviallyDestructibleNonSerializableTestTypes;                  \
+INSTANTIATE_TYPED_TEST_CASE_P(                                              \
+    HashTableImpl,                                                          \
+    NonTriviallyDestructibleValueHashTableTestLongOnly,                     \
+    _NonTriviallyDestructibleNonSerializableTestTypes);                     \
+INSTANTIATE_TYPED_TEST_CASE_P(                                              \
+    HashTableImpl,                                                          \
+    NonTriviallyDestructibleValueHashTableTest,                             \
+    _NonTriviallyDestructibleNonSerializableTestTypes);                     \
+                                                                            \
+}  /* namespace quickstep */                                                \
+struct quickstep_hashtable_test_dummy  /* NOLINT(build/class) */
+
+// Similar to QUICKSTEP_TEST_HASHTABLE_IMPL(), but only instantiates test cases
+// that use LONG keys.
+#define QUICKSTEP_TEST_HASHTABLE_IMPL_LONG_ONLY(HashTableImpl)              \
+namespace quickstep {                                                       \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, false, false, false>,             \
+    HashTableImpl<TestHashPayload, false, false, false, true>,              \
+    HashTableImpl<TestHashPayload, false, false, true, false>,              \
+    HashTableImpl<TestHashPayload, false, false, true, true>,               \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, true>,               \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, false, true, true, true>,                \
+    HashTableImpl<TestHashPayload, true, false, false, false>,              \
+    HashTableImpl<TestHashPayload, true, false, false, true>,               \
+    HashTableImpl<TestHashPayload, true, false, true, false>,               \
+    HashTableImpl<TestHashPayload, true, false, true, true>,                \
+    HashTableImpl<TestHashPayload, true, true, true, false>,                \
+    HashTableImpl<TestHashPayload, true, true, true, true>>                 \
+        _CommonTestTypes;                                                   \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              HashTableTestLongOnly,                        \
+                              _CommonTestTypes);                            \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, true, false, false, false>,              \
+    HashTableImpl<TestHashPayload, true, false, false, true>,               \
+    HashTableImpl<TestHashPayload, true, false, true, false>,               \
+    HashTableImpl<TestHashPayload, true, false, true, true>,                \
+    HashTableImpl<TestHashPayload, true, true, true, false>,                \
+    HashTableImpl<TestHashPayload, true, true, true, true>>                 \
+        _ResizableTestTypes;                                                \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              ResizableHashTableTestLongOnly,               \
+                              _ResizableTestTypes);                         \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, false, false, false>,             \
+    HashTableImpl<TestHashPayload, false, false, false, true>,              \
+    HashTableImpl<TestHashPayload, false, false, true, false>,              \
+    HashTableImpl<TestHashPayload, false, false, true, true>,               \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, true>,               \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, false, true, true, true>>                \
+        _NonResizableTestTypes;                                             \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              NonResizableHashTableTestLongOnly,            \
+                              _NonResizableTestTypes);                      \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, false, false, false>,             \
+    HashTableImpl<TestHashPayload, false, false, true, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, true, false, false, false>,              \
+    HashTableImpl<TestHashPayload, true, false, true, false>,               \
+    HashTableImpl<TestHashPayload, true, true, true, false>>                \
+        _DuplicateKeysForbiddenTypes;                                       \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              DuplicateKeysForbiddenHashTableTestLongOnly,  \
+                              _DuplicateKeysForbiddenTypes);                \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<TestHashPayload, false, true, false, false>,              \
+    HashTableImpl<TestHashPayload, false, true, false, true>,               \
+    HashTableImpl<TestHashPayload, false, true, true, false>,               \
+    HashTableImpl<TestHashPayload, false, true, true, true>>                \
+        _FixedSizeSerializableTestTypes;                                    \
+INSTANTIATE_TYPED_TEST_CASE_P(HashTableImpl,                                \
+                              FixedSizeSerializableHashTableTestLongOnly,   \
+                              _FixedSizeSerializableTestTypes);             \
+                                                                            \
+typedef ::testing::Types<                                                   \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, false, false>,                              \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, false, true>,                               \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, true, false>,                               \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  false, false, true, true>,                                \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, false, false>,                               \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, false, true>,                                \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, true, false>,                                \
+    HashTableImpl<NonTriviallyDestructibleTestHashPayload,                  \
+                  true, false, true, true>>                                 \
+        _NonTriviallyDestructibleNonSerializableTestTypes;                  \
+INSTANTIATE_TYPED_TEST_CASE_P(                                              \
+    HashTableImpl,                                                          \
+    NonTriviallyDestructibleValueHashTableTestLongOnly,                     \
+    _NonTriviallyDestructibleNonSerializableTestTypes);                     \
+                                                                            \
+}  /* namespace quickstep */                                                \
 struct quickstep_hashtable_test_dummy  /* NOLINT(build/class) */
 
 #endif  // QUICKSTEP_STORAGE_TESTS_HASHTABLE_UNITTEST_COMMON_HPP_

--- a/storage/tests/SimpleScalarSeparateChainingHashTable_unittest.cpp
+++ b/storage/tests/SimpleScalarSeparateChainingHashTable_unittest.cpp
@@ -1,0 +1,25 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "gtest/gtest.h"
+
+#include "storage/SimpleScalarSeparateChainingHashTable.hpp"
+#include "storage/tests/HashTable_unittest_common.hpp"
+#include "storage/tests/StorageTestConfig.h"
+
+#ifdef QUICKSTEP_LONG_HASH_REVERSIBLE
+QUICKSTEP_TEST_HASHTABLE_IMPL_LONG_ONLY(SimpleScalarSeparateChainingHashTable);
+#endif  // QUICKSTEP_LONG_HASH_REVERSIBLE

--- a/storage/tests/StorageTestConfig.h.in
+++ b/storage/tests/StorageTestConfig.h.in
@@ -1,0 +1,17 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#cmakedefine QUICKSTEP_LONG_HASH_REVERSIBLE

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -178,6 +178,7 @@ target_link_libraries(quickstep_types_TypedValue
                       quickstep_types_Type_proto
                       quickstep_types_TypedValue_proto
                       quickstep_types_port_strnlen
+                      quickstep_utility_HashPair
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_TypedValue_proto
                       quickstep_types_Type_proto

--- a/types/TypedValue.hpp
+++ b/types/TypedValue.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 #include "types/TypeID.hpp"
 #include "types/TypedValue.pb.h"
 #include "types/port/strnlen.hpp"
+#include "utility/HashPair.hpp"
 #include "utility/Macros.hpp"
 
 #include "third_party/farmhash/farmhash.h"
@@ -61,7 +62,7 @@ class TypedValue {
    **/
   TypedValue()
       : value_info_(0) {
-    value_union_.long_value = 0;
+    value_union_.hash64 = 0;
   }
 
   /**
@@ -91,8 +92,8 @@ class TypedValue {
    **/
   explicit TypedValue(const int literal_int)
       : value_info_(static_cast<std::uint64_t>(kInt)) {
-    // Zero-out all bytes in the union for fastEqualCheck().
-    value_union_.long_value = 0;
+    // Zero-out all bytes in the union for getHash() and fastEqualCheck().
+    value_union_.hash64 = 0;
     value_union_.int_value = literal_int;
   }
 
@@ -109,9 +110,11 @@ class TypedValue {
    **/
   explicit TypedValue(const float literal_float)
       : value_info_(static_cast<std::uint64_t>(kFloat)) {
-    // Zero-out all bytes in the union for fastEqualCheck().
-    value_union_.long_value = 0;
-    value_union_.float_value = literal_float;
+    // Zero-out all bytes in the union for getHash() and fastEqualCheck().
+    value_union_.hash64 = 0;
+
+    // Canonicalize negative zero.
+    value_union_.float_value = literal_float == 0 ? 0 : literal_float;
   }
 
   /**
@@ -119,7 +122,8 @@ class TypedValue {
    **/
   explicit TypedValue(const double literal_double)
       : value_info_(static_cast<std::uint64_t>(kDouble)) {
-    value_union_.double_value = literal_double;
+    // Canonicalize negative zero.
+    value_union_.double_value = literal_double == 0 ? 0 : literal_double;
   }
 
   /**
@@ -178,6 +182,18 @@ class TypedValue {
     // initialized.
     value_union_.long_value = 0;
   }
+
+  /**
+   * @brief Constructor for reversing a hash function, recovering the original
+   *        value.
+   *
+   * @warning This is only usable for Types that have a reversible hash
+   *          function. Check HashIsReversible() if unsure.
+   *
+   * @param type_id The ID of the value's Type.
+   * @param hash The value's hash.
+   **/
+  inline TypedValue(const TypeID type_id, const std::size_t hash);
 
   /**
    * @brief Destructor.
@@ -271,6 +287,30 @@ class TypedValue {
   }
 
   /**
+   * @brief Determine if the hash function getHash() is reversible for
+   *        instances of a given type.
+   *
+   * @param type_id The ID of the type to check.
+   * @return Whether the hash function getHash() is reversible for instances of
+   *         the type denoted by type_id.
+   **/
+  static bool HashIsReversible(const TypeID type_id) {
+    switch (type_id) {
+      case kInt:
+      case kFloat:
+        return sizeof(value_union_.int_value) <= sizeof(std::size_t);
+      case kLong:
+      case kDouble:
+      case kDatetime:
+      case kDatetimeInterval:
+      case kYearMonthInterval:
+        return sizeof(value_union_) <= sizeof(std::size_t);
+      default:
+        return false;
+    }
+  }
+
+  /**
    * @brief Clears this value, making it equivalent to a default-constructed
    *        TypedValue (int 0). Frees any owned out-of-line data.
    **/
@@ -280,7 +320,7 @@ class TypedValue {
     }
 
     value_info_ = 0;
-    value_union_.long_value = 0;
+    value_union_.hash64 = 0;
   }
 
   /**
@@ -338,13 +378,10 @@ class TypedValue {
         return sizeof(int);
       case kLong:
       case kDouble:
-        return sizeof(std::int64_t);
       case kDatetime:
-        return sizeof(DatetimeLit);
       case kDatetimeInterval:
-        return sizeof(DatetimeIntervalLit);
       case kYearMonthInterval:
-        return sizeof(YearMonthIntervalLit);
+        return sizeof(value_union_);
       default:
         return value_info_ >> kSizeShift;
     }
@@ -460,23 +497,16 @@ class TypedValue {
    **/
   inline const void* getDataPtr() const {
     DCHECK(!isNull());
-    switch (getTypeID()) {
-      case kInt:
-        return &(value_union_.int_value);
-      case kLong:
-        return &(value_union_.long_value);
-      case kFloat:
-        return &(value_union_.float_value);
-      case kDouble:
-        return &(value_union_.double_value);
-      case kDatetime:
-        return &(value_union_.datetime_value);
-      case kDatetimeInterval:
-        return &(value_union_.datetime_interval_value);
-      case kYearMonthInterval:
-        return &(value_union_.year_month_interval_value);
-      default:
-        return value_union_.out_of_line_data;
+    if (value_info_ & kSizeBitsMask) {
+      // Data is out-of-line.
+      DCHECK(!RepresentedInline(getTypeID()));
+      return value_union_.out_of_line_data;
+    } else {
+       // According to the C standard, a pointer to a union points to each of
+       // its members and vice versa (i.e. every non-bitfield member of a union
+       // is always aligned at the front of the union itself).
+      DCHECK(RepresentedInline(getTypeID()));
+      return &value_union_;
     }
   }
 
@@ -490,40 +520,31 @@ class TypedValue {
    **/
   inline void copyInto(void *destination) const {
     DCHECK(!isNull());
-    switch (getTypeID()) {
-      case kInt:
-        *static_cast<int*>(destination) = value_union_.int_value;
-        return;
-      case kLong:
-        *static_cast<std::int64_t*>(destination) = value_union_.long_value;
-        return;
-      case kFloat:
-        *static_cast<float*>(destination) = value_union_.float_value;
-        return;
-      case kDouble:
-        *static_cast<double*>(destination) = value_union_.double_value;
-        return;
-      case kDatetime:
-        *static_cast<DatetimeLit*>(destination) = value_union_.datetime_value;
-        return;
-      case kDatetimeInterval:
-        *static_cast<DatetimeIntervalLit*>(destination) = value_union_.datetime_interval_value;
-        return;
-      case kYearMonthInterval:
-        *static_cast<YearMonthIntervalLit*>(destination) = value_union_.year_month_interval_value;
-        return;
-      default:
-        std::memcpy(destination,
-                    value_union_.out_of_line_data,
-                    value_info_ >> kSizeShift);
-        return;
+    const std::size_t out_of_line_size = value_info_ >> kSizeShift;
+    if (out_of_line_size != 0) {
+      std::memcpy(destination,
+                  value_union_.out_of_line_data,
+                  value_info_ >> kSizeShift);
+    } else {
+      switch (getTypeID()) {
+        case kInt:
+        case kFloat:
+          // 4 bytes byte-for-byte copy.
+          *static_cast<int*>(destination) = value_union_.int_value;
+          break;
+        default:
+          // 8 bytes byte-for-byte copy.
+          *static_cast<ValueUnion*>(destination) = value_union_;
+      }
     }
   }
 
   /**
    * @brief Get a hash of this TypedValue.
-   * @note The std::hash function is used for numeric values, and FarmHash is
-   *       used for all other values.
+   * @note A trivial bit-for-bit identity hash is used for inline literal
+   *       values (although on 32-bit systems bits from 64-bit wide scalars
+   *       will be mixed by CombineHashes()), and FarmHash is used for all
+   *       other values.
    * @note String values which are the same will hash to the same value, even
    *       if they are different types (i.e. Char or VarChar with different
    *       width parameters). This is intentional.
@@ -532,40 +553,83 @@ class TypedValue {
    * @return A hash of this TypedValue.
    **/
   inline std::size_t getHash() const {
-    DCHECK(!isNull());
     switch (getTypeID()) {
-      case kInt: {
-        return std::hash<int>()(value_union_.int_value);
-      }
-      case kLong: {
-        return std::hash<std::int64_t>()(value_union_.long_value);
-      }
-      case kFloat: {
-        return std::hash<float>()(value_union_.float_value);
-      }
-      case kDouble: {
-        return std::hash<double>()(value_union_.double_value);
-      }
-      case kDatetime: {
-        return std::hash<std::int64_t>()(value_union_.datetime_value.ticks);
-      }
-      case kDatetimeInterval: {
-        return std::hash<std::int64_t>()(value_union_.datetime_interval_value.interval_ticks);
-      }
-      case kYearMonthInterval: {
-        return std::hash<std::int64_t>()(value_union_.year_month_interval_value.months);
-      }
+      case kInt:
+      case kLong:
+      case kFloat:
+      case kDouble:
+      case kDatetime:
+      case kDatetimeInterval:
+      case kYearMonthInterval:
+        return getHashScalarLiteral();
       case kChar:
-      case kVarChar: {
-        // Don't hash a null-terminator or any bytes that follow it.
-        std::size_t len = getAsciiStringLength();
-        return util::Hash(static_cast<const char*>(value_union_.out_of_line_data),
-                          len);
-      }
+      case kVarChar:
+        return getHashAsciiString();
       default:
-        return util::Hash(static_cast<const char*>(value_union_.out_of_line_data),
-                          getDataSize());
+        return getHashOutOfLineNonString();
     }
+  }
+
+  /**
+   * @brief Simplified version of getHash() that is only for scalar literals
+   *        that are represented inline.
+   *
+   * @note A trivial bit-for-bit identity hash is used for inline scalar
+   *       literals (although on 32-bit systems bits from 64-bit wide scalars
+   *       will be mixed by CombineHashes()).
+   * @warning It is an error to call this for a TypedValue where
+   *          RepresentedInline() is false. If in doubt, use the generic
+   *          getHash() method instead.
+   * @warning This must not be used with null values.
+   *
+   * @return A hash of this TypedValue.
+   **/
+  inline std::size_t getHashScalarLiteral() const;
+
+  /**
+   * @brief Simplified version of getHash() that is only for ASCII string types
+   *        (i.e. instances of CharType or VarCharType).
+   *
+   * @note FarmHash is the hash function used for strings.
+   * @note Strings which are the same according to lexicographical comparison
+   *       will hash to the same value, even if they are different types (e.g.
+   *       CharType vs. VarCharType and/or string types with different width
+   *       parameters). This is intentional.
+   * @warning It is an error to call this for a TypedValue where getTypeID() is
+   *          not kChar or kVarChar. If in doubt, use the generic getHash()
+   *          method instead.
+   * @warning This must not be used with null values.
+   *
+   * @return A hash of this TypedValue.
+   **/
+  inline std::size_t getHashAsciiString() const {
+    DCHECK(!isNull());
+    DCHECK(getTypeID() == kChar || getTypeID() == kVarChar);
+
+    // Don't hash a null-terminator or any bytes that follow it.
+    return util::Hash(static_cast<const char*>(value_union_.out_of_line_data),
+                      getAsciiStringLength());
+  }
+
+  /**
+   * @brief Simplified version of getHash() that is only for types that are
+   *        represented out-of-line but are NOT ASCII strings.
+   *
+   * @note FarmHash is the hash function used for types represented
+   *       out-of-line.
+   * @warning It is an error to call this for a TypedValue where
+   *          RepresentedInline() is true, or if getTypeID() is kChar or
+   *          kVarChar. If in doubt, use the generic getHash() instead.
+   * @warning This must not be used with null values.
+   *
+   * @return A hash of this TypedValue.
+   **/
+  inline std::size_t getHashOutOfLineNonString() const {
+    DCHECK(!isNull());
+    DCHECK(!RepresentedInline(getTypeID())
+           && !(getTypeID() == kChar || getTypeID() == kVarChar));
+    return util::Hash(static_cast<const char*>(value_union_.out_of_line_data),
+                      getDataSize());
   }
 
   /**
@@ -587,16 +651,23 @@ class TypedValue {
     switch (getTypeID()) {
       case kInt:
       case kLong:
+      case kFloat:
+      case kDouble:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
-        return value_union_.long_value == other.value_union_.long_value;
-      // NOTE(chasseur): Signed zero and subnormals mean bitwise equality isn't
-      // always suited for floats.
-      case kFloat:
-        return value_union_.float_value == other.value_union_.float_value;
-      case kDouble:
-        return value_union_.double_value == other.value_union_.double_value;
+        // NOTE(chasseur): We simply do a byte-for-byte equality check of
+        // 'value_union_' for types that are represented inline. For types that
+        // are effectively 64-bit integers (LONG, DATETIME, and both INTERVAL
+        // types) this is exactly the same as normal integer equality. For
+        // types shorter than 64 bits (INT and FLOAT) we zero-out the union
+        // when constructing the TypedValue, so the non-value bytes of the
+        // union will always compare the same. Finally, for floating-point
+        // types (FLOAT and DOUBLE), we always convert negative zero to
+        // ordinary zero so that bitwise comparison will give correct results
+        // for exact equality (although the usual caveats about rounding errors
+        // for floating-point arithmetic still apply).
+        return value_union_.hash64 == other.value_union_.hash64;
       case kChar:
       case kVarChar: {
         const std::size_t len = getAsciiStringLength();
@@ -683,6 +754,18 @@ class TypedValue {
     value_info_ |= kOwnershipMask;
   }
 
+  // Templated helper method for getHashScalarLiteral(). Has implementations
+  // for 64-bit systems (always the trivial identity hash) and 32-bit systems
+  // (the trivial identity hash for scalars that are themselves 32 bits like
+  // INT and FLOAT, otherwise CombineHashes() applied to the lower and upper
+  // 4 bytes of 'value_union_').
+  template <bool size_t_64bit>
+  inline std::size_t getHashScalarLiteralImpl() const;
+
+  // Helper method for hash-reversing constructor.
+  template <bool size_t_64bit>
+  inline void reverseHash(const std::size_t hash);
+
   union ValueUnion {
     int int_value;
     std::int64_t long_value;
@@ -692,7 +775,38 @@ class TypedValue {
     DatetimeLit datetime_value;
     DatetimeIntervalLit datetime_interval_value;
     YearMonthIntervalLit year_month_interval_value;
+
+    // Used to interpret the bytes of any of the inline fields above as a
+    // 64-bit integer, providing a trivial reversible hash function.
+    std::uint64_t hash64;
+
+    // For 32-bit systems, this struct splits the 8 bytes of the ValueUnion
+    // into 2 4-byte fields that we can use CombineHashes() on.
+    struct Hash32 {
+      std::uint32_t a;
+      std::uint32_t b;
+    } hash32;
   } value_union_;
+
+  // Some static asserts that guarantee certain assumptions about ValueUnion
+  // hold.
+  static_assert(sizeof(ValueUnion) == sizeof(std::uint64_t),
+                "TypedValue::ValueUnion must fit in 64 bits.");
+
+  static_assert(sizeof(ValueUnion) == sizeof(ValueUnion::Hash32),
+                "TypedValue::ValueUnion::Hash32 must cover all of ValueUnion.");
+
+  static_assert(sizeof(ValueUnion) == sizeof(std::int64_t)
+                    && sizeof(ValueUnion) == sizeof(double)
+                    && sizeof(ValueUnion) == sizeof(DatetimeLit)
+                    && sizeof(ValueUnion) == sizeof(DatetimeIntervalLit)
+                    && sizeof(ValueUnion) == sizeof(YearMonthIntervalLit),
+                "All inline fields of TypedValue::ValueUnion except for "
+                "int_value and float_value should be 64 bits.");
+
+  static_assert(sizeof(int) == 4 && sizeof(float) == 4,
+                "TypedValue::ValueUnion::int_value and "
+                "TypedValue::ValueUnion::float_value should both be 32 bits.");
 
   // Lowest-order 6 bits are the TypeID, the 7th-lowest bit is the NULL
   // indicator, and the 8th-lowest bit indicates whether
@@ -751,6 +865,60 @@ inline YearMonthIntervalLit TypedValue::getLiteral<YearMonthIntervalLit>() const
   DCHECK_EQ(kYearMonthInterval, getTypeID());
   DCHECK(!isNull());
   return value_union_.year_month_interval_value;
+}
+
+// Explicit specializations of getHashScalarLiteralImpl().
+
+// 32-bit size_t.
+template <>
+inline std::size_t TypedValue::getHashScalarLiteralImpl<false>() const {
+  switch (getTypeID()) {
+    case kInt:
+    case kFloat:
+      return value_union_.hash32.a;
+    default:
+      return CombineHashes(value_union_.hash32.a, value_union_.hash32.b);
+  }
+}
+
+// 64-bit size_t.
+template <>
+inline std::size_t TypedValue::getHashScalarLiteralImpl<true>() const {
+  return value_union_.hash64;
+}
+
+// Implementation of TypedValue::getHashScalarLiteral() is written out-of-line
+// here because instantiations of TypedValue::getHashScalarLiteralImpl() must
+// come after the explicit specializations above.
+inline std::size_t TypedValue::getHashScalarLiteral() const {
+  DCHECK(!isNull());
+  DCHECK(RepresentedInline(getTypeID()));
+  return getHashScalarLiteralImpl<sizeof(std::size_t) == sizeof(std::uint64_t)>();
+}
+
+// Explicit specializations of reverseHash().
+
+// 32-bit size_t.
+template <>
+inline void TypedValue::reverseHash<false>(const std::size_t hash) {
+  value_union_.hash32.a = hash;
+  value_union_.hash32.b = 0;
+}
+
+// 64-bit size_t.
+template <>
+inline void TypedValue::reverseHash<true>(const std::size_t hash) {
+  value_union_.hash64 = hash;
+}
+
+// Implementation of hash-reversing constructor is written out-of-line here
+// because instantiations of TypedValue::reverseHash() must come after the
+// explicit specializations above.
+inline TypedValue::TypedValue(const TypeID type_id,
+                              const std::size_t hash)
+    : value_info_(static_cast<std::uint64_t>(type_id)) {
+  DCHECK(HashIsReversible(type_id));
+  reverseHash<sizeof(std::size_t) == sizeof(std::uint64_t)>(hash);
 }
 
 }  // namespace quickstep

--- a/types/TypedValue.hpp
+++ b/types/TypedValue.hpp
@@ -290,6 +290,12 @@ class TypedValue {
    * @brief Determine if the hash function getHash() is reversible for
    *        instances of a given type.
    *
+   * @note If getHash() is reversible, then it is possible to use the
+   *       hash-reversing constructor above to perfectly recreate a value from
+   *       its hash code. This is exploited by some code (e.g.
+   *       SimpleScalarSeparateChainingHashTable) to avoid copying and storing
+   *       values when just their hashes can be stored instead.
+   *
    * @param type_id The ID of the type to check.
    * @return Whether the hash function getHash() is reversible for instances of
    *         the type denoted by type_id.

--- a/types/tests/TypedValue_unittest.cpp
+++ b/types/tests/TypedValue_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -1498,6 +1498,16 @@ void CheckHashCollisions(const vector<TypedValue> &values) {
   }
 }
 
+template <typename ScalarLiteralType>
+void CheckHashReversal(const vector<TypedValue> &values) {
+  for (const TypedValue &original_value : values) {
+    const std::size_t hash = original_value.getHash();
+    TypedValue reconstructed(original_value.getTypeID(), hash);
+    EXPECT_EQ(original_value.getLiteral<ScalarLiteralType>(),
+              reconstructed.getLiteral<ScalarLiteralType>());
+  }
+}
+
 template <typename NumericType>
 void CheckNumericHash() {
   vector<TypedValue> values;
@@ -1512,6 +1522,10 @@ void CheckNumericHash() {
   values.push_back(TypedValue(numeric_limits<NumericType>::min()));
 
   CheckHashEquivalence(values);
+
+  if (sizeof(NumericType) <= sizeof(std::size_t)) {
+    CheckHashReversal<NumericType>(values);
+  }
 
   // On 32-bit platforms, INT64_MIN and INT64_MAX can collide with hashes for
   // 0 and -1.


### PR DESCRIPTION
This PR introduces `SimpleScalarSeparateChainingHashTable`, which is a special, simplified version of `SeparateChainingHashTable` for scalar (non-composite) keys that have a reversible hash function. It eliminates much of the complexity of key management (including the need to store a key separately at all) and hashing. Using the simplified version in hash-join and aggregation-grouping operations is expected to be faster than using the original `SeparateChainingHashTable` (although the original, along with `LinearOpenAddressingHashTable`, is still available as fallbacks for cases where we require their full generality, like string keys or composite keys).

Besides the introduction of the new `HashTable` class itself, this PR also introduces a couple of other changes that the new implementation depends on:
1. Hashing logic in `TypedValue` is changed so that we use our own trivially reversible hash function for simple scalar types instead of relying on std::hash.
2. Functionality in the base `HashTable` class that involves management of key storage has been moved to a new helper class `HashTableKeyManager`. The preexisting `HashTable` implementations require this functionality and automatically create a `HashTableKeyManager` object when they are created. The new `SimpleScalarSeparateChainingHashTable` doesn't require a `HashTableKeyManager` and thus doesn't create one.

There is probably some additional fast-path tuning that we can do for hash joins generally and for the new `SimpleScalarSeparateChainingHashTable` specifically, but this is a good first step towards optimizing the common case for joins and grouping operations with simple scalar keys.
