### PR TITLE
CreateTable inserts the table into Catalog without using WorkOrder.

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -770,7 +770,8 @@ void ExecutionGenerator::convertCreateTable(
   }
 
   execution_plan_->addRelationalOperator(
-      new CreateTableOperator(catalog_relation.release()));
+      new CreateTableOperator(catalog_relation.release(),
+                              optimizer_context_->catalog_database()));
 }
 
 void ExecutionGenerator::convertDeleteTuples(

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -88,9 +88,7 @@ target_link_libraries(quickstep_relationaloperators_CreateTableOperator
                       glog
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
-                      quickstep_queryexecution_WorkOrdersContainer
                       quickstep_relationaloperators_RelationalOperator
-                      quickstep_relationaloperators_WorkOrder
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_relationaloperators_DeleteOperator
                       glog

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -85,7 +85,6 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       quickstep_storage_ValueAccessor
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_relationaloperators_CreateTableOperator
-                      glog
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_relationaloperators_RelationalOperator

--- a/relational_operators/CreateTableOperator.cpp
+++ b/relational_operators/CreateTableOperator.cpp
@@ -21,8 +21,6 @@
 
 #include "catalog/CatalogDatabase.hpp"
 
-#include "glog/logging.h"
-
 namespace quickstep {
 
 bool CreateTableOperator::getAllWorkOrders(WorkOrdersContainer *container) {

--- a/relational_operators/CreateTableOperator.cpp
+++ b/relational_operators/CreateTableOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include "catalog/CatalogDatabase.hpp"
-#include "query_execution/WorkOrdersContainer.hpp"
 
 #include "glog/logging.h"
 
@@ -29,18 +28,9 @@ namespace quickstep {
 bool CreateTableOperator::getAllWorkOrders(WorkOrdersContainer *container) {
   if (!work_generated_) {
     work_generated_ = true;
-    container->addNormalWorkOrder(
-        new CreateTableWorkOrder(relation_.release()),
-        op_index_);
+    database_->addRelation(relation_.release());
   }
-  return work_generated_;
-}
-
-void CreateTableWorkOrder::execute(QueryContext *query_context,
-                                   CatalogDatabase *catalog_database,
-                                   StorageManager *storage_manager) {
-  DCHECK(catalog_database != nullptr);
-  catalog_database->addRelation(relation_.release());
+  return true;
 }
 
 }  // namespace quickstep

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,14 +22,11 @@
 
 #include "catalog/CatalogRelation.hpp"
 #include "relational_operators/RelationalOperator.hpp"
-#include "relational_operators/WorkOrder.hpp"
 #include "utility/Macros.hpp"
 
 namespace quickstep {
 
 class CatalogDatabase;
-class QueryContext;
-class StorageManager;
 class WorkOrdersContainer;
 
 /** \addtogroup RelationalOperators
@@ -47,52 +44,28 @@ class CreateTableOperator : public RelationalOperator {
    * @param relation The relation to add. This CreateTableOperator owns
    *        relation until the WorkOrder it produces is successfully executed,
    *        at which point it is owned by database.
+   * @param database The database to add a relation to.
    **/
-  explicit CreateTableOperator(CatalogRelation *relation)
+  CreateTableOperator(CatalogRelation *relation,
+                      CatalogDatabase *database)
       : relation_(relation),
+        database_(database),
         work_generated_(false) {}
 
   ~CreateTableOperator() override {}
 
+  /**
+   * @note no WorkOrder generated for this operator.
+   **/
   bool getAllWorkOrders(WorkOrdersContainer *container) override;
 
  private:
   std::unique_ptr<CatalogRelation> relation_;
+  CatalogDatabase *database_;
+
   bool work_generated_;
 
   DISALLOW_COPY_AND_ASSIGN(CreateTableOperator);
-};
-
-/**
- * @brief A WorkOrder produced by CreateTableOperator.
- **/
-class CreateTableWorkOrder : public WorkOrder {
- public:
-  /**
-   * @brief Constructor.
-   *
-   * @param relation The relation to add. This class does NOT take ownership
-   *        of the passed-in pointer, and it must remain valid until after
-   *        execute() is called, at which point it is owned by catalog_database
-   *        in execute().
-   **/
-  explicit CreateTableWorkOrder(CatalogRelation *relation)
-      : relation_(relation) {}
-
-  ~CreateTableWorkOrder() override {}
-
-  /**
-   * @exception RelationNameCollision A relation with the same name is already
-   *            present in the database.
-   **/
-  void execute(QueryContext *query_context,
-               CatalogDatabase *catalog_database,
-               StorageManager *storage_manager) override;
-
- private:
-  std::unique_ptr<CatalogRelation> relation_;
-
-  DISALLOW_COPY_AND_ASSIGN(CreateTableWorkOrder);
 };
 
 /** @} */


### PR DESCRIPTION
`CreateTableOperator` does not need `WorkOrder`-based execution model. Instead, the table will get inserted immediately into the master `Catalog` once `Foreman` processes it.

This is consistent with distributed Quickstep, and avoids the unnecessary `WorkOrder` serialization.