### PR TITLE
Add a helper function for instantiating templates that have many bool parameters.

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -351,6 +351,7 @@ target_link_libraries(TemplateUtil_unittest
                       glog
                       gtest
                       gtest_main
+                      quickstep_utility_Macros
                       quickstep_utility_TemplateUtil)
 add_test(TemplateUtil_unittest TemplateUtil_unittest)
 

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -165,6 +165,7 @@ add_library(quickstep_utility_StringUtil StringUtil.cpp StringUtil.hpp)
 # Note that TextBasedTest.{hpp, cpp} are not in this static library.
 # Any tests that use them need to include them in the
 # executable.
+add_library(quickstep_utility_TemplateUtil ../empty_src.cpp TemplateUtil.hpp)
 add_library(quickstep_utility_TextBasedTestDriver
             textbased_test/TextBasedTestDriver.cpp
             textbased_test/TextBasedTestDriver.hpp
@@ -225,6 +226,7 @@ target_link_libraries(quickstep_utility_ShardedLockManager
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_StringUtil
                       glog)
+target_link_libraries(quickstep_utility_TemplateUtil)
 target_link_libraries(quickstep_utility_TextBasedTestDriver
                       glog
                       gtest
@@ -263,6 +265,7 @@ target_link_libraries(quickstep_utility
                       quickstep_utility_SortConfiguration_proto
                       quickstep_utility_SqlError
                       quickstep_utility_StringUtil
+                      quickstep_utility_TemplateUtil
                       quickstep_utility_TextBasedTestDriver
                       quickstep_utility_ThreadSafeQueue
                       quickstep_utility_TreeStringSerializable
@@ -342,6 +345,14 @@ target_link_libraries(TreeStringSerializable_unittest
                       gtest_main
                       quickstep_utility_TreeStringSerializable)
 add_test(TreeStringSerializable_unittest TreeStringSerializable_unittest)
+
+add_executable(TemplateUtil_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/TemplateUtil_unittest.cpp")
+target_link_libraries(TemplateUtil_unittest
+                      glog
+                      gtest
+                      gtest_main
+                      quickstep_utility_TemplateUtil)
+add_test(TemplateUtil_unittest TemplateUtil_unittest)
 
 # Benchmarks:
 if (UNIX)

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -41,7 +41,7 @@ struct Seq {};
  *        Seq<1,2,...,N>.
  *
  * GenSeq is defined here for C++11 compatibility. For C++14 and above,
- * std::make_interger_sequence can be used to achieve the same functionality.
+ * std::make_integer_sequence can be used to achieve the same functionality.
  */
 template<std::size_t N, std::size_t ...S>
 struct GenSeq : GenSeq<N-1, N-1, S...> {};

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -140,8 +140,7 @@ inline ReturnT* CreateBoolInstantiatedInstance(Tuple&& args) {
 template <template <bool ...> class T, class ReturnT,
           bool ...bool_values, typename ...Bools,
           typename Tuple>
-inline ReturnT* CreateBoolInstantiatedInstance(
-    Tuple&& args, bool tparam, Bools ...rest_tparams) {
+inline ReturnT* CreateBoolInstantiatedInstance(Tuple&& args, bool tparam, Bools ...rest_tparams) {
   if (tparam) {
     return CreateBoolInstantiatedInstance<T, ReturnT, bool_values..., true>(
         std::forward<Tuple>(args), rest_tparams...);

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -1,0 +1,157 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *   University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_UTILITY_TEMPLATE_UTIL_HPP_
+#define QUICKSTEP_UTILITY_TEMPLATE_UTIL_HPP_
+
+#include <utility>
+
+namespace quickstep {
+
+/** \addtogroup Utility
+ *  @{
+ */
+
+/**
+ * @brief Represents a compile-time sequence of integers.
+ *
+ * Seq is defined here for C++11 compatibility. For C++14 and above,
+ * std::integer_sequence can be used to achieve the same functionality.
+ */
+template<int ...>
+struct Seq {};
+
+/**
+ * @brief The helper class for creating Seq. GenSeq<N>::type is equivalent to
+ *        Seq<1,2,...,N>.
+ *
+ * GenSeq is defined here for C++11 compatibility. For C++14 and above,
+ * std::make_interger_sequence can be used to achieve the same functionality.
+ */
+template<int N, int ...S>
+struct GenSeq : GenSeq<N-1, N-1, S...> {};
+
+template<int ...S>
+struct GenSeq<0, S...> {
+  typedef Seq<S...> type;
+};
+
+
+/**
+ * @brief Final step of CreateBoolInstantiatedInstance. Now all bool_values are
+ *        ready. Instantiate the template and create (i.e. new) an instance.
+ */
+template <template <bool ...> class T, class ReturnT,
+          bool ...bool_values, int ...i,
+          typename Tuple>
+inline ReturnT* CreateBoolInstantiatedInstanceInner(Tuple&& args, Seq<i...>&& indices) {
+  return new T<bool_values...>(std::get<i>(std::forward<Tuple>(args))...);
+}
+
+/**
+ * @brief Edge case of the recursive CreateBoolInstantiatedInstance function
+ *        when all bool variables have been branched and replaced with compile-time
+ *        bool constants.
+ */
+template <template <bool ...> class T, class ReturnT,
+          bool ...bool_values,
+          typename ArgsTuple>
+inline ReturnT* CreateBoolInstantiatedInstance(ArgsTuple&& args) {
+  // Note that the constructor arguments have been forwarded as a tuple (args).
+  // Here we generate a compile-time index sequence (i.e. typename GenSeq<n_args>::type())
+  // for the tuple, so that the tuple can be unpacked as a sequence of constructor
+  // parameters in CreateBoolInstantiatedInstanceInner.
+  constexpr std::size_t n_args = std::tuple_size<ArgsTuple>::value;
+  return CreateBoolInstantiatedInstanceInner<T, ReturnT, bool_values...>(
+      std::forward<ArgsTuple>(args), typename GenSeq<n_args>::type());
+}
+
+/**
+ * @brief A helper function for creating bool branched templates.
+ *
+ * The scenario for using this helper function is that, suppose we have a class
+ * where all template parameters are bools:
+ * --
+ * template <bool c1, bool c2, bool c3>
+ * class SomeClass : BaseClass {
+ *   // This simple function will be invoked in computationally-intensive loops.
+ *   inline SomeType someSimpleFunction(...) {
+ *     if (c1) {
+ *       doSomeThing1();
+ *     }
+ *     if (c2) {
+ *       doSomeThing2();
+ *     }
+ *     if (c3) {
+ *       doSomeThing3();
+ *     }
+ *   }
+ * };
+ * --
+ * Typically, this bool-paramterized template is for performance consideration.
+ * That is, we would like to make a copy of code for each configuration of bool
+ * values, so that there will be no branchings in someSimpleFunction().
+ *
+ * The problem is that, to conditionally instantiate the template, given bool
+ * variables c1, c2, c3, we have to do something like this:
+ * --
+ * if (c1) {
+ *   if (c2) {
+ *     if (c3) {
+ *       return new SomeClass<true, true, true>(some_args...);
+ *     } else {
+ *       return new SomeClass<true, true, false>(some_args...);
+ *     }
+ *   } else {
+ *     if (c3) {
+ *       return new SomeClass<true, false, true>(some_args...);
+ *     } else {
+ *       return new SomeClass<true, false, false>(some_args...);
+ *     }
+ * } else {
+ *   ...
+ * }
+ * --
+ * Then there will be power(2,N) branches if the template has N bool parameters,
+ * making it tedious to do the instantiating.
+ *
+ * Now, this helper function can achieve the branched instantiation in one
+ * statement as:
+ * --
+ * return CreateBoolInstantiatedInstance<SomeClass,BaseClass>(
+ *     std::forward_as_tuple(some_args...), c1, c2, c3);
+ * --
+ */
+template <template <bool ...> class T, class ReturnT,
+          bool ...bool_values, typename ...Bools,
+          typename ArgsTuple>
+inline ReturnT* CreateBoolInstantiatedInstance(
+    ArgsTuple&& args, bool tparam, Bools ...rest_tparams) {
+  if (tparam) {
+    return CreateBoolInstantiatedInstance<T, ReturnT, bool_values..., true>(
+        std::forward<ArgsTuple>(args), rest_tparams...);
+  } else {
+    return CreateBoolInstantiatedInstance<T, ReturnT, bool_values..., false>(
+        std::forward<ArgsTuple>(args), rest_tparams...);
+  }
+}
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_UTILITY_TEMPLATE_UTIL_HPP_

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -32,7 +32,7 @@ namespace quickstep {
  * Seq is defined here for C++11 compatibility. For C++14 and above,
  * std::integer_sequence can be used to achieve the same functionality.
  */
-template<size_t ...>
+template<std::size_t ...>
 struct Seq {};
 
 /**
@@ -42,10 +42,10 @@ struct Seq {};
  * GenSeq is defined here for C++11 compatibility. For C++14 and above,
  * std::make_interger_sequence can be used to achieve the same functionality.
  */
-template<size_t N, size_t ...S>
+template<std::size_t N, std::size_t ...S>
 struct GenSeq : GenSeq<N-1, N-1, S...> {};
 
-template<size_t ...S>
+template<std::size_t ...S>
 struct GenSeq<0, S...> {
   typedef Seq<S...> type;
 };
@@ -56,7 +56,7 @@ struct GenSeq<0, S...> {
  *        ready. Instantiate the template and create (i.e. new) an instance.
  */
 template <template <bool ...> class T, class ReturnT,
-          bool ...bool_values, size_t ...i,
+          bool ...bool_values, std::size_t ...i,
           typename Tuple>
 inline ReturnT* CreateBoolInstantiatedInstanceInner(Tuple&& args, Seq<i...>&& indices) {
   return new T<bool_values...>(std::get<i>(std::forward<Tuple>(args))...);

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -56,10 +56,10 @@ struct GenSeq<0, S...> {
  *        ready. Instantiate the template and create (i.e. new) an instance.
  */
 template <template <bool ...> class T, class ReturnT,
-          bool ...bool_values, std::size_t ...i,
-          typename Tuple>
-inline ReturnT* CreateBoolInstantiatedInstanceInner(Tuple&& args, Seq<i...>&& indices) {
-  return new T<bool_values...>(std::get<i>(std::forward<Tuple>(args))...);
+          bool ...bool_values, typename ArgsTuple,
+          std::size_t ...i>
+inline ReturnT* CreateBoolInstantiatedInstanceInner(ArgsTuple&& args, Seq<i...>&& indices) {
+  return new T<bool_values...>(std::get<i>(std::forward<ArgsTuple>(args))...);
 }
 
 /**

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -32,7 +32,7 @@ namespace quickstep {
  * Seq is defined here for C++11 compatibility. For C++14 and above,
  * std::integer_sequence can be used to achieve the same functionality.
  */
-template<int ...>
+template<size_t ...>
 struct Seq {};
 
 /**
@@ -42,10 +42,10 @@ struct Seq {};
  * GenSeq is defined here for C++11 compatibility. For C++14 and above,
  * std::make_interger_sequence can be used to achieve the same functionality.
  */
-template<int N, int ...S>
+template<size_t N, size_t ...S>
 struct GenSeq : GenSeq<N-1, N-1, S...> {};
 
-template<int ...S>
+template<size_t ...S>
 struct GenSeq<0, S...> {
   typedef Seq<S...> type;
 };
@@ -56,7 +56,7 @@ struct GenSeq<0, S...> {
  *        ready. Instantiate the template and create (i.e. new) an instance.
  */
 template <template <bool ...> class T, class ReturnT,
-          bool ...bool_values, int ...i,
+          bool ...bool_values, size_t ...i,
           typename Tuple>
 inline ReturnT* CreateBoolInstantiatedInstanceInner(Tuple&& args, Seq<i...>&& indices) {
   return new T<bool_values...>(std::get<i>(std::forward<Tuple>(args))...);

--- a/utility/TemplateUtil.hpp
+++ b/utility/TemplateUtil.hpp
@@ -18,6 +18,7 @@
 #ifndef QUICKSTEP_UTILITY_TEMPLATE_UTIL_HPP_
 #define QUICKSTEP_UTILITY_TEMPLATE_UTIL_HPP_
 
+#include <tuple>
 #include <utility>
 
 namespace quickstep {
@@ -56,10 +57,10 @@ struct GenSeq<0, S...> {
  *        ready. Instantiate the template and create (i.e. new) an instance.
  */
 template <template <bool ...> class T, class ReturnT,
-          bool ...bool_values, typename ArgsTuple,
-          std::size_t ...i>
-inline ReturnT* CreateBoolInstantiatedInstanceInner(ArgsTuple&& args, Seq<i...>&& indices) {
-  return new T<bool_values...>(std::get<i>(std::forward<ArgsTuple>(args))...);
+          bool ...bool_values, std::size_t ...i,
+          typename Tuple>
+inline ReturnT* CreateBoolInstantiatedInstanceInner(Tuple&& args, Seq<i...>&& indices) {
+  return new T<bool_values...>(std::get<i>(std::forward<Tuple>(args))...);
 }
 
 /**
@@ -69,15 +70,15 @@ inline ReturnT* CreateBoolInstantiatedInstanceInner(ArgsTuple&& args, Seq<i...>&
  */
 template <template <bool ...> class T, class ReturnT,
           bool ...bool_values,
-          typename ArgsTuple>
-inline ReturnT* CreateBoolInstantiatedInstance(ArgsTuple&& args) {
+          typename Tuple>
+inline ReturnT* CreateBoolInstantiatedInstance(Tuple&& args) {
   // Note that the constructor arguments have been forwarded as a tuple (args).
   // Here we generate a compile-time index sequence (i.e. typename GenSeq<n_args>::type())
   // for the tuple, so that the tuple can be unpacked as a sequence of constructor
   // parameters in CreateBoolInstantiatedInstanceInner.
-  constexpr std::size_t n_args = std::tuple_size<ArgsTuple>::value;
+  constexpr std::size_t n_args = std::tuple_size<Tuple>::value;
   return CreateBoolInstantiatedInstanceInner<T, ReturnT, bool_values...>(
-      std::forward<ArgsTuple>(args), typename GenSeq<n_args>::type());
+      std::forward<Tuple>(args), typename GenSeq<n_args>::type());
 }
 
 /**
@@ -138,15 +139,15 @@ inline ReturnT* CreateBoolInstantiatedInstance(ArgsTuple&& args) {
  */
 template <template <bool ...> class T, class ReturnT,
           bool ...bool_values, typename ...Bools,
-          typename ArgsTuple>
+          typename Tuple>
 inline ReturnT* CreateBoolInstantiatedInstance(
-    ArgsTuple&& args, bool tparam, Bools ...rest_tparams) {
+    Tuple&& args, bool tparam, Bools ...rest_tparams) {
   if (tparam) {
     return CreateBoolInstantiatedInstance<T, ReturnT, bool_values..., true>(
-        std::forward<ArgsTuple>(args), rest_tparams...);
+        std::forward<Tuple>(args), rest_tparams...);
   } else {
     return CreateBoolInstantiatedInstance<T, ReturnT, bool_values..., false>(
-        std::forward<ArgsTuple>(args), rest_tparams...);
+        std::forward<Tuple>(args), rest_tparams...);
   }
 }
 

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -120,7 +120,7 @@ TEST(TemplateUtilTest, TemplateUtilTest) {
   std::unique_ptr<BaseClass> base(
       CreateBoolInstantiatedInstanceInner<SomeClass, BaseClass, false, false, true, true, false, false>(
           std::forward_as_tuple(10, std::move(arg)),
-          typename GenSeq<2>::type()));
+          GenSeq<2>::type()));
 }
 
 }  // namespace quickstep

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -105,9 +105,9 @@ std::string concat(int x, float y, SomeArgType &&z) {
   return oss.str();
 }
 
-template <typename ...Args, size_t ...i>
-std::string concat(std::tuple<Args...> &&args, Seq<i...> &&indices) {
-  return concat(std::forward<Args>(std::get<i>(args))...);
+template <typename Tuple, size_t ...i>
+std::string concat(Tuple &&args, Seq<i...> &&indices) {
+  return concat(std::get<i>(std::forward<Tuple>(args))...);
 }
 
 TEST(TemplateUtilTest, TemplateUtilTest) {

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -1,0 +1,109 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *   University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "utility/TemplateUtil.hpp"
+
+#include <memory>
+#include <string>
+#include <sstream>
+
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace quickstep {
+
+class SomeArgType {
+ public:
+  explicit SomeArgType(std::string value) : value_(value) {
+  }
+
+  SomeArgType(SomeArgType &&arg) {
+    value_ = std::move(arg.value_);
+  }
+
+  std::string toString() const {
+    return value_;
+  }
+
+ private:
+  std::string value_;
+
+  DISALLOW_COPY_AND_ASSIGN(SomeArgType);
+};
+
+class BaseClass {
+ public:
+  virtual std::string toString() const = 0;
+};
+
+template <bool c1, bool c2, bool c3, bool c4, bool c5, bool c6>
+class SomeClass : public BaseClass {
+ public:
+  SomeClass(int a1, SomeArgType &&a2)
+      : a1_(a1), a2_(std::forward<SomeArgType>(a2)) {
+  }
+
+  std::string toString() const override {
+    std::ostringstream oss;
+    oss << "{ ";
+    if (c1) {
+      oss << "c1 ";
+    }
+    if (c2) {
+      oss << "c2 ";
+    }
+    if (c3) {
+      oss << "c3 ";
+    }
+    if (c4) {
+      oss << "c4 ";
+    }
+    if (c5) {
+      oss << "c5 ";
+    }
+    if (c6) {
+      oss << "c6 ";
+    }
+    oss << "} " << a1_ << " " << a2_.toString();
+    return oss.str();
+  }
+
+ private:
+  int a1_;
+  SomeArgType a2_;
+};
+
+void RunTest(bool c1, bool c2, bool c3, bool c4, bool c5, bool c6, std::string expected) {
+  // arg should be perfectly forwarded.
+  SomeArgType arg("xyz");
+
+  std::unique_ptr<BaseClass> base(
+      CreateBoolInstantiatedInstance<SomeClass, BaseClass>(std::forward_as_tuple(10, std::move(arg)),
+                                                           c1, c2, c3, c4, c5, c6));
+  EXPECT_TRUE(base->toString() == expected);
+}
+
+TEST(TemplateUtilTest, TemplateUtilTest) {
+  RunTest(true, false, true, false, true, false, "{ c1 c3 c5 } 10 xyz");
+  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
+  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
+  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
+}
+
+}  // namespace quickstep

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -115,10 +115,12 @@ TEST(TemplateUtilTest, TemplateUtilTest) {
 //  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
 //  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
 //  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
-  SomeArgType arg("abc");
-  std::string result = concat(std::forward_as_tuple(1, 2.5, std::move(arg)), GenSeq<3>::type());
-  EXPECT_TRUE(result == "1 2.5 abc");
 
+  SomeArgType arg("xyz");
+  std::unique_ptr<BaseClass> base(
+      CreateBoolInstantiatedInstanceInner<SomeClass, BaseClass, false, false, true, true, false, false>(
+          std::forward_as_tuple(10, std::move(arg)),
+          typename GenSeq<2>::type()));
 }
 
 }  // namespace quickstep

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -99,15 +99,26 @@ class SomeClass : public BaseClass {
 //  EXPECT_TRUE(base->toString() == expected);
 //}
 
+std::string concat(int x, float y, SomeArgType &&z) {
+  std::ostringstream oss;
+  oss << x << " " << y << " " << z.toString();
+  return oss.str();
+}
+
+template <typename ...Args, size_t ...i>
+std::string concat(std::tuple<Args...> &&args, Seq<i...> &&indices) {
+  return concat(std::forward<Args>(std::get<i>(args))...);
+}
+
 TEST(TemplateUtilTest, TemplateUtilTest) {
 //  RunTest(true, false, true, false, true, false, "{ c1 c3 c5 } 10 xyz");
 //  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
 //  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
 //  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
-  std::tuple<int, float, std::string> value(1, 2.5, "abc");
-  EXPECT_TRUE(std::get<0>(value) == 1);
-  EXPECT_TRUE(std::get<1>(value) == 2.5);
-  EXPECT_TRUE(std::get<2>(value) == std::string("abc"));
+  SomeArgType arg("abc");
+  std::string result = concat(std::forward_as_tuple(1, 2.5, std::move(arg)), GenSeq<3>::type());
+  EXPECT_TRUE(result == "1 2.5 abc");
+
 }
 
 }  // namespace quickstep

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -102,16 +102,10 @@ void RunTest(bool c1, bool c2, bool c3, bool c4, bool c5, bool c6, std::string e
 }
 
 TEST(TemplateUtilTest, TemplateUtilTest) {
-//  RunTest(true, false, true, false, true, false, "{ c1 c3 c5 } 10 xyz");
-//  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
-//  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
-//  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
-
-  SomeArgType arg("xyz");
-  std::unique_ptr<BaseClass> base(
-      CreateBoolInstantiatedInstanceInner<SomeClass, BaseClass, false, false, true, true, false, false>(
-          std::forward_as_tuple(10, std::move(arg)),
-          GenSeq<2>::type()));
+  RunTest(true, false, true, false, true, false, "{ c1 c3 c5 } 10 xyz");
+  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
+  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
+  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
 }
 
 }  // namespace quickstep

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -20,6 +20,8 @@
 #include <memory>
 #include <string>
 #include <sstream>
+#include <tuple>
+#include <utility>
 
 #include "utility/Macros.hpp"
 
@@ -89,25 +91,14 @@ class SomeClass : public BaseClass {
   SomeArgType a2_;
 };
 
-//void RunTest(bool c1, bool c2, bool c3, bool c4, bool c5, bool c6, std::string expected) {
-//  // arg should be perfectly forwarded.
-//  SomeArgType arg("xyz");
-//
-//  std::unique_ptr<BaseClass> base(
-//      CreateBoolInstantiatedInstance<SomeClass, BaseClass>(std::forward_as_tuple(10, std::move(arg)),
-//                                                           c1, c2, c3, c4, c5, c6));
-//  EXPECT_TRUE(base->toString() == expected);
-//}
+void RunTest(bool c1, bool c2, bool c3, bool c4, bool c5, bool c6, std::string expected) {
+  // arg should be perfectly forwarded.
+  SomeArgType arg("xyz");
 
-std::string concat(int x, float y, SomeArgType &&z) {
-  std::ostringstream oss;
-  oss << x << " " << y << " " << z.toString();
-  return oss.str();
-}
-
-template <typename Tuple, size_t ...i>
-std::string concat(Tuple &&args, Seq<i...> &&indices) {
-  return concat(std::get<i>(std::forward<Tuple>(args))...);
+  std::unique_ptr<BaseClass> base(
+      CreateBoolInstantiatedInstance<SomeClass, BaseClass>(std::forward_as_tuple(10, std::move(arg)),
+                                                           c1, c2, c3, c4, c5, c6));
+  EXPECT_TRUE(base->toString() == expected);
 }
 
 TEST(TemplateUtilTest, TemplateUtilTest) {

--- a/utility/tests/TemplateUtil_unittest.cpp
+++ b/utility/tests/TemplateUtil_unittest.cpp
@@ -89,21 +89,25 @@ class SomeClass : public BaseClass {
   SomeArgType a2_;
 };
 
-void RunTest(bool c1, bool c2, bool c3, bool c4, bool c5, bool c6, std::string expected) {
-  // arg should be perfectly forwarded.
-  SomeArgType arg("xyz");
-
-  std::unique_ptr<BaseClass> base(
-      CreateBoolInstantiatedInstance<SomeClass, BaseClass>(std::forward_as_tuple(10, std::move(arg)),
-                                                           c1, c2, c3, c4, c5, c6));
-  EXPECT_TRUE(base->toString() == expected);
-}
+//void RunTest(bool c1, bool c2, bool c3, bool c4, bool c5, bool c6, std::string expected) {
+//  // arg should be perfectly forwarded.
+//  SomeArgType arg("xyz");
+//
+//  std::unique_ptr<BaseClass> base(
+//      CreateBoolInstantiatedInstance<SomeClass, BaseClass>(std::forward_as_tuple(10, std::move(arg)),
+//                                                           c1, c2, c3, c4, c5, c6));
+//  EXPECT_TRUE(base->toString() == expected);
+//}
 
 TEST(TemplateUtilTest, TemplateUtilTest) {
-  RunTest(true, false, true, false, true, false, "{ c1 c3 c5 } 10 xyz");
-  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
-  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
-  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
+//  RunTest(true, false, true, false, true, false, "{ c1 c3 c5 } 10 xyz");
+//  RunTest(true, true, true, true, true, true, "{ c1 c2 c3 c4 c5 c6 } 10 xyz");
+//  RunTest(false, false, true, true, false, false, "{ c3 c4 } 10 xyz");
+//  RunTest(false, false, false, false, false, false, "{ } 10 xyz");
+  std::tuple<int, float, std::string> value(1, 2.5, "abc");
+  EXPECT_TRUE(std::get<0>(value) == 1);
+  EXPECT_TRUE(std::get<1>(value) == 2.5);
+  EXPECT_TRUE(std::get<2>(value) == std::string("abc"));
 }
 
 }  // namespace quickstep


### PR DESCRIPTION
Implemented the `CreateBoolInstantiatedInstance` function for alleviating the tedious work of instantiating templates that have many bool parameters (say >= 4).

This helper function will be used in the upcoming string pattern matching PR.

The scenario for using this helper function is that, suppose we have a class where all template parameters are bools:
```
template <bool c1, bool c2, bool c3>
class SomeClass : public BaseClass {
  // This simple function will be invoked in computationally-intensive loops.
  inline SomeType someSimpleFunction(...) {
    if (c1) {
      doSomeThing1();
    }
    if (c2) {
      doSomeThing2();
    }
    if (c3) {
      doSomeThing3();
    }
  }
};
```
Typically, this bool-parameterized template is for performance consideration.
That is, we would like to make a copy of code for each configuration of bool values, so that there will be no branchings in someSimpleFunction().

The problem is that, to conditionally instantiate the template, given bool variables c1, c2, c3, we have to do something like this:
```
if (c1) {
  if (c2) {
    if (c3) {
      return new SomeClass<true, true, true>(some_args...);
    } else {
      return new SomeClass<true, true, false>(some_args...);
    }
  } else {
    if (c3) {
      return new SomeClass<true, false, true>(some_args...);
    } else {
      return new SomeClass<true, false, false>(some_args...);
    }
  }
} else {
  ...
}
```
Then there will be power(2,N) branches if the template has N bool parameters, making it tedious to do the instantiation.

Now, this helper function can achieve the branched instantiation in one
statement as:
```
return CreateBoolInstantiatedInstance<SomeClass,BaseClass>(
    std::forward_as_tuple(some_args...), c1, c2, c3);
```