### PR TITLE
Refactor passing tmb info to work orders.

### DIFF
--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -196,8 +196,7 @@ int main(int argc, char* argv[]) {
   // Setup QueryProcessor, including CatalogDatabase and StorageManager.
   std::unique_ptr<QueryProcessor> query_processor;
   try {
-    // TODO(zuyu): Remove passing 'bus' once WorkOrder serialization is done.
-    query_processor.reset(new QueryProcessor(catalog_path, fixed_storage_path, foreman.getBusClientID(), &bus));
+    query_processor.reset(new QueryProcessor(catalog_path, fixed_storage_path, foreman.getBusClientID()));
   } catch (const std::exception &e) {
     LOG(FATAL) << "FATAL ERROR DURING STARTUP: " << e.what();
   } catch (...) {

--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -420,7 +420,10 @@ bool Foreman::fetchNormalWorkOrders(const dag_node_index index) {
     }
     const size_t num_pending_workorders_before =
         workorders_container_->getNumNormalWorkOrders(index);
-    done_gen_[index] = query_dag_->getNodePayloadMutable(index)->getAllWorkOrders(workorders_container_.get());
+    done_gen_[index] =
+        query_dag_->getNodePayloadMutable(index)->getAllWorkOrders(workorders_container_.get(),
+                                                                   foreman_client_id_,
+                                                                   bus_);
 
     // TODO(shoban): It would be a good check to see if operator is making
     // useful progress, i.e., the operator either generates work orders to

--- a/query_execution/tests/Foreman_unittest.cpp
+++ b/query_execution/tests/Foreman_unittest.cpp
@@ -143,7 +143,10 @@ class MockOperator: public RelationalOperator {
   }
 
   // Override methods from the base class.
-  bool getAllWorkOrders(WorkOrdersContainer *container) override {
+  bool getAllWorkOrders(
+      WorkOrdersContainer *container,
+      const tmb::client_id foreman_client_id,
+      tmb::MessageBus *bus) override {
     ++num_calls_get_workorders_;
     if (produce_workorders_) {
       if (has_streaming_input_) {

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -745,9 +745,7 @@ void ExecutionGenerator::convertCopyFrom(
               physical_plan->escape_strings(),
               FLAGS_parallelize_load,
               *output_relation,
-              insert_destination_index,
-              optimizer_context_->getForemanClientID(),
-              optimizer_context_->getMessageBus()));
+              insert_destination_index));
   insert_destination_proto->set_relational_op_index(scan_operator_index);
 
   const QueryPlan::DAGNodeIndex save_blocks_operator_index =
@@ -855,9 +853,7 @@ void ExecutionGenerator::convertDeleteTuples(
         execution_plan_->addRelationalOperator(new DeleteOperator(
             *input_relation_info->relation,
             execution_predicate_index,
-            input_relation_info->isStoredRelation(),
-            optimizer_context_->getForemanClientID(),
-            optimizer_context_->getMessageBus()));
+            input_relation_info->isStoredRelation()));
     if (!input_relation_info->isStoredRelation()) {
       execution_plan_->addDirectDependency(delete_tuples_index,
                                            input_relation_info->producer_operator_index,
@@ -1005,9 +1001,7 @@ void ExecutionGenerator::convertUpdateTable(
               *optimizer_context_->catalog_database()->getRelationByIdMutable(input_rel_id),
               relocation_destination_index,
               execution_predicate_index,
-              update_group_index,
-              optimizer_context_->getForemanClientID(),
-              optimizer_context_->getMessageBus()));
+              update_group_index));
   relocation_destination_proto->set_relational_op_index(update_operator_index);
 
   const QueryPlan::DAGNodeIndex save_blocks_index =
@@ -1228,9 +1222,7 @@ void ExecutionGenerator::convertSort(const P::SortPtr &physical_sort) {
                                    sort_merge_run_config_id,
                                    64 /* merge_factor */,
                                    physical_sort->limit(),
-                                   false /* input_relation_is_stored */,
-                                   optimizer_context_->getForemanClientID(),
-                                   optimizer_context_->getMessageBus()));
+                                   false /* input_relation_is_stored */));
   execution_plan_->addDirectDependency(merge_run_operator_index,
                                        run_generator_index,
                                        false /* is_pipeline_breaker */);

--- a/query_optimizer/Optimizer.hpp
+++ b/query_optimizer/Optimizer.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@
 #include "utility/Macros.hpp"
 
 #include "tmb/id_typedefs.h"
