### PR TITLE
Code Style Fix for Table Gen.

### DIFF
--- a/expressions/table_generator/CMakeLists.txt
+++ b/expressions/table_generator/CMakeLists.txt
@@ -37,27 +37,26 @@ add_library(quickstep_expressions_tablegenerator_GeneratorFunctionHandle
 
 # Link dependencies:
 target_link_libraries(quickstep_expressions_tablegenerator_GenerateSeries
-                      quickstep_types_TypedValue
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GenerateSeriesHandle
                       glog
                       quickstep_expressions_tablegenerator_GeneratorFunction_proto
-                      quickstep_types_Type
+                      quickstep_types_TypedValue
+                      quickstep_types_TypedValue_proto
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunction
-                      quickstep_types_TypedValue
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunctionFactory
                       glog
                       quickstep_expressions_tablegenerator_GenerateSeries
-                      quickstep_expressions_tablegenerator_GenerateSeriesHandle
                       quickstep_expressions_tablegenerator_GeneratorFunction
                       quickstep_expressions_tablegenerator_GeneratorFunction_proto
                       quickstep_types_TypedValue
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunctionHandle
                       quickstep_expressions_tablegenerator_GeneratorFunction_proto
-                      quickstep_types_Type
+                      quickstep_types_TypedValue
+                      quickstep_types_TypedValue_proto
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunction_proto
                       quickstep_types_TypedValue_proto

--- a/expressions/table_generator/GenerateSeries.hpp
+++ b/expressions/table_generator/GenerateSeries.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -21,16 +22,20 @@
 #include <string>
 #include <vector>
 
-#include "expressions/table_generator/GeneratorFunction.hpp"
-#include "expressions/table_generator/GeneratorFunctionHandle.hpp"
 #include "expressions/table_generator/GenerateSeriesHandle.hpp"
+#include "expressions/table_generator/GeneratorFunction.hpp"
 #include "types/Type.hpp"
-#include "types/TypedValue.hpp"
 #include "types/TypeFactory.hpp"
+#include "types/TypeID.hpp"
+#include "types/TypedValue.hpp"
 #include "types/operations/comparisons/GreaterComparison.hpp"
 #include "utility/Macros.hpp"
 
+#include "glog/logging.h"
+
 namespace quickstep {
+
+class GeneratorFunctionHandle;
 
 /** \addtogroup Expressions
  *  @{

--- a/expressions/table_generator/GenerateSeries.hpp
+++ b/expressions/table_generator/GenerateSeries.hpp
@@ -65,7 +65,7 @@ class GenerateSeries : public GeneratorFunction {
     return getName() + "(<start>, <end>[, <step>])";
   }
 
-  GeneratorFunctionHandle *createHandle(
+  GeneratorFunctionHandle* createHandle(
       const std::vector<TypedValue> &arguments) const override {
     // Checks arguments and create the function handle for generate_series.
 
@@ -110,7 +110,7 @@ class GenerateSeries : public GeneratorFunction {
   }
 
  private:
-  GeneratorFunctionHandle *concretizeWithType(
+  GeneratorFunctionHandle* concretizeWithType(
       const std::vector<const Type*> &arg_types,
       const std::vector<TypedValue> &args,
       const Type &type) const {

--- a/expressions/table_generator/GenerateSeriesHandle.hpp
+++ b/expressions/table_generator/GenerateSeriesHandle.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,12 +19,14 @@
 #ifndef QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATE_SERIES_HANDLE_HPP_
 #define QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATE_SERIES_HANDLE_HPP_
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #include "expressions/table_generator/GeneratorFunctionHandle.hpp"
 #include "types/Type.hpp"
-#include "types/TypeFactory.hpp"
+#include "types/TypeID.hpp"
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/containers/ColumnVectorsValueAccessor.hpp"
@@ -61,7 +64,7 @@ class GenerateSeriesHandle : public GeneratorFunctionHandle {
     return type_;
   }
 
-  size_t getEstimatedCardinality() const override {
+  std::size_t getEstimatedCardinality() const override {
     switch (type_.getTypeID()) {
       case TypeID::kInt: {
         return estimateCardinality<int>();
@@ -161,7 +164,7 @@ class GenerateSeriesHandle : public GeneratorFunctionHandle {
   }
 
   template <typename T>
-  size_t estimateCardinality() const {
+  std::size_t estimateCardinality() const {
     T step = step_.getLiteral<T>();
     DCHECK_NE(step, static_cast<T>(0));
     return static_cast<std::size_t>(

--- a/expressions/table_generator/GenerateSeriesHandle.hpp
+++ b/expressions/table_generator/GenerateSeriesHandle.hpp
@@ -57,7 +57,7 @@ class GenerateSeriesHandle : public GeneratorFunctionHandle {
     return getName();
   }
 
-  const Type &getOutputColumnType(int index) const override {
+  const Type& getOutputColumnType(int index) const override {
     if (index > 0) {
       LOG(FATAL) << "generate_series function has only 1 output column";
     }
@@ -118,8 +118,6 @@ class GenerateSeriesHandle : public GeneratorFunctionHandle {
   }
 
  private:
-  friend class GenerateSeries;
-
   /**
    * @brief Constructor. A GenerateSeriesHandle object should only be
    *        instantiated inside method GenerateSeries::createHandle().
@@ -145,7 +143,7 @@ class GenerateSeriesHandle : public GeneratorFunctionHandle {
   }
 
   template <typename T>
-  NativeColumnVector *generateColumn() const {
+  NativeColumnVector* generateColumn() const {
     T start = start_.getLiteral<T>();
     T end = end_.getLiteral<T>();
     T step = step_.getLiteral<T>();
@@ -175,6 +173,8 @@ class GenerateSeriesHandle : public GeneratorFunctionHandle {
   const TypedValue start_;
   const TypedValue end_;
   const TypedValue step_;
+
+  friend class GenerateSeries;
 
   DISALLOW_COPY_AND_ASSIGN(GenerateSeriesHandle);
 };

--- a/expressions/table_generator/GeneratorFunction.hpp
+++ b/expressions/table_generator/GeneratorFunction.hpp
@@ -90,7 +90,7 @@ class GeneratorFunction {
    *         table generation. Caller is responsible for deleting the returned
    *         object.
    **/
-  virtual GeneratorFunctionHandle *createHandle(
+  virtual GeneratorFunctionHandle* createHandle(
       const std::vector<TypedValue> &arguments) const = 0;
 
  protected:

--- a/expressions/table_generator/GeneratorFunction.hpp
+++ b/expressions/table_generator/GeneratorFunction.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,15 +19,16 @@
 #ifndef QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATOR_FUNCTION_HPP_
 #define QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATOR_FUNCTION_HPP_
 
+#include <exception>
 #include <string>
 #include <vector>
 
-#include "types/TypedValue.hpp"
 #include "utility/Macros.hpp"
 
 namespace quickstep {
 
 class GeneratorFunctionHandle;
+class TypedValue;
 
 /** \addtogroup Expressions
  *  @{

--- a/expressions/table_generator/GeneratorFunctionFactory.cpp
+++ b/expressions/table_generator/GeneratorFunctionFactory.cpp
@@ -58,9 +58,8 @@ const GeneratorFunction* GeneratorFunctionFactory::getByName(const std::string &
 GeneratorFunctionHandle* GeneratorFunctionFactory::reconstructFromProto(
     const serialization::GeneratorFunctionHandle &proto) const {
   const GeneratorFunction *func_template = getByName(proto.function_name());
-  if (func_template == nullptr) {
-    LOG(FATAL) << "Generator function " << proto.function_name() << " not found";
-  }
+  CHECK(func_template != nullptr)
+      << "Generator function " << proto.function_name() << " not found";
 
   std::vector<TypedValue> args;
   for (const auto &arg_proto : proto.args()) {

--- a/expressions/table_generator/GeneratorFunctionFactory.cpp
+++ b/expressions/table_generator/GeneratorFunctionFactory.cpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,11 +19,12 @@
 #include "expressions/table_generator/GeneratorFunctionFactory.hpp"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "expressions/table_generator/GenerateSeries.hpp"
-#include "expressions/table_generator/GenerateSeriesHandle.hpp"
 #include "expressions/table_generator/GeneratorFunction.hpp"
+#include "expressions/table_generator/GeneratorFunction.pb.h"
 #include "types/TypedValue.hpp"
 
 #include "glog/logging.h"
@@ -53,7 +55,7 @@ const GeneratorFunction* GeneratorFunctionFactory::GetByName(const std::string &
   }
 }
 
-GeneratorFunctionHandle *GeneratorFunctionFactory::ReconstructFromProto(
+GeneratorFunctionHandle* GeneratorFunctionFactory::ReconstructFromProto(
     const serialization::GeneratorFunctionHandle &proto) const {
   const GeneratorFunction *func_template = GetByName(proto.function_name());
   if (func_template == nullptr) {

--- a/expressions/table_generator/GeneratorFunctionFactory.cpp
+++ b/expressions/table_generator/GeneratorFunctionFactory.cpp
@@ -46,7 +46,7 @@ const GeneratorFunctionFactory& GeneratorFunctionFactory::Instance() {
   return instance;
 }
 
-const GeneratorFunction* GeneratorFunctionFactory::GetByName(const std::string &name) const {
+const GeneratorFunction* GeneratorFunctionFactory::getByName(const std::string &name) const {
   const auto it = func_map_.find(name);
   if (it != func_map_.end()) {
     return it->second;
@@ -55,15 +55,15 @@ const GeneratorFunction* GeneratorFunctionFactory::GetByName(const std::string &
   }
 }
 
-GeneratorFunctionHandle* GeneratorFunctionFactory::ReconstructFromProto(
+GeneratorFunctionHandle* GeneratorFunctionFactory::reconstructFromProto(
     const serialization::GeneratorFunctionHandle &proto) const {
-  const GeneratorFunction *func_template = GetByName(proto.function_name());
+  const GeneratorFunction *func_template = getByName(proto.function_name());
   if (func_template == nullptr) {
     LOG(FATAL) << "Generator function " << proto.function_name() << " not found";
   }
 
   std::vector<TypedValue> args;
-  for (const auto& arg_proto : proto.args()) {
+  for (const auto &arg_proto : proto.args()) {
     args.emplace_back(TypedValue::ReconstructFromProto(arg_proto));
   }
 

--- a/expressions/table_generator/GeneratorFunctionFactory.hpp
+++ b/expressions/table_generator/GeneratorFunctionFactory.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,16 +19,17 @@
 #ifndef QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATOR_FUNCTION_FACTORY_HPP_
 #define QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATOR_FUNCTION_FACTORY_HPP_
 
-#include <string>
 #include <map>
+#include <string>
 
-#include "expressions/table_generator/GeneratorFunction.pb.h"
 #include "utility/Macros.hpp"
 
 namespace quickstep {
 
 class GeneratorFunction;
 class GeneratorFunctionHandle;
+
+namespace serialization { class GeneratorFunctionHandle; }
 
 /** \addtogroup Expressions
  *  @{

--- a/expressions/table_generator/GeneratorFunctionFactory.hpp
+++ b/expressions/table_generator/GeneratorFunctionFactory.hpp
@@ -61,7 +61,7 @@ class GeneratorFunctionFactory {
    * @return A pointer to the GeneratorFunction specified by name, or NULL if
    *         name does not match any known GeneratorFunction.
    **/
-  const GeneratorFunction *GetByName(const std::string &name) const;
+  const GeneratorFunction* getByName(const std::string &name) const;
 
   /**
    * @brief Reconstruct a particular GeneratorFunctionHandle by its protobuf
@@ -72,7 +72,7 @@ class GeneratorFunctionFactory {
    * @return A new GeneratorFunctionHandle object constructed from the protobuf
    *         message. Caller is responsible for deleting the returned object.
    */
-  GeneratorFunctionHandle *ReconstructFromProto(
+  GeneratorFunctionHandle* reconstructFromProto(
       const serialization::GeneratorFunctionHandle &proto) const;
 
  private:

--- a/expressions/table_generator/GeneratorFunctionHandle.hpp
+++ b/expressions/table_generator/GeneratorFunctionHandle.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,18 +19,21 @@
 #ifndef QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATOR_FUNCTION_HANDLE_HPP_
 #define QUICKSTEP_EXPRESSIONS_TABLE_GENERATOR_GENERATOR_FUNCTION_HANDLE_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "expressions/table_generator/GeneratorFunction.pb.h"
-#include "types/Type.hpp"
+#include "types/TypedValue.hpp"
+#include "types/TypedValue.pb.h"
 #include "utility/Macros.hpp"
 
 namespace quickstep {
 
 class ColumnVectorsValueAccessor;
+class Type;
 
 /** \addtogroup Expressions
  *  @{
@@ -86,7 +90,7 @@ class GeneratorFunctionHandle {
    *
    * @return The estimated number of rows that the function will generate.
    */
-  virtual size_t getEstimatedCardinality() const = 0;
+  virtual std::size_t getEstimatedCardinality() const = 0;
 
   /**
    * @brief Populate the given ColumnVectorsValueAccessor with data.

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -134,10 +134,8 @@ target_link_libraries(quickstep_parser_ParseExpression
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_parser_ParseGeneratorTableReference
                       quickstep_parser_ParseBasicExpressions
-                      quickstep_parser_ParseString
                       quickstep_parser_ParseTableReference
-                      quickstep_utility_Macros
-                      quickstep_utility_PtrList)
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_parser_ParseGroupBy
                       quickstep_parser_ParseExpression
                       quickstep_parser_ParseTreeNode

--- a/parser/ParseGeneratorTableReference.cpp
+++ b/parser/ParseGeneratorTableReference.cpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -19,8 +20,6 @@
 
 #include <string>
 #include <vector>
-
-#include "parser/ParseTableReference.hpp"
 
 namespace quickstep {
 

--- a/parser/ParseGeneratorTableReference.hpp
+++ b/parser/ParseGeneratorTableReference.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,10 +24,8 @@
 #include <vector>
 
 #include "parser/ParseBasicExpressions.hpp"
-#include "parser/ParseString.hpp"
 #include "parser/ParseTableReference.hpp"
 #include "utility/Macros.hpp"
-#include "utility/PtrList.hpp"
 
 namespace quickstep {
 

--- a/query_execution/QueryContext.cpp
+++ b/query_execution/QueryContext.cpp
@@ -1,7 +1,7 @@
 
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ QueryContext::QueryContext(const serialization::QueryContext &proto,
 
   for (int i = 0; i < proto.generator_functions_size(); ++i) {
     const GeneratorFunctionHandle *func_handle =
-        GeneratorFunctionFactory::Instance().ReconstructFromProto(proto.generator_functions(i));
+        GeneratorFunctionFactory::Instance().reconstructFromProto(proto.generator_functions(i));
     DCHECK(func_handle != nullptr);
     generator_function_groups_.emplace_back(
         std::unique_ptr<const GeneratorFunctionHandle>(func_handle));

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -61,6 +61,11 @@ class QueryContext {
   typedef std::uint32_t aggregation_state_id;
 
   /**
+   * @brief A unique identifier for a GeneratorFunctionHandle per query.
+   **/
+  typedef std::uint32_t generator_function_id;
+
+  /**
    * @brief A unique identifier for an InsertDestination per query.
    *
    * @note A negative value indicates a nonexistent InsertDestination.
@@ -103,11 +108,6 @@ class QueryContext {
    * @brief A unique identifier for a group of UpdateAssignments per query.
    **/
   typedef std::uint32_t update_group_id;
-
-  /**
-   * @brief A unique identifier for a group of GeneratorFunctionHandles per query.
-   **/
-  typedef std::uint32_t generator_function_id;
 
   /**
    * @brief Constructor.
@@ -161,6 +161,19 @@ class QueryContext {
   inline void destroyAggregationState(const aggregation_state_id id) {
     DCHECK_LT(id, aggregation_states_.size());
     aggregation_states_[id].reset();
+  }
+
+  /**
+   * @brief Get the GeneratorFunctionHandle.
+   *
+   * @param id The GeneratorFunctionHandle id in the query.
+   *
+   * @return The GeneratorFunctionHandle, alreadly created in the constructor.
+   **/
+  inline const GeneratorFunctionHandle& getGeneratorFunctionHandle(
+      const generator_function_id id) {
+    DCHECK_LT(static_cast<std::size_t>(id), generator_functions_.size());
+    return *generator_functions_[id];
   }
 
   /**
@@ -283,19 +296,9 @@ class QueryContext {
     return update_groups_[id];
   }
 
-  /**
-   * @brief Get the GeneratorFunctionHandle.
-   *
-   * @param id The GeneratorFunctionHandle id in the query.
-   * @return The GeneratorFunctionHandle, alreadly created in the constructor.
-   **/
-  inline const GeneratorFunctionHandle* getGeneratorFunctionHandle(
-      const generator_function_id id) {
-    return generator_function_groups_[id].get();
-  }
-
  private:
   std::vector<std::unique_ptr<AggregationOperationState>> aggregation_states_;
+  std::vector<std::unique_ptr<const GeneratorFunctionHandle>> generator_functions_;
   std::vector<std::unique_ptr<InsertDestination>> insert_destinations_;
   std::vector<std::unique_ptr<JoinHashTable>> join_hash_tables_;
   std::vector<std::unique_ptr<const Predicate>> predicates_;
@@ -303,7 +306,6 @@ class QueryContext {
   std::vector<std::unique_ptr<const SortConfiguration>> sort_configs_;
   std::vector<std::unique_ptr<Tuple>> tuples_;
   std::vector<std::unordered_map<attribute_id, std::unique_ptr<const Scalar>>> update_groups_;
-  std::vector<std::unique_ptr<const GeneratorFunctionHandle>> generator_function_groups_;
 
   DISALLOW_COPY_AND_ASSIGN(QueryContext);
 };

--- a/query_optimizer/logical/CMakeLists.txt
+++ b/query_optimizer/logical/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -178,8 +178,10 @@ target_link_libraries(quickstep_queryoptimizer_logical_Sort
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_TableGenerator
                       quickstep_expressions_tablegenerator_GeneratorFunctionHandle
+                      quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_utility_Cast

--- a/query_optimizer/logical/TableGenerator.hpp
+++ b/query_optimizer/logical/TableGenerator.hpp
@@ -1,7 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
-#   Copyright 2016 Pivotal Software, Inc.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -72,21 +72,21 @@ class TableGenerator : public Logical {
   /**
    * @return The reference to the generator function handle.
    */
-  const GeneratorFunctionHandlePtr &generator_function_handle() const {
+  const GeneratorFunctionHandlePtr& generator_function_handle() const {
     return generator_function_handle_;
   }
 
   /**
    * @return The alias name of this table.
    */
-  const std::string &table_alias() const {
+  const std::string& table_alias() const {
     return table_alias_;
   }
 
   /**
    * @return The reference to the output attributes of this table.
    */
-  const std::vector<expressions::AttributeReferencePtr> &attribute_list() const {
+  const std::vector<expressions::AttributeReferencePtr>& attribute_list() const {
     return attribute_list_;
   }
 

--- a/query_optimizer/logical/TableGenerator.hpp
+++ b/query_optimizer/logical/TableGenerator.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+#   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,14 +24,14 @@
 #include <vector>
 
 #include "expressions/table_generator/GeneratorFunctionHandle.hpp"
+#include "query_optimizer/OptimizerContext.hpp"
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/logical/Logical.hpp"
 #include "query_optimizer/logical/LogicalType.hpp"
 #include "utility/Cast.hpp"
 #include "utility/Macros.hpp"
-
-#include "glog/logging.h"
 
 namespace quickstep {
 namespace optimizer {

--- a/query_optimizer/physical/CMakeLists.txt
+++ b/query_optimizer/physical/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ target_link_libraries(quickstep_queryoptimizer_physical_NestedLoopsJoin
                       quickstep_queryoptimizer_physical_BinaryJoin
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_physical_PhysicalType
-                      quickstep_utility_Macros) 
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_physical_PatternMatcher
                       quickstep_queryoptimizer_physical_PhysicalType)
 target_link_libraries(quickstep_queryoptimizer_physical_Physical
@@ -181,6 +181,8 @@ target_link_libraries(quickstep_queryoptimizer_physical_TableGenerator
                       quickstep_expressions_tablegenerator_GeneratorFunctionHandle
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
+                      quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_physical_PhysicalType
                       quickstep_utility_Cast

--- a/query_optimizer/physical/TableGenerator.hpp
+++ b/query_optimizer/physical/TableGenerator.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+#   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,12 +26,12 @@
 #include "expressions/table_generator/GeneratorFunctionHandle.hpp"
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
+#include "query_optimizer/expressions/ExpressionUtil.hpp"
 #include "query_optimizer/physical/Physical.hpp"
 #include "query_optimizer/physical/PhysicalType.hpp"
 #include "utility/Cast.hpp"
 #include "utility/Macros.hpp"
-
-#include "glog/logging.h"
 
 namespace quickstep {
 namespace optimizer {

--- a/query_optimizer/physical/TableGenerator.hpp
+++ b/query_optimizer/physical/TableGenerator.hpp
@@ -1,7 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
-#   Copyright 2016 Pivotal Software, Inc.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -76,18 +76,18 @@ class TableGenerator : public Physical {
   /**
    * @return The reference to the generator function handle.
    */
-  const GeneratorFunctionHandlePtr &generator_function_handle() const {
+  const GeneratorFunctionHandlePtr& generator_function_handle() const {
     return generator_function_handle_;
   }
 
   /**
    * @return The alias name of this table.
    */
-  const std::string &table_alias() const {
+  const std::string& table_alias() const {
     return table_alias_;
   }
 
-  const std::vector<expressions::AttributeReferencePtr> &attribute_list() const {
+  const std::vector<expressions::AttributeReferencePtr>& attribute_list() const {
     return attribute_list_;
   }
 

--- a/query_optimizer/resolver/Resolver.cpp
+++ b/query_optimizer/resolver/Resolver.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -1125,7 +1125,7 @@ L::LogicalPtr Resolver::resolveGeneratorTableReference(
 
   // Resolve the generator function
   const quickstep::GeneratorFunction *func_template =
-      GeneratorFunctionFactory::Instance().GetByName(func_name->value());
+      GeneratorFunctionFactory::Instance().getByName(func_name->value());
   if (func_template == nullptr) {
       THROW_SQL_ERROR_AT(func_name)
           << "Generator function " << func_name->value() << " not found";

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -286,8 +286,9 @@ target_link_libraries(quickstep_relationaloperators_SortRunGenerationOperator
                       quickstep_utility_SortConfiguration)
 target_link_libraries(quickstep_relationaloperators_TableGeneratorOperator
                       glog
-                      quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_CatalogRelation
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_tablegenerator_GeneratorFunctionHandle
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrdersContainer
                       quickstep_relationaloperators_RelationalOperator

--- a/relational_operators/TableGeneratorOperator.cpp
+++ b/relational_operators/TableGeneratorOperator.cpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 
 #include "relational_operators/TableGeneratorOperator.hpp"
 
+#include "expressions/table_generator/GeneratorFunctionHandle.hpp"
 #include "query_execution/QueryContext.hpp"
 #include "query_execution/WorkOrdersContainer.hpp"
 #include "storage/InsertDestination.hpp"

--- a/relational_operators/TableGeneratorOperator.cpp
+++ b/relational_operators/TableGeneratorOperator.cpp
@@ -55,11 +55,11 @@ void TableGeneratorWorkOrder::execute(QueryContext *query_context,
       query_context->getInsertDestination(output_destination_index_);
   DCHECK(output_destination != nullptr);
 
-  const GeneratorFunctionHandle *function_handle =
+  const GeneratorFunctionHandle &function_handle =
       query_context->getGeneratorFunctionHandle(generator_function_index_);
 
   ColumnVectorsValueAccessor temp_result;
-  function_handle->populateColumns(&temp_result);
+  function_handle.populateColumns(&temp_result);
 
   output_destination->bulkInsertTuples(&temp_result);
 }

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -1,6 +1,7 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *   University of Wisconsin—Madison.
+ *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,8 +19,6 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_TABLE_GENERATOR_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_TABLE_GENERATOR_OPERATOR_HPP_
 
-#include <cstddef>
-#include <memory>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"


### PR DESCRIPTION
This PR fixed code style issues merged in #39. See the wiki for the [code style guide](https://github.com/pivotalsoftware/quickstep/wiki/Quickstep-Style-Guide).

Some highlights:
 * For new files, we need to run `include-what-you-use` script.
 * For return values, the reference symbol (`&`) or the pointer symbol (`*`) should be next to the return values, instead of the function name.
 * For non-static methods, the first letter of the method name should be in the lower case.
 * Always use `std::size_t`, defined in `<cstddef>`.
 * Items in `QueryContext` is sorted by alphabet order.