### PR TITLE
Refactored DropTableOperator.

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -167,6 +167,7 @@ void ExecutionGenerator::generatePlan(const P::PhysicalPtr &physical_plan) {
     const QueryPlan::DAGNodeIndex drop_table_index =
         execution_plan_->addRelationalOperator(
             new DropTableOperator(*temporary_relation,
+                                  optimizer_context_->catalog_database(),
                                   false /* only_drop_blocks */));
     DCHECK(!temporary_relation_info.isStoredRelation());
     execution_plan_->addDependenciesForDropOperator(
@@ -797,6 +798,7 @@ void ExecutionGenerator::convertDeleteTuples(
     const QueryPlan::DAGNodeIndex drop_table_index =
         execution_plan_->addRelationalOperator(
             new DropTableOperator(*input_relation_info->relation,
+                                  optimizer_context_->catalog_database(),
                                   true /* only_drop_blocks */));
     if (!input_relation_info->isStoredRelation()) {
       execution_plan_->addDirectDependency(drop_table_index,
@@ -833,7 +835,8 @@ void ExecutionGenerator::convertDropTable(
     const P::DropTablePtr &physical_plan) {
   // DropTable is converted to a DropTable operator.
   execution_plan_->addRelationalOperator(
-      new DropTableOperator(*physical_plan->catalog_relation()));
+      new DropTableOperator(*physical_plan->catalog_relation(),
+                            optimizer_context_->catalog_database()));
 }
 
 void ExecutionGenerator::convertInsertTuple(
@@ -1199,6 +1202,7 @@ void ExecutionGenerator::convertSort(const P::SortPtr &physical_sort) {
       execution_plan_->addRelationalOperator(
           new DropTableOperator(
               *merged_runs_relation,
+              optimizer_context_->catalog_database(),
               false /* only_drop_blocks */));
   execution_plan_->addDirectDependency(
       drop_merged_runs_index,


### PR DESCRIPTION
@pateljm @jianqiao @hbdeshmukh 

This PR refactored `DropTableOperator`, which contains two tasks:
 1. Drop blocks using `StorageManager`, and
 1. Make either change in `CatalogDatabase`:
   * drop the relation, or
   * clear the blocks, but keep the relation.

In the distributed version, `Task 1` might be executed in every `Worker` where its `StorageManager` has loaded some block from the being-dropped relation, while `Task 2` should be executed only once (otherwise, the exception `RelationIdNotFound` will be thrown).

Thus, this PR enables:
 * `Task 1` wraps as `DropTableWorkOrder` to execute in some `Worker`.
 * `Task 2` happens once when `Foreman` fetches `WorkOrder`s for this operator.

Note that there are some extra work to do in future so that `DropTableOperator` could work in the distributed version with multiple workers. For example, `Foreman` should generate multiple `WorkOrder`s, instead of one for now.
