### PR TITLE
Fixed the block counting bug.

### DIFF
--- a/storage/StorageBlockBase.hpp
+++ b/storage/StorageBlockBase.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class StorageBlockBase {
    **/
   virtual ~StorageBlockBase() {
 #ifdef QUICKSTEP_DEBUG
-    CHECK_EQ(0, ref_count_)
+    CHECK_EQ(0, getRefCount())
         << "Nonzero ref_count_ when deleting block ("
         << BlockIdUtil::Domain(id_) << ", "
         << BlockIdUtil::Counter(id_) << ")";


### PR DESCRIPTION
This PR should fix the block counting bug encountered in `quickstep_queryoptimizer_tests_executiongenerator`. See https://travis-ci.org/pivotalsoftware/quickstep/jobs/112693625 for more info.

```
F0229 21:18:05.125586 17407 StorageBlockBase.hpp:42] Check failed: 0 == ref_count_ (0 vs. 1) Nonzero ref_count_ when deleting block (1, 2)
```

The main issue would be that we access the atomic value in an incorrect way. This should be fixed by accessing the value using the given API `load`, instead of the value name directly.