### PR TITLE
Skip over special characters '.' and '\'

### DIFF
--- a/cli/LineReader.cpp
+++ b/cli/LineReader.cpp
@@ -171,6 +171,9 @@ std::string LineReader::getNextCommand() {
               // If the dot or forward slash begins the line, begin a command search.
               if (scan_position == 0) {
                 line_state = kCommand;
+              } else {
+                // This is a regular character, so skip over it.
+                scan_position = special_char_location + 1;
               }
               break;
             default:


### PR DESCRIPTION
Some SQL commands such as the query below simply loop infinitely in the LineReader.
```
SELECT * FROM generate_series(1.5, 5.5);
``` 
Easy fix -- skip over these characters that are not at the beginning of the line. 