-
-namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -54,15 +52,12 @@ class Optimizer {
    *        names for temporary relations.
    * @param database The database that the query is executed on.
    * @param storage_manager The storage manager for the database.
-   * @param bus A pointer to the TMB.
    */
-  // TODO(zuyu): Remove passing 'bus' once WorkOrder serialization is done.
   Optimizer(const tmb::client_id foreman_client_id,
             const std::size_t query_id,
             CatalogDatabase *database,
-            StorageManager *storage_manager,
-            tmb::MessageBus *bus)
-      : optimizer_context_(foreman_client_id, query_id, database, storage_manager, bus) {}
+            StorageManager *storage_manager)
+      : optimizer_context_(foreman_client_id, query_id, database, storage_manager) {}
 
   /**
    * @brief Destructor.

--- a/query_optimizer/OptimizerContext.hpp
+++ b/query_optimizer/OptimizerContext.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@
 #include "utility/Macros.hpp"
 
 #include "tmb/id_typedefs.h"
-
-namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -58,19 +56,16 @@ class OptimizerContext {
    * @param catalog_database The catalog database where this query is executed.
    * @param storage_manager The storage manager to use for allocating storage
    *        blocks.
-   * @param bus A pointer to the TMB.
    */
   OptimizerContext(const tmb::client_id foreman_client_id,
                    const std::size_t query_id,
                    CatalogDatabase *catalog_database,
-                   StorageManager *storage_manager,
-                   tmb::MessageBus *bus)
+                   StorageManager *storage_manager)
       : foreman_client_id_(foreman_client_id),
         query_id_(query_id),
         current_expr_id_(-1),
         catalog_database_(catalog_database),
         storage_manager_(storage_manager),
-        bus_(bus),
         is_catalog_changed_(false) {}
 
   /**
@@ -117,15 +112,6 @@ class OptimizerContext {
   std::size_t query_id() const { return query_id_; }
 
   /**
-   * @brief Get a pointer to the TMB.
-   *
-   * @return A pointer to the TMB.
-   **/
-  tmb::MessageBus* getMessageBus() {
-    return bus_;
-  }
-
-  /**
    * @brief Gets the next ExprId.
    *
    * @return A new ExprId.
@@ -154,9 +140,6 @@ class OptimizerContext {
 
   CatalogDatabase *catalog_database_;
   StorageManager *storage_manager_;
-
-  // TODO(zuyu): Remove 'bus_' once WorkOrder serialization is done.
-  tmb::MessageBus *bus_;
 
   bool is_catalog_changed_;
 

--- a/query_optimizer/QueryProcessor.cpp
+++ b/query_optimizer/QueryProcessor.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ namespace quickstep {
 QueryHandle* QueryProcessor::generateQueryHandle(const ParseStatement &statement) {
   std::unique_ptr<QueryHandle> query_handle(new QueryHandle());
 
-  optimizer::Optimizer optimizer(foreman_client_id_, query_id_, getDefaultDatabase(), storage_manager_.get(), bus_);
+  optimizer::Optimizer optimizer(foreman_client_id_, query_id_, getDefaultDatabase(), storage_manager_.get());
   optimizer.generateQueryHandle(statement, query_handle.get());
 
   if (optimizer.isCatalogChanged() && !catalog_altered_) {

--- a/query_optimizer/QueryProcessor.hpp
+++ b/query_optimizer/QueryProcessor.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@
 #include "utility/Macros.hpp"
 
 #include "tmb/id_typedefs.h"
-
-namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -134,15 +132,12 @@ class QueryProcessor {
    * @param storage_path The filesystem directory where blocks are stored on
    *        disk.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param bus A pointer to the TMB.
    **/
   QueryProcessor(const std::string &catalog_filename,
                  const std::string &storage_path,
-                 const tmb::client_id foreman_client_id,
-                 tmb::MessageBus *bus)
+                 const tmb::client_id foreman_client_id)
       : catalog_filename_(catalog_filename),
         foreman_client_id_(foreman_client_id),
