### PR TITLE
Move the construction of QueryContext inside Foreman.

### DIFF
--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -45,7 +45,6 @@ typedef quickstep::LineReaderDumb LineReaderImpl;
 #include "parser/SqlParserWrapper.hpp"
 #include "query_execution/Foreman.hpp"
 #include "query_execution/QueryExecutionTypedefs.hpp"
-#include "query_execution/QueryContext.hpp"
 #include "query_execution/Worker.hpp"
 #include "query_execution/WorkerDirectory.hpp"
 #include "query_execution/WorkerMessage.hpp"
@@ -96,7 +95,6 @@ using quickstep::ParseResult;
 using quickstep::ParseStatement;
 using quickstep::PrintToScreen;
 using quickstep::PtrVector;
-using quickstep::QueryContext;
 using quickstep::QueryHandle;
 using quickstep::QueryPlan;
 using quickstep::QueryProcessor;
@@ -234,9 +232,6 @@ int main(int argc, char* argv[]) {
   PtrVector<Worker> workers;
   vector<client_id> worker_client_ids;
 
-  // TODO(zuyu): Construct QueryContext in Shiftboss to avoid Worker's access.
-  std::unique_ptr<QueryContext> query_context;
-
   // Initialize the worker threads.
   DCHECK_EQ(static_cast<std::size_t>(real_num_workers),
             worker_cpu_affinities.size());
@@ -311,14 +306,10 @@ int main(int argc, char* argv[]) {
         DCHECK(query_handle->getQueryPlanMutable() != nullptr);
         foreman.setQueryPlan(query_handle->getQueryPlanMutable()->getQueryPlanDAGMutable());
 
+        foreman.reconstructQueryContextFromProto(query_handle->getQueryContextProto());
+
         try {
           start = std::chrono::steady_clock::now();
-          query_context.reset(new QueryContext(query_handle->getQueryContextProto(),
-                                               query_processor->getDefaultDatabase(),
-                                               query_processor->getStorageManager(),
-                                               foreman.getBusClientID(),
-                                               &bus));
-          foreman.setQueryContext(query_context.get());
           foreman.start();
           foreman.join();
           end = std::chrono::steady_clock::now();

--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(quickstep_queryexecution_WorkerSelectionPolicy ../empty_src.cpp Work
 # Link dependencies:
 target_link_libraries(quickstep_queryexecution_Foreman
                       glog
+                      gtest
                       quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_QueryExecutionMessages_proto

--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -423,7 +423,7 @@ bool Foreman::fetchNormalWorkOrders(const dag_node_index index) {
     done_gen_[index] =
         query_dag_->getNodePayloadMutable(index)->getAllWorkOrders(workorders_container_.get(),
                                                                    catalog_database_,
-                                                                   query_context_,
+                                                                   query_context_.get(),
                                                                    storage_manager_,
                                                                    foreman_client_id_,
                                                                    bus_);

--- a/query_execution/Foreman.hpp
+++ b/query_execution/Foreman.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
+#include "query_execution/QueryContext.hpp"
 #include "query_execution/QueryExecutionTypedefs.hpp"
 #include "query_execution/WorkOrdersContainer.hpp"
 #include "query_execution/WorkerMessage.hpp"
@@ -35,14 +36,17 @@
 #include "utility/DAG.hpp"
 #include "utility/Macros.hpp"
 
+#include "gtest/gtest_prod.h"
+
 #include "tmb/message_bus.h"
 
 namespace quickstep {
 
 class CatalogDatabase;
-class QueryContext;
 class StorageManager;
 class WorkerDirectory;
+
+namespace serialization { class QueryContext; }
 
 /** \addtogroup QueryExecution
  *  @{
@@ -76,7 +80,6 @@ class Foreman : public Thread {
         catalog_database_(catalog_database),
         storage_manager_(storage_manager),
         cpu_id_(cpu_id),
-        query_context_(nullptr),
         num_operators_finished_(0),
         max_msgs_per_worker_(1),
         num_numa_nodes_(num_numa_nodes) {
@@ -113,13 +116,13 @@ class Foreman : public Thread {
   }
 
   /**
-   * @brief Set the QueryContext for the query to be executed.
+   * @brief Reconstruct the QueryContext for the query to be executed.
    *
-   * @param query_context A pointer to the QueryContext.
+   * @param proto The serialized QueryContext.
    **/
-  // TODO(zuyu): Remove this API once the Shiftboss is introduced.
-  inline void setQueryContext(QueryContext *query_context) {
-    query_context_ = query_context;
+  inline void reconstructQueryContextFromProto(const serialization::QueryContext &proto) {
+    query_context_.reset(
+        new QueryContext(proto, catalog_database_, storage_manager_, foreman_client_id_, bus_));
   }
 
   /**
@@ -480,7 +483,7 @@ class Foreman : public Thread {
 
   DAG<RelationalOperator, bool> *query_dag_;
 
-  QueryContext *query_context_;
+  std::unique_ptr<QueryContext> query_context_;
 
   // Number of operators who've finished their execution.
   std::size_t num_operators_finished_;
@@ -522,6 +525,7 @@ class Foreman : public Thread {
   WorkerDirectory *workers_;
 
   friend class ForemanTest;
+  FRIEND_TEST(ForemanTest, TwoNodesDAGPartiallyFilledBlocksTest);
 
   DISALLOW_COPY_AND_ASSIGN(Foreman);
 };

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
@@ -25,7 +25,6 @@
 #include "cli/PrintToScreen.hpp"
 #include "parser/ParseStatement.hpp"
 #include "query_execution/Foreman.hpp"
-#include "query_execution/QueryContext.hpp"
 #include "query_execution/Worker.hpp"
 #include "query_optimizer/ExecutionGenerator.hpp"
 #include "query_optimizer/LogicalGenerator.hpp"
@@ -94,12 +93,7 @@ void ExecutionGeneratorTestRunner::runTestCase(
         foreman_->setQueryPlan(
             query_handle.getQueryPlanMutable()->getQueryPlanDAGMutable());
 
-        query_context_.reset(new QueryContext(query_handle.getQueryContextProto(),
-                                              test_database_loader_.catalog_database(),
-                                              test_database_loader_.storage_manager(),
-                                              foreman_->getBusClientID(),
-                                              &bus_));
-        foreman_->setQueryContext(query_context_.get());
+        foreman_->reconstructQueryContextFromProto(query_handle.getQueryContextProto());
 
         foreman_->start();
         foreman_->join();

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.hpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@
 
 #include "parser/SqlParserWrapper.hpp"
 #include "query_execution/Foreman.hpp"
-#include "query_execution/QueryContext.hpp"
 #include "query_execution/QueryExecutionTypedefs.hpp"
 #include "query_execution/Worker.hpp"
 #include "query_execution/WorkerDirectory.hpp"
@@ -111,7 +110,6 @@ class ExecutionGeneratorTestRunner : public TextBasedTestRunner {
   MessageBusImpl bus_;
   std::unique_ptr<Foreman> foreman_;
   std::unique_ptr<Worker> worker_;
-  std::unique_ptr<QueryContext> query_context_;
 
   std::unique_ptr<WorkerDirectory> workers_;
 


### PR DESCRIPTION
This PR moves the construction of `QueryContext` inside `Foreman`. And for the distributed case, inside `Shiftboss`.

This may affect @hbdeshmukh 's work on learning-based scheduling mechanism, particular `QueryManager`.