### PR TITLE
Comparison flip refactor

### DIFF
--- a/storage/CSBTreeIndexSubBlock.cpp
+++ b/storage/CSBTreeIndexSubBlock.cpp
@@ -624,22 +624,7 @@ TupleIdSequence* CSBTreeIndexSubBlock::getMatchesForPredicate(const ComparisonPr
   // If the literal is on the left, flip the comparison around.
   ComparisonID comp = predicate.getComparison().getComparisonID();
   if (left_literal) {
-    switch (comp) {
-      case ComparisonID::kLess:
-        comp = ComparisonID::kGreater;
-        break;
-      case ComparisonID::kLessOrEqual:
-        comp = ComparisonID::kGreaterOrEqual;
-        break;
-      case ComparisonID::kGreater:
-        comp = ComparisonID::kLess;
-        break;
-      case ComparisonID::kGreaterOrEqual:
-        comp = ComparisonID::kLessOrEqual;
-        break;
-      default:
-        break;
-    }
+    flipComparisonID(comp);
   }
 
   TupleIdSequence *idx_result;

--- a/types/operations/comparisons/ComparisonID.hpp
+++ b/types/operations/comparisons/ComparisonID.hpp
@@ -54,6 +54,28 @@ extern const char *kComparisonShortNames[
     static_cast<typename std::underlying_type<ComparisonID>::type>(
         ComparisonID::kNumComparisonIDs)];
 
+/**
+ * Flips a comparison. As in greater than flips to less than, less than flips
+ * to greater than, and similarly for greater/less than or equals. Notice that
+ * flipping equals results in equals, same for not equals.
+ * @param comparison - The Id of a comparison to flip.
+ * @return The flipped comparison id.
+ */
+inline ComparisonID flipComparisonID(const ComparisonID comparison) {
+  switch (comparison) {
+    case ComparisonID::kLess:
+      return ComparisonID::kGreater;
+    case ComparisonID::kLessOrEqual:
+      return ComparisonID::kGreaterOrEqual;
+    case ComparisonID::kGreater:
+      return ComparisonID::kLess;
+    case ComparisonID::kGreaterOrEqual:
+      return ComparisonID::kLessOrEqual;
+    default:
+      return comparison;
+  }
+}
+
 /** @} */
 
 }  // namespace quickstep

--- a/types/operations/comparisons/ComparisonID.hpp
+++ b/types/operations/comparisons/ComparisonID.hpp
@@ -55,10 +55,13 @@ extern const char *kComparisonShortNames[
         ComparisonID::kNumComparisonIDs)];
 
 /**
- * Flips a comparison. As in greater than flips to less than, less than flips
- * to greater than, and similarly for greater/less than or equals. Notice that
- * flipping equals results in equals, same for not equals.
- * @param comparison - The Id of a comparison to flip.
+ * @brief Flips a comparison. 
+ * 
+ * As in greater than flips to less than, less than flips to greater than, and
+ * similarly for greater/less than or equals. Notice that flipping equals
+ * results in equals, same for not equals.
+ * 
+ * @param comparison The Id of a comparison to flip.
  * @return The flipped comparison id.
  */
 inline ComparisonID flipComparisonID(const ComparisonID comparison) {


### PR DESCRIPTION
This is a small change that is auxiliary to the upcoming Small Materialized Aggregates SubBlock (SMA) addition.

It refactors code for flipping a comparison (less than -> greater than) to an easy to access function in ComparisonID.hpp . This new function will be used in the SMA block.