### PR TITLE
Delay dropping table until all blocks get deleted.

### DIFF
--- a/catalog/CatalogDatabase.cpp
+++ b/catalog/CatalogDatabase.cpp
@@ -53,7 +53,9 @@ bool CatalogDatabase::ProtoIsValid(const serialization::CatalogDatabase &proto) 
   return true;
 }
 
-CatalogDatabase::CatalogDatabase(const serialization::CatalogDatabase &proto) : name_(proto.name()) {
+CatalogDatabase::CatalogDatabase(const serialization::CatalogDatabase &proto)
+    : name_(proto.name()),
+      status_(Status::kConsistent) {
   DCHECK(ProtoIsValid(proto))
       << "Attempted to create CatalogDatabase from an invalid proto description:\n"
       << proto.DebugString();

--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -482,7 +482,11 @@ void Foreman::processOperator(const dag_node_index index,
 void Foreman::markOperatorFinished(const dag_node_index index) {
   execution_finished_[index] = true;
   ++num_operators_finished_;
-  const relation_id output_rel = query_dag_->getNodePayload(index).getOutputRelationID();
+
+  RelationalOperator *op = query_dag_->getNodePayloadMutable(index);
+  op->updateCatalogOnCompletion();
+
+  const relation_id output_rel = op->getOutputRelationID();
   for (const pair<dag_node_index, bool> &dependent_link : query_dag_->getDependents(index)) {
     const dag_node_index dependent_op_index = dependent_link.first;
     RelationalOperator *dependent_op = query_dag_->getNodePayloadMutable(dependent_op_index);

--- a/relational_operators/DropTableOperator.cpp
+++ b/relational_operators/DropTableOperator.cpp
@@ -46,6 +46,8 @@ bool DropTableOperator::getAllWorkOrders(
     container->addNormalWorkOrder(
         new DropTableWorkOrder(std::move(relation_blocks)),
         op_index_);
+
+    database_->setStatus(CatalogDatabase::Status::kPendingBlockDeletions);
   }
 
   return work_generated_;
@@ -58,6 +60,8 @@ void DropTableOperator::updateCatalogOnCompletion() {
   } else {
     database_->dropRelationById(rel_id);
   }
+
+  database_->setStatus(CatalogDatabase::Status::kConsistent);
 }
 
 void DropTableWorkOrder::execute(QueryContext *query_context,

--- a/relational_operators/DropTableOperator.cpp
+++ b/relational_operators/DropTableOperator.cpp
@@ -46,16 +46,18 @@ bool DropTableOperator::getAllWorkOrders(
     container->addNormalWorkOrder(
         new DropTableWorkOrder(std::move(relation_blocks)),
         op_index_);
-
-    // TODO(zuyu): move the following code to a better place.
-    const relation_id rel_id = relation_.getID();
-    if (only_drop_blocks_) {
-      database_->getRelationByIdMutable(rel_id)->clearBlocks();
-    } else {
-      database_->dropRelationById(rel_id);
-    }
   }
+
   return work_generated_;
+}
+
+void DropTableOperator::updateCatalogOnCompletion() {
+  const relation_id rel_id = relation_.getID();
+  if (only_drop_blocks_) {
+    database_->getRelationByIdMutable(rel_id)->clearBlocks();
+  } else {
+    database_->dropRelationById(rel_id);
+  }
 }
 
 void DropTableWorkOrder::execute(QueryContext *query_context,

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -70,6 +70,8 @@ class DropTableOperator : public RelationalOperator {
                         const tmb::client_id foreman_client_id,
                         tmb::MessageBus *bus) override;
 
+  void updateCatalogOnCompletion() override;
+
  private:
   const CatalogRelation &relation_;
   CatalogDatabase *database_;

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -77,6 +77,14 @@ class RelationalOperator {
                                 tmb::MessageBus *bus) = 0;
 
   /**
+   * @brief Update Catalog upon the completion of this RelationalOperator, if
+   *        necessary.
+   *
+   **/
+  virtual void updateCatalogOnCompletion() {
+  }
+
+  /**
    * @brief Inform this RelationalOperator that ALL the dependencies which break
    *        the pipeline have been met.
    *


### PR DESCRIPTION
This PR refactors `DropTableOperator` (updated by #43) to delay the table drop until all blocks get deleted. This avoids the dangling reference to the being-dropped `CatalogRelation` in the blocks.

This PR also provides a virtual method `RelationalOperator::updateCatalogOnCompletion` for other operators such as `CreateTableOperator` and `CreateIndexOperator`.

