### PR TITLE
Overrode the doneFeedingInputBlocks method for HashJoinOperator

### DIFF
--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -376,6 +376,12 @@ void Foreman::sendWorkerMessage(const std::size_t worker_id,
 bool Foreman::fetchNormalWorkOrders(const dag_node_index index) {
   bool generated_new_workorders = false;
   if (!done_gen_[index]) {
+    // Do not fetch any work units until all blocking dependencies are met.
+    // The releational operator is not aware of blocking dependencies for
+    // uncorrelated scalar queries.
+    if (!checkAllBlockingDependenciesMet(index)) {
+      return false;
+    }
     const size_t num_pending_workorders_before =
         workorders_container_->getNumNormalWorkOrders(index);
     done_gen_[index] = query_dag_->getNodePayloadMutable(index)->getAllWorkOrders(workorders_container_.get());

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -142,6 +142,9 @@ class HashJoinOperator : public RelationalOperator {
   }
 
   void doneFeedingInputBlocks(const relation_id rel_id) override {
+    // The HashJoinOperator depends on BuildHashOperator too, but it
+    // should ignore a doneFeedingInputBlocks() message that comes
+    // after completion of BuildHashOperator. Therefore we need this check.
     if (probe_relation_.getID() == rel_id) {
       done_feeding_input_relation_ = true;
     }

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -141,6 +141,12 @@ class HashJoinOperator : public RelationalOperator {
     return output_relation_.getID();
   }
 
+  void doneFeedingInputBlocks(const relation_id rel_id) override {
+    if (probe_relation_.getID() == rel_id) {
+      done_feeding_input_relation_ = true;
+    }
+  }
+
  private:
   const CatalogRelation &build_relation_;
   const CatalogRelation &probe_relation_;


### PR DESCRIPTION
This PR fixes the correctness issue of some of the SSB query results. It seems that the base class method ``doneFeedingInputBlocks()`` of ``RelationalOperators``, was not overridden in ``HashJoinOperator``. The doxygen of ``doneFeedingInputBlocks()`` does mention that it needs to be overridden for exactly such scenarios, but the overriding was not done for ``HashJoinOperator``. 

In addition to that, I also added another condition before fetching normal WorkOrders for an operator (thanks to Qiang for discovering these issues).

I tried all the SSB queries with 10 threads and they produce consistent results now. 