### PR TITLE
Auto detect the hardware concurrency level, when possible, and use that.

### DIFF
--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <thread>
+#include <thread>  // NOLINT(build/c++11)
 
 
 #include "cli/CliConfig.h"  // For QUICKSTEP_USE_LINENOISE.

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -118,7 +118,7 @@ static constexpr char kPathSeparator = '/';
 static constexpr char kDefaultStoragePath[] = "qsstor/";
 #endif
 
-DEFINE_int32(num_workers, 0, "Number of worker threads. If this values is "
+DEFINE_int32(num_workers, 0, "Number of worker threads. If this value is "
                              "specified and is greater than 0, then this "
                              "user-supplied value is used. Else (i.e. the"
                              "default case), we examine the reported "


### PR DESCRIPTION
Use std::thread::hardware_concurrency mechanism to detect the degree of hardware parallelism and use that as the default. 