-        bus_(bus),
         catalog_altered_(false),
         query_id_(0) {
     loadCatalog();
@@ -189,8 +184,6 @@ class QueryProcessor {
   std::string catalog_filename_;
 
   const tmb::client_id foreman_client_id_;
-  // TODO(zuyu): Remove 'bus_' once WorkOrder serialization is done.
-  tmb::MessageBus *bus_;
 
   std::unique_ptr<Catalog> catalog_;
   std::unique_ptr<StorageManager> storage_manager_;

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -72,8 +72,7 @@ void ExecutionGeneratorTestRunner::runTestCase(
     OptimizerContext optimizer_context(foreman_->getBusClientID(),
                                        0 /* query_id */,
                                        test_database_loader_.catalog_database(),
-                                       test_database_loader_.storage_manager(),
-                                       &bus_);
+                                       test_database_loader_.storage_manager());
 
     if (result.condition != ParseResult::kSuccess) {
       if (result.condition == ParseResult::kError) {

--- a/query_optimizer/tests/OptimizerTest.cpp
+++ b/query_optimizer/tests/OptimizerTest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -64,8 +64,7 @@ OptimizerTest::OptimizerTest()
       optimizer_context_(new OptimizerContext(tmb::kClientIdNone /* foreman_client_id */,
                                               0 /* query_id */,
                                               catalog_database_.get(),
-                                              nullptr /* storage_manager */,
-                                              nullptr /* TMB */)),
+                                              nullptr /* storage_manager */)),
       physical_generator_(new PhysicalGenerator()) {}
 
 E::AliasPtr OptimizerTest::createAlias(const E::ExpressionPtr &expression,

--- a/query_optimizer/tests/OptimizerTextTestRunner.cpp
+++ b/query_optimizer/tests/OptimizerTextTestRunner.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -52,8 +52,7 @@ void OptimizerTextTestRunner::runTestCase(const std::string &input,
   OptimizerContext optimizer_context(tmb::kClientIdNone /* foreman_client_id */,
                                      0 /* query_id */,
                                      test_database_loader_.catalog_database(),
-                                     nullptr /* storage_manager */,
-                                     nullptr /* TMB */);
+                                     nullptr /* storage_manager */);
   if (result.condition != ParseResult::kSuccess) {
     *output = result.error_message;
   } else {

--- a/relational_operators/AggregationOperator.cpp
+++ b/relational_operators/AggregationOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,9 +26,14 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool AggregationOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool AggregationOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (input_relation_is_stored_) {
     if (!started_) {
       for (const block_id input_block_id : input_relation_block_ids_) {

--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -65,7 +69,9 @@ class AggregationOperator : public RelationalOperator {
 
   ~AggregationOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
     input_relation_block_ids_.push_back(input_block_id);

--- a/relational_operators/BuildHashOperator.cpp
+++ b/relational_operators/BuildHashOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
 namespace {
@@ -55,7 +57,10 @@ class TupleReferenceGenerator {
 
 }  // namespace
 
-bool BuildHashOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool BuildHashOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (input_relation_is_stored_) {
     if (!started_) {
       for (const block_id input_block_id : input_relation_block_ids_) {

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -75,7 +79,9 @@ class BuildHashOperator : public RelationalOperator {
 
   ~BuildHashOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id,
                       const relation_id input_relation_id) override {

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -68,7 +68,8 @@ target_link_libraries(quickstep_relationaloperators_AggregationOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_AggregationOperationState
                       quickstep_storage_StorageBlockInfo
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -85,16 +86,19 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       quickstep_storage_TupleReference
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_relationaloperators_CreateIndexOperator                      
+                      quickstep_utility_Macros
+                      tmb)
+target_link_libraries(quickstep_relationaloperators_CreateIndexOperator
                       quickstep_catalog_CatalogRelation
                       quickstep_relationaloperators_RelationalOperator
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_CreateTableOperator
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_relationaloperators_RelationalOperator
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_DeleteOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -119,7 +123,8 @@ target_link_libraries(quickstep_relationaloperators_DestroyHashOperator
                       quickstep_queryexecution_WorkOrdersContainer
                       quickstep_relationaloperators_RelationalOperator
                       quickstep_relationaloperators_WorkOrder
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_DropTableOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -130,7 +135,8 @@ target_link_libraries(quickstep_relationaloperators_DropTableOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_FinalizeAggregationOperator
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -139,7 +145,8 @@ target_link_libraries(quickstep_relationaloperators_FinalizeAggregationOperator
                       quickstep_relationaloperators_RelationalOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_AggregationOperationState
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_HashJoinOperator
                       gflags_nothreads-static
                       glog
@@ -162,7 +169,8 @@ target_link_libraries(quickstep_relationaloperators_HashJoinOperator
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_types_containers_ColumnVectorsValueAccessor
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_InsertOperator
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -172,7 +180,8 @@ target_link_libraries(quickstep_relationaloperators_InsertOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_InsertDestination
                       quickstep_types_containers_Tuple
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_NestedLoopsJoinOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -191,7 +200,8 @@ target_link_libraries(quickstep_relationaloperators_NestedLoopsJoinOperator
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_types_containers_ColumnVectorsValueAccessor
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_RebuildWorkOrder
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -209,7 +219,8 @@ target_link_libraries(quickstep_relationaloperators_RelationalOperator
                       quickstep_queryexecution_QueryContext
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_StorageBlockInfo
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_SaveBlocksOperator
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -218,7 +229,8 @@ target_link_libraries(quickstep_relationaloperators_SaveBlocksOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_SelectOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -233,7 +245,8 @@ target_link_libraries(quickstep_relationaloperators_SelectOperator
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_SortMergeRunOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -288,7 +301,8 @@ target_link_libraries(quickstep_relationaloperators_SortRunGenerationOperator
                       quickstep_storage_StorageManager
                       quickstep_storage_TupleIdSequence
                       quickstep_utility_Macros
-                      quickstep_utility_SortConfiguration)
+                      quickstep_utility_SortConfiguration
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_TableGeneratorOperator
                       glog
                       quickstep_catalog_CatalogRelation
@@ -301,7 +315,8 @@ target_link_libraries(quickstep_relationaloperators_TableGeneratorOperator
                       quickstep_storage_InsertDestination
                       quickstep_storage_StorageBlockInfo
                       quickstep_types_containers_ColumnVectorsValueAccessor
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_TextScanOperator
                       gflags_nothreads-static
                       glog

--- a/relational_operators/CreateIndexOperator.cpp
+++ b/relational_operators/CreateIndexOperator.cpp
@@ -23,7 +23,9 @@
 
 namespace quickstep {
 
-bool CreateIndexOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool CreateIndexOperator::getAllWorkOrders(WorkOrdersContainer *container,
+                                           const tmb::client_id foreman_client_id,
+                                           tmb::MessageBus *bus) {
   if (!work_generated_) {
     work_generated_ = true;
     relation_->addIndex(index_name_);

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -59,7 +59,9 @@ class CreateIndexOperator : public RelationalOperator {
   /**
    * @note no WorkOrder generated for this operator.
    **/
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
  private:
   CatalogRelation *relation_;

--- a/relational_operators/CreateTableOperator.cpp
+++ b/relational_operators/CreateTableOperator.cpp
@@ -21,9 +21,14 @@
 
 #include "catalog/CatalogDatabase.hpp"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool CreateTableOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool CreateTableOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (!work_generated_) {
     work_generated_ = true;
     database_->addRelation(relation_.release());

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -24,6 +24,10 @@
 #include "relational_operators/RelationalOperator.hpp"
 #include "utility/Macros.hpp"
 
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
+
 namespace quickstep {
 
 class CatalogDatabase;
@@ -57,7 +61,9 @@ class CreateTableOperator : public RelationalOperator {
   /**
    * @note no WorkOrder generated for this operator.
    **/
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
  private:
   std::unique_ptr<CatalogRelation> relation_;

--- a/relational_operators/DeleteOperator.cpp
+++ b/relational_operators/DeleteOperator.cpp
@@ -32,15 +32,19 @@
 #include "storage/StorageManager.hpp"
 #include "threading/ThreadIDBasedMap.hpp"
 
-#include "tmb/message_bus.h"
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+#include "tmb/message_bus.h"
 #include "tmb/tagged_message.h"
 
 namespace quickstep {
 
-bool DeleteOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool DeleteOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (relation_is_stored_) {
     // If relation_ is stored, iterate over the list of blocks in relation_.
     if (!started_) {
@@ -50,8 +54,8 @@ bool DeleteOperator::getAllWorkOrders(WorkOrdersContainer *container) {
                                 predicate_index_,
                                 input_block_id,
                                 op_index_,
-                                foreman_client_id_,
-                                bus_),
+                                foreman_client_id,
+                                bus),
             op_index_);
       }
       started_ = true;
@@ -64,8 +68,8 @@ bool DeleteOperator::getAllWorkOrders(WorkOrdersContainer *container) {
                               predicate_index_,
                               relation_block_ids_[num_workorders_generated_],
                               op_index_,
-                              foreman_client_id_,
-                              bus_),
+                              foreman_client_id,
+                              bus),
           op_index_);
       ++num_workorders_generated_;
     }

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -60,19 +60,13 @@ class DeleteOperator : public RelationalOperator {
    *        tuples will be deleted).
    * @param relation_is_stored If relation is a stored relation and is fully
    *        available to the operator before it can start generating workorders.
-   * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param bus A pointer to the TMB.
    **/
   DeleteOperator(const CatalogRelation &relation,
                  const QueryContext::predicate_id predicate_index,
-                 const bool relation_is_stored,
-                 const tmb::client_id foreman_client_id,
-                 tmb::MessageBus *bus)
+                 const bool relation_is_stored)
      :  relation_(relation),
         predicate_index_(predicate_index),
         relation_is_stored_(relation_is_stored),
-        foreman_client_id_(foreman_client_id),
-        bus_(bus),
         started_(false),
         relation_block_ids_(relation_is_stored ? relation.getBlocksSnapshot()
                                                : std::vector<block_id>()),
@@ -80,7 +74,9 @@ class DeleteOperator : public RelationalOperator {
 
   ~DeleteOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   const relation_id getOutputRelationID() const override {
     return relation_.getID();
@@ -103,10 +99,6 @@ class DeleteOperator : public RelationalOperator {
   const QueryContext::predicate_id predicate_index_;
 
   const bool relation_is_stored_;
-
-  const tmb::client_id foreman_client_id_;
-  // TODO(zuyu): Remove 'bus_' once WorkOrder serialization is done.
-  tmb::MessageBus *bus_;
 
   bool started_;
 

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,9 +22,14 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool DestroyHashOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool DestroyHashOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;
     container->addNormalWorkOrder(new DestroyHashWorkOrder(hash_table_index_),

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,6 +22,10 @@
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -49,7 +53,9 @@ class DestroyHashOperator : public RelationalOperator {
 
   ~DestroyHashOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
  private:
   const QueryContext::join_hash_table_id hash_table_index_;

--- a/relational_operators/DropTableOperator.cpp
+++ b/relational_operators/DropTableOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -29,9 +29,14 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool DropTableOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool DropTableOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;
 

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,6 +26,10 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -62,7 +66,9 @@ class DropTableOperator : public RelationalOperator {
 
   ~DropTableOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
  private:
   const CatalogRelation &relation_;

--- a/relational_operators/FinalizeAggregationOperator.cpp
+++ b/relational_operators/FinalizeAggregationOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,11 +23,16 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
 class InsertDestination;
 
-bool FinalizeAggregationOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool FinalizeAggregationOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !started_) {
     started_ = true;
     container->addNormalWorkOrder(

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -58,7 +62,9 @@ class FinalizeAggregationOperator : public RelationalOperator {
 
   ~FinalizeAggregationOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;

--- a/relational_operators/HashJoinOperator.cpp
+++ b/relational_operators/HashJoinOperator.cpp
@@ -45,6 +45,8 @@
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 using std::unique_ptr;
 using std::vector;
 
@@ -185,7 +187,10 @@ class VectorBasedJoinedTupleCollector {
 
 }  // namespace
 
-bool HashJoinOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool HashJoinOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   // We wait until the building of global hash table is complete.
   if (blocking_dependencies_met_) {
     if (probe_relation_is_stored_) {

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -31,6 +31,10 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
+
 namespace quickstep {
 
 class CatalogDatabase;
@@ -117,7 +121,9 @@ class HashJoinOperator : public RelationalOperator {
 
   ~HashJoinOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id,
                       const relation_id input_relation_id) override {

--- a/relational_operators/InsertOperator.cpp
+++ b/relational_operators/InsertOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,9 +26,14 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool InsertOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool InsertOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;
     container->addNormalWorkOrder(

--- a/relational_operators/InsertOperator.hpp
+++ b/relational_operators/InsertOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -57,7 +61,9 @@ class InsertOperator : public RelationalOperator {
 
   ~InsertOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;

--- a/relational_operators/NestedLoopsJoinOperator.cpp
+++ b/relational_operators/NestedLoopsJoinOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 using std::unique_ptr;
 using std::vector;
 
@@ -62,7 +64,10 @@ void NestedLoopsJoinOperator::feedInputBlock(const block_id input_block_id, cons
   }
 }
 
-bool NestedLoopsJoinOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool NestedLoopsJoinOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (left_relation_is_stored_ && right_relation_is_stored_) {
     // Make sure we generate workorders only once.
     if (!all_workorders_generated_) {

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -31,6 +31,10 @@
 #include "utility/Macros.hpp"
 
 #include "glog/logging.h"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -103,7 +107,9 @@ class NestedLoopsJoinOperator : public RelationalOperator {
 
   ~NestedLoopsJoinOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void doneFeedingInputBlocks(const relation_id rel_id) override {
     if (rel_id == left_input_relation_.getID()) {

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,6 +28,10 @@
 #include "utility/Macros.hpp"
 
 #include "glog/logging.h"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -61,12 +65,16 @@ class RelationalOperator {
    *
    * @param container A pointer to a WorkOrdersContainer to be used to store the
    *        generated WorkOrders.
+   * @param foreman_client_id The TMB client ID of the Foreman thread.
+   * @param bus A pointer to the TMB.
    *
    * @return Whether the operator has finished generating work orders. If \c
    *         false, the execution engine will invoke this method after at least
    *         one pending work order has finished executing.
    **/
-  virtual bool getAllWorkOrders(WorkOrdersContainer *container) = 0;
+  virtual bool getAllWorkOrders(WorkOrdersContainer *container,
+                                const tmb::client_id foreman_client_id,
+                                tmb::MessageBus *bus) = 0;
 
   /**
    * @brief Inform this RelationalOperator that ALL the dependencies which break

--- a/relational_operators/SaveBlocksOperator.cpp
+++ b/relational_operators/SaveBlocksOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,9 +25,14 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool SaveBlocksOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool SaveBlocksOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   while (num_workorders_generated_ < destination_block_ids_.size()) {
     container->addNormalWorkOrder(
         new SaveBlocksWorkOrder(

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -54,7 +58,9 @@ class SaveBlocksOperator : public RelationalOperator {
 
   ~SaveBlocksOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override;
 

--- a/relational_operators/SelectOperator.cpp
+++ b/relational_operators/SelectOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -30,11 +30,16 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
 class Predicate;
 
-bool SelectOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool SelectOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (input_relation_is_stored_) {
     if (!started_) {
       for (const block_id input_block_id : input_relation_block_ids_) {

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -29,6 +29,10 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -121,7 +125,9 @@ class SelectOperator : public RelationalOperator {
 
   ~SelectOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
     input_relation_block_ids_.push_back(input_block_id);

--- a/relational_operators/SortRunGenerationOperator.cpp
+++ b/relational_operators/SortRunGenerationOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -31,9 +31,14 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
-bool SortRunGenerationOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool SortRunGenerationOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (input_relation_is_stored_) {
     // Input blocks are from a base relation.
     if (!started_) {

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -29,6 +29,10 @@
 #include "utility/Macros.hpp"
 
 #include "glog/logging.h"
+
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
@@ -95,7 +99,9 @@ class SortRunGenerationOperator : public RelationalOperator {
 
   ~SortRunGenerationOperator() {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
     DCHECK(input_relation_id == input_relation_.getID());

--- a/relational_operators/TableGeneratorOperator.cpp
+++ b/relational_operators/TableGeneratorOperator.cpp
@@ -26,12 +26,17 @@
 
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+
 namespace quickstep {
 
 class CatalogDatabase;
 class StorageManager;
 
-bool TableGeneratorOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool TableGeneratorOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (!started_) {
     // Currently the generator function is not abstracted to be parallelizable,
     // so just produce one work order.

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -29,6 +29,10 @@
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
 
+#include "tmb/id_typedefs.h"
+
+namespace tmb { class MessageBus; }
+
 namespace quickstep {
 
 class CatalogDatabase;
@@ -66,7 +70,9 @@ class TableGeneratorOperator : public RelationalOperator {
 
   ~TableGeneratorOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
   }

--- a/relational_operators/TextScanOperator.cpp
+++ b/relational_operators/TextScanOperator.cpp
@@ -45,11 +45,12 @@
 #include "types/containers/Tuple.hpp"
 #include "utility/Glob.hpp"
 
-#include "tmb/message_bus.h"
-#include "tmb/tagged_message.h"
-
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+
+#include "tmb/id_typedefs.h"
+#include "tmb/message_bus.h"
+#include "tmb/tagged_message.h"
 
 using std::isxdigit;
 using std::size_t;
@@ -137,7 +138,10 @@ inline unsigned DetectRowTerminator(const char *search_string,
 
 }  // namespace
 
-bool TextScanOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool TextScanOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   const std::vector<std::string> files = utility::file::GlobExpand(file_pattern_);
   if (parallelize_load_) {
     // Parallel implementation: Split work orders are generated for each file
@@ -152,8 +156,8 @@ bool TextScanOperator::getAllWorkOrders(WorkOrdersContainer *container) {
               new TextSplitWorkOrder(file,
                                      process_escape_sequences_,
                                      op_index_,
-                                     foreman_client_id_,
-                                     bus_),
+                                     foreman_client_id,
+                                     bus),
               op_index_);
           ++num_split_work_orders_;
         }

--- a/relational_operators/UpdateOperator.cpp
+++ b/relational_operators/UpdateOperator.cpp
@@ -34,15 +34,18 @@
 #include "threading/ThreadIDBasedMap.hpp"
 #include "utility/Macros.hpp"
 
-#include "tmb/message_bus.h"
-
 #include "glog/logging.h"
 
+#include "tmb/id_typedefs.h"
+#include "tmb/message_bus.h"
 #include "tmb/tagged_message.h"
 
 namespace quickstep {
 
-bool UpdateOperator::getAllWorkOrders(WorkOrdersContainer *container) {
+bool UpdateOperator::getAllWorkOrders(
+    WorkOrdersContainer *container,
+    const tmb::client_id foreman_client_id,
+    tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !started_) {
     for (const block_id input_block_id : input_blocks_) {
       container->addNormalWorkOrder(
@@ -52,8 +55,8 @@ bool UpdateOperator::getAllWorkOrders(WorkOrdersContainer *container) {
                               update_group_index_,
                               input_block_id,
                               op_index_,
-                              foreman_client_id_,
-                              bus_),
+                              foreman_client_id,
+                              bus),
           op_index_);
     }
     started_ = true;

--- a/relational_operators/UpdateOperator.hpp
+++ b/relational_operators/UpdateOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -65,8 +65,6 @@ class UpdateOperator : public RelationalOperator {
    * @param update_group_index The index of a update group (the map of
    *        attribute_ids to Scalars) which should be evaluated to get the new
    *        value for the corresponding attribute.
-   * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param bus A pointer to the TMB.
    *
    * @warning The constructed InsertDestination should belong to relation, but
    *          must NOT contain any pre-existing blocks.
@@ -74,21 +72,19 @@ class UpdateOperator : public RelationalOperator {
   UpdateOperator(const CatalogRelation &relation,
                  const QueryContext::insert_destination_id relocation_destination_index,
                  const QueryContext::predicate_id predicate_index,
-                 const QueryContext::update_group_id update_group_index,
-                 const tmb::client_id foreman_client_id,
-                 tmb::MessageBus *bus)
+                 const QueryContext::update_group_id update_group_index)
       : relation_(relation),
         relocation_destination_index_(relocation_destination_index),
         predicate_index_(predicate_index),
         update_group_index_(update_group_index),
         input_blocks_(relation.getBlocksSnapshot()),
-        foreman_client_id_(foreman_client_id),
-        bus_(bus),
         started_(false) {}
 
   ~UpdateOperator() override {}
 
-  bool getAllWorkOrders(WorkOrdersContainer *container) override;
+  bool getAllWorkOrders(WorkOrdersContainer *container,
+                        const tmb::client_id foreman_client_id,
+                        tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return relocation_destination_index_;
@@ -105,10 +101,6 @@ class UpdateOperator : public RelationalOperator {
   const QueryContext::update_group_id update_group_index_;
 
   const std::vector<block_id> input_blocks_;
-
-  const tmb::client_id foreman_client_id_;
-  // TODO(zuyu): Remove 'bus_' once WorkOrder serialization is done.
-  tmb::MessageBus *bus_;
 
   bool started_;
 

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -344,7 +344,9 @@ class AggregationOperatorTest : public ::testing::Test {
   void execute() {
     const std::size_t op_index = 0;
     WorkOrdersContainer op_container(1, 0);
-    op_->getAllWorkOrders(&op_container);
+    op_->getAllWorkOrders(&op_container,
+                          tmb::kClientIdNone /* foreman_client_id */,
+                          nullptr /* TMB */);
 
     while (op_container.hasNormalWorkOrder(op_index)) {
       WorkOrder *work_order = op_container.getNormalWorkOrder(op_index);
@@ -356,7 +358,9 @@ class AggregationOperatorTest : public ::testing::Test {
 
     WorkOrdersContainer finalize_op_container(1, 0);
     const std::size_t finalize_op_index = 0;
-    finalize_op_->getAllWorkOrders(&finalize_op_container);
+    finalize_op_->getAllWorkOrders(&finalize_op_container,
+                                   tmb::kClientIdNone /* foreman_client_id */,
+                                   nullptr /* TMB */);
 
     while (finalize_op_container.hasNormalWorkOrder(finalize_op_index)) {
       WorkOrder *work_order = finalize_op_container.getNormalWorkOrder(finalize_op_index);

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -229,7 +229,7 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
     op->setOperatorIndex(kOpIndex);
     WorkOrdersContainer container(1, 0);
     const std::size_t op_index = 0;
-    op->getAllWorkOrders(&container);
+    op->getAllWorkOrders(&container, tmb::kClientIdNone /* foreman_client_id */, nullptr /* TMB */);
 
     while (container.hasNormalWorkOrder(op_index)) {
       WorkOrder *work_order = container.getNormalWorkOrder(op_index);

--- a/relational_operators/tests/SortMergeRunOperator_unittest.cpp
+++ b/relational_operators/tests/SortMergeRunOperator_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -1426,7 +1426,7 @@ class SortMergeRunOperatorTest : public ::testing::Test {
     bool done;
     WorkOrdersContainer container(kOpIndex + 1, 0);
     do {
-      done = merge_op_->getAllWorkOrders(&container);
+      done = merge_op_->getAllWorkOrders(&container, foreman_client_id_, &bus_);
       while (container.hasNormalWorkOrder(kOpIndex)) {
         std::unique_ptr<WorkOrder> order(container.getNormalWorkOrder(kOpIndex));
         order->execute(query_context_.get(), db_.get(), storage_manager_.get());
@@ -1442,7 +1442,7 @@ class SortMergeRunOperatorTest : public ::testing::Test {
     do {
       if (!done) {
         // Find work orders to execute, if not done already.
-        done = merge_op_->getAllWorkOrders(&container);
+        done = merge_op_->getAllWorkOrders(&container, foreman_client_id_, &bus_);
       }
 
       executed = false;
@@ -1501,9 +1501,7 @@ class SortMergeRunOperatorTest : public ::testing::Test {
                                              sort_config_index,
                                              merge_factor,
                                              top_k,
-                                             true,
-                                             foreman_client_id_,
-                                             &bus_));
+                                             true));
     merge_op_->setOperatorIndex(kOpIndex);
 
     // Set up the QueryContext.
@@ -1542,9 +1540,7 @@ class SortMergeRunOperatorTest : public ::testing::Test {
                                              sort_config_index,
                                              merge_factor,
                                              top_k,
-                                             false,
-                                             foreman_client_id_,
-                                             &bus_));
+                                             false));
     merge_op_->setOperatorIndex(kOpIndex);
 
     // Set up the QueryContext.

--- a/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
+++ b/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -278,7 +278,7 @@ class SortRunGenerationOperatorTest : public ::testing::Test {
 
   void executeOperator(RelationalOperator *op) {
     WorkOrdersContainer container(kOpIndex + 1, 0);
-    op->getAllWorkOrders(&container);
+    op->getAllWorkOrders(&container, thread_client_id_, &bus_);
     while (container.hasNormalWorkOrder(kOpIndex)) {
       std::unique_ptr<WorkOrder> order(container.getNormalWorkOrder(kOpIndex));
       order->execute(query_context_.get(), db_.get(), storage_manager_.get());

--- a/relational_operators/tests/TextScanOperator_unittest.cpp
+++ b/relational_operators/tests/TextScanOperator_unittest.cpp
@@ -1,5 +1,5 @@
 /**
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -86,7 +86,9 @@ class TextScanOperatorTest : public ::testing::Test {
     WorkOrdersContainer container(1, 0);
     const std::size_t op_index = 0;
     op->informAllBlockingDependenciesMet();
-    op->getAllWorkOrders(&container);
+    op->getAllWorkOrders(&container,
+                         tmb::kClientIdNone /* foreman_client_id */,
+                         nullptr /* TMB */);
 
     while (container.hasNormalWorkOrder(op_index)) {
       WorkOrder *work_order = container.getNormalWorkOrder(op_index);
@@ -149,9 +151,7 @@ TEST_F(TextScanOperatorTest, ScanTest) {
                            true,
                            false,
                            *relation_,
-                           output_destination_index,
-                           tmb::kClientIdNone /* foreman_client_id */,
-                           nullptr /* TMB */));
+                           output_destination_index));
 
   // Setup query_context_.
   query_context_.reset(new QueryContext(query_context_proto,


### PR DESCRIPTION
This PR uses `RelationalOperator::getAllWorkOrders` to pass TMB-related info to WorkOrders, instead of indirectly passing from the optimizer and then operators..

Note that there will be a similar follow-up PR to refactor passing the Foreman client id for `InsertDestination`s.