### PR TITLE
Refactor the query completion checks.

### DIFF
--- a/query_execution/Foreman.hpp
+++ b/query_execution/Foreman.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -154,6 +154,15 @@ class Foreman : public Thread {
   typedef DAG<RelationalOperator, bool>::size_type_nodes dag_node_index;
 
   /**
+   * @brief Check if the current query has finished its execution.
+   *
+   * @return True if the query has finished. Otherwise false.
+   **/
+  bool checkQueryExecutionFinished() const {
+    return num_operators_finished_ == query_dag_->size();
+  }
+
+  /**
    * @brief Check if all the dependencies of the node at specified index have
    *        finished their execution.
    *
@@ -234,26 +243,18 @@ class Foreman : public Thread {
    * @brief Initialize the Foreman before starting the event loop. This binds
    * the Foreman thread to configured CPU, and does initial processing of
    * operator before waiting for events from Workers.
-   *
-   * @return Whether the Foreman is done processing execution. In a corner
-   *         case, when operators don't generate work orders, Foreman is done
-   *         with execution immediately in the initialize step.
    **/
-  bool initialize();
+  void initialize();
 
   /**
    * @brief Process a message sent to Foreman.
    *
    * @param messsage Message sent to Foreman.
    *
-   * @return Whether Foreman has completed processing and scheduling the DAG,
-   *         i.e., all operators in DAG have completely finished generating
-   *         work, and all WorkOrders have finished executing.
-   *
    * @note We still need to cleanUp() before exiting, if we want to reuse this
    *       Foreman instance for processing another DAG.
    **/
-  bool processMessage(const ForemanMessage &message);
+  void processMessage(const ForemanMessage &message);
 
   /**
    * @brief Process work order feedback message and notify relational operator.

--- a/query_execution/tests/Foreman_unittest.cpp
+++ b/query_execution/tests/Foreman_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -279,30 +279,35 @@ class ForemanTest : public ::testing::Test {
   inline bool placeDataPipelineMessage(const QueryPlan::DAGNodeIndex source_operator_index) {
     VLOG(3) << "Place DataPipeline message for Op[" << source_operator_index << "]";
     ForemanMessage foreman_message(ForemanMessage::DataPipelineMessage(source_operator_index, 0, 0));
-    return foreman_->processMessage(foreman_message);
+    foreman_->processMessage(foreman_message);
+    return foreman_->checkQueryExecutionFinished();
   }
 
   inline bool placeWorkOrderCompleteMessage(const QueryPlan::DAGNodeIndex index) {
     VLOG(3) << "Place WorkOrderComplete message for Op[" << index << "]";
     ForemanMessage foreman_message(ForemanMessage::WorkOrderCompletionMessage(index, 0));
-    return foreman_->processMessage(foreman_message);
+    foreman_->processMessage(foreman_message);
+    return foreman_->checkQueryExecutionFinished();
   }
 
   inline bool placeRebuildWorkOrderCompleteMessage(const QueryPlan::DAGNodeIndex index) {
     VLOG(3) << "Place RebuildWorkOrderComplete message for Op[" << index << "]";
     ForemanMessage foreman_message(ForemanMessage::RebuildCompletionMessage(index, 0));
-    return foreman_->processMessage(foreman_message);
+    foreman_->processMessage(foreman_message);
+    return foreman_->checkQueryExecutionFinished();
   }
 
   inline bool placeOutputBlockMessage(const QueryPlan::DAGNodeIndex index) {
     VLOG(3) << "Place OutputBlock message for Op[" << index << "]";
     ForemanMessage foreman_message(
     ForemanMessage::DataPipelineMessage(index, BlockIdUtil::GetBlockId(1 /* domain */, 1), 0));
-    return foreman_->processMessage(foreman_message);
+    foreman_->processMessage(foreman_message);
+    return foreman_->checkQueryExecutionFinished();
   }
 
   inline bool startForeman() {
-    return foreman_->initialize();
+    foreman_->initialize();
+    return foreman_->checkQueryExecutionFinished();
   }
 
   inline int getWorkerInputQueueSize() {


### PR DESCRIPTION
Provide a new API in `Foreman` to check the query completion, instead of the return values of several methods.