### PR TITLE
Use DCHECK_NOTNULL in constructor init list.

### DIFF
--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -111,13 +111,10 @@ class AggregationWorkOrder : public WorkOrder {
    * @param input_block_id The block id.
    * @param state The AggregationState to use.
    **/
-  AggregationWorkOrder(
-      const block_id input_block_id,
-      AggregationOperationState *state)
+  AggregationWorkOrder(const block_id input_block_id,
+                       AggregationOperationState *state)
       : input_block_id_(input_block_id),
-        state_(state) {
-    DCHECK(state_ != nullptr);
-  }
+        state_(DCHECK_NOTNULL(state)) {}
 
   ~AggregationWorkOrder() override {}
 

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -147,11 +147,8 @@ class BuildHashWorkOrder : public WorkOrder {
         join_key_attributes_(join_key_attributes),
         any_join_key_attributes_nullable_(any_join_key_attributes_nullable),
         build_block_id_(build_block_id),
-        hash_table_(hash_table),
-        storage_manager_(storage_manager) {
-    DCHECK(hash_table_ != nullptr);
-    DCHECK(storage_manager_ != nullptr);
-  }
+        hash_table_(DCHECK_NOTNULL(hash_table)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~BuildHashWorkOrder() override {}
 

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -88,11 +88,13 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_relationaloperators_CreateIndexOperator
+                      glog
                       quickstep_catalog_CatalogRelation
                       quickstep_relationaloperators_RelationalOperator
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_relationaloperators_CreateTableOperator
+                      glog
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_relationaloperators_RelationalOperator

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -23,6 +23,8 @@
 #include "relational_operators/RelationalOperator.hpp"
 #include "utility/Macros.hpp"
 
+#include "glog/logging.h"
+
 #include "tmb/id_typedefs.h"
 
 namespace tmb { class MessageBus; }
@@ -55,7 +57,7 @@ class CreateIndexOperator : public RelationalOperator {
    **/
   CreateIndexOperator(CatalogRelation *relation,
                       const std::string &index_name)
-      : relation_(relation),
+      : relation_(DCHECK_NOTNULL(relation)),
         index_name_(index_name),
         work_generated_(false) {}
 

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -24,6 +24,8 @@
 #include "relational_operators/RelationalOperator.hpp"
 #include "utility/Macros.hpp"
 
+#include "glog/logging.h"
+
 #include "tmb/id_typedefs.h"
 
 namespace tmb { class MessageBus; }
@@ -54,8 +56,8 @@ class CreateTableOperator : public RelationalOperator {
    **/
   CreateTableOperator(CatalogRelation *relation,
                       CatalogDatabase *database)
-      : relation_(relation),
-        database_(database),
+      : relation_(DCHECK_NOTNULL(relation)),
+        database_(DCHECK_NOTNULL(database)),
         work_generated_(false) {}
 
   ~CreateTableOperator() override {}

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -141,13 +141,10 @@ class DeleteWorkOrder : public WorkOrder {
       : input_relation_(input_relation),
         input_block_id_(input_block_id),
         predicate_(predicate),
-        storage_manager_(storage_manager),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
         delete_operator_index_(delete_operator_index),
         foreman_client_id_(foreman_client_id),
-        bus_(bus) {
-    DCHECK(storage_manager_ != nullptr);
-    DCHECK(bus_ != nullptr);
-  }
+        bus_(DCHECK_NOTNULL(bus)) {}
 
   ~DeleteWorkOrder() override {}
 

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -83,9 +83,7 @@ class DestroyHashWorkOrder : public WorkOrder {
   DestroyHashWorkOrder(const QueryContext::join_hash_table_id hash_table_index,
                        QueryContext *query_context)
       : hash_table_index_(hash_table_index),
-        query_context_(query_context) {
-    DCHECK(query_context_ != nullptr);
-  }
+        query_context_(DCHECK_NOTNULL(query_context)) {}
 
   ~DestroyHashWorkOrder() override {}
 

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -100,9 +100,7 @@ class DropTableWorkOrder : public WorkOrder {
   DropTableWorkOrder(std::vector<block_id> &&blocks,
                      StorageManager *storage_manager)
       : blocks_(std::move(blocks)),
-        storage_manager_(storage_manager) {
-    DCHECK(storage_manager_ != nullptr);
-  }
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~DropTableWorkOrder() override {}
 

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -109,11 +109,8 @@ class FinalizeAggregationWorkOrder : public WorkOrder {
    */
   FinalizeAggregationWorkOrder(AggregationOperationState *state,
                                InsertDestination *output_destination)
-      : state_(state),
-        output_destination_(output_destination) {
-    DCHECK(state_ != nullptr);
-    DCHECK(output_destination_ != nullptr);
-  }
+      : state_(DCHECK_NOTNULL(state)),
+        output_destination_(DCHECK_NOTNULL(output_destination)) {}
 
   ~FinalizeAggregationWorkOrder() override {}
 

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -228,13 +228,9 @@ class HashJoinWorkOrder : public WorkOrder {
         block_id_(lookup_block_id),
         residual_predicate_(residual_predicate),
         selection_(selection),
-        output_destination_(output_destination),
-        hash_table_(hash_table),
-        storage_manager_(storage_manager) {
-    DCHECK(output_destination_ != nullptr);
-    DCHECK(hash_table_ != nullptr);
-    DCHECK(storage_manager_ != nullptr);
-  }
+        output_destination_(DCHECK_NOTNULL(output_destination)),
+        hash_table_(DCHECK_NOTNULL(hash_table)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~HashJoinWorkOrder() override {}
 

--- a/relational_operators/InsertOperator.hpp
+++ b/relational_operators/InsertOperator.hpp
@@ -107,11 +107,8 @@ class InsertWorkOrder : public WorkOrder {
    **/
   InsertWorkOrder(InsertDestination *output_destination,
                   Tuple *tuple)
-      : output_destination_(output_destination),
-        tuple_(tuple) {
-    DCHECK(output_destination_ != nullptr);
-    DCHECK(tuple_ != nullptr);
-  }
+      : output_destination_(DCHECK_NOTNULL(output_destination)),
+        tuple_(DCHECK_NOTNULL(tuple)) {}
 
   ~InsertWorkOrder() override {}
 

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -247,14 +247,10 @@ class NestedLoopsJoinWorkOrder : public WorkOrder {
         right_input_relation_(right_input_relation),
         left_block_id_(left_block_id),
         right_block_id_(right_block_id),
-        join_predicate_(join_predicate),
+        join_predicate_(DCHECK_NOTNULL(join_predicate)),
         selection_(selection),
-        output_destination_(output_destination),
-        storage_manager_(storage_manager) {
-    DCHECK(join_predicate_ != nullptr);
-    DCHECK(output_destination_ != nullptr);
-    DCHECK(storage_manager_ != nullptr);
-  }
+        output_destination_(DCHECK_NOTNULL(output_destination)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~NestedLoopsJoinWorkOrder() override {}
 

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -105,9 +105,7 @@ class SaveBlocksWorkOrder : public WorkOrder {
                       StorageManager *storage_manager)
       : save_block_id_(save_block_id),
         force_(force),
-        storage_manager_(storage_manager) {
-    DCHECK(storage_manager_ != nullptr);
-  }
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~SaveBlocksWorkOrder() override {}
 

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -214,11 +214,8 @@ class SelectWorkOrder : public WorkOrder {
         simple_projection_(simple_projection),
         simple_selection_(simple_selection),
         selection_(selection),
-        output_destination_(output_destination),
-        storage_manager_(storage_manager) {
-    DCHECK(output_destination_ != nullptr);
-    DCHECK(storage_manager_ != nullptr);
-  }
+        output_destination_(DCHECK_NOTNULL(output_destination)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~SelectWorkOrder() override {}
 

--- a/relational_operators/SortMergeRunOperator.hpp
+++ b/relational_operators/SortMergeRunOperator.hpp
@@ -246,15 +246,12 @@ class SortMergeRunWorkOrder : public WorkOrder {
         input_runs_(std::move(input_runs)),
         top_k_(top_k),
         merge_level_(merge_level),
-        output_destination_(output_destination),
-        storage_manager_(storage_manager),
+        output_destination_(DCHECK_NOTNULL(output_destination)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
         operator_index_(operator_index),
         foreman_client_id_(foreman_client_id),
-        bus_(bus) {
+        bus_(DCHECK_NOTNULL(bus)) {
     DCHECK(sort_config_.isValid());
-    DCHECK(output_destination_ != nullptr);
-    DCHECK(storage_manager_ != nullptr);
-    DCHECK(bus_ != nullptr);
   }
 
   const SortConfiguration &sort_config_;

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -166,11 +166,9 @@ class SortRunGenerationWorkOrder : public WorkOrder {
       : input_relation_(input_relation),
         input_block_id_(input_block_id),
         sort_config_(sort_config),
-        output_destination_(output_destination),
-        storage_manager_(storage_manager) {
+        output_destination_(DCHECK_NOTNULL(output_destination)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)) {
     DCHECK(sort_config_.isValid());
-    DCHECK(output_destination_ != nullptr);
-    DCHECK(storage_manager_ != nullptr);
   }
 
   ~SortRunGenerationWorkOrder() {}

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -120,9 +120,7 @@ class TableGeneratorWorkOrder : public WorkOrder {
   TableGeneratorWorkOrder(const GeneratorFunctionHandle &function_handle,
                           InsertDestination *output_destination)
       : function_handle_(function_handle),
-        output_destination_(output_destination) {
-    DCHECK(output_destination_ != nullptr);
-  }
+        output_destination_(DCHECK_NOTNULL(output_destination)) {}
 
   ~TableGeneratorWorkOrder() override {}
 

--- a/relational_operators/TextScanOperator.hpp
+++ b/relational_operators/TextScanOperator.hpp
@@ -334,13 +334,10 @@ class TextSplitWorkOrder : public WorkOrder {
                      MessageBus *bus)
       : filename_(filename),
         process_escape_sequences_(process_escape_sequences),
-        storage_manager_(storage_manager),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
         operator_index_(operator_index),
         foreman_client_id_(foreman_client_id),
-        bus_(bus) {
-    DCHECK(storage_manager_ != nullptr);
-    DCHECK(bus_ != nullptr);
-  }
+        bus_(DCHECK_NOTNULL(bus)) {}
 
   /**
    * @exception TextScanReadError The text file could not be opened for

--- a/relational_operators/UpdateOperator.hpp
+++ b/relational_operators/UpdateOperator.hpp
@@ -154,15 +154,11 @@ class UpdateWorkOrder : public WorkOrder {
         input_block_id_(input_block_id),
         predicate_(predicate),
         assignments_(assignments),
-        relocation_destination_(relocation_destination),
-        storage_manager_(storage_manager),
+        relocation_destination_(DCHECK_NOTNULL(relocation_destination)),
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
         update_operator_index_(update_operator_index),
         foreman_client_id_(foreman_client_id),
-        bus_(bus) {
-    DCHECK(relocation_destination_ != nullptr);
-    DCHECK(storage_manager != nullptr);
-    DCHECK(bus_ != nullptr);
-  }
+        bus_(DCHECK_NOTNULL(bus)) {}
 
   ~UpdateWorkOrder() override {}
 


### PR DESCRIPTION
This PR uses `DCHECK_NOTNULL` to ensure the pointer arguments is not `nullptr` in constructors' init list.