### PR TITLE
Introduced ForemanLite.

### DIFF
--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -21,6 +21,7 @@ QS_PROTOBUF_GENERATE_CPP(queryexecution_QueryExecutionMessages_proto_srcs
 
 # Declare micro-libs:
 add_library(quickstep_queryexecution_Foreman Foreman.cpp Foreman.hpp)
+add_library(quickstep_queryexecution_ForemanLite ../empty_src.cpp ForemanLite.hpp)
 add_library(quickstep_queryexecution_QueryContext QueryContext.cpp QueryContext.hpp)
 add_library(quickstep_queryexecution_QueryContext_proto
             ${queryexecution_QueryContext_proto_srcs}
@@ -41,6 +42,7 @@ target_link_libraries(quickstep_queryexecution_Foreman
                       glog
                       gtest
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_queryexecution_ForemanLite
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_QueryExecutionMessages_proto
                       quickstep_queryexecution_QueryExecutionTypedefs
@@ -54,9 +56,13 @@ target_link_libraries(quickstep_queryexecution_Foreman
                       quickstep_storage_InsertDestination
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
-                      quickstep_threading_Thread
                       quickstep_threading_ThreadUtil
                       quickstep_utility_DAG
+                      quickstep_utility_Macros
+                      tmb)
+target_link_libraries(quickstep_queryexecution_ForemanLite
+                      glog
+                      quickstep_threading_Thread
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_queryexecution_QueryContext
@@ -124,6 +130,7 @@ target_link_libraries(quickstep_queryexecution_WorkerSelectionPolicy
 add_library(quickstep_queryexecution ../empty_src.cpp QueryExecutionModule.hpp)
 target_link_libraries(quickstep_queryexecution
                       quickstep_queryexecution_Foreman
+                      quickstep_queryexecution_ForemanLite
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_QueryContext_proto
                       quickstep_queryexecution_QueryExecutionMessages_proto

--- a/query_execution/ForemanLite.hpp
+++ b/query_execution/ForemanLite.hpp
@@ -1,0 +1,85 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_EXECUTION_FOREMAN_LITE_HPP_
+#define QUICKSTEP_QUERY_EXECUTION_FOREMAN_LITE_HPP_
+
+#include "threading/Thread.hpp"
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+#include "tmb/id_typedefs.h"
+#include "tmb/message_bus.h"
+
+namespace quickstep {
+
+/** \addtogroup QueryExecution
+ *  @{
+ */
+
+/**
+ * @brief A base class that Foreman implements. This class is used to derive
+ *        for implementations for both the single-node and distributed versions.
+ **/
+class ForemanLite : public Thread {
+ public:
+  /**
+   * @brief Constructor.
+   *
+   * @param bus A pointer to the TMB.
+   * @param cpu_id The ID of the CPU to which the Foreman thread can be pinned.
+   *
+   * @note If cpu_id is not specified, Foreman thread can be possibly moved
+   *       around on different CPUs by the OS.
+  **/
+  ForemanLite(tmb::MessageBus *bus,
+              const int cpu_id)
+      : bus_(DCHECK_NOTNULL(bus)),
+        cpu_id_(cpu_id) {
+    foreman_client_id_ = bus_->Connect();
+  }
+
+  ~ForemanLite() override {}
+
+  /**
+   * @brief Get the TMB client ID of Foreman thread.
+   *
+   * @return TMB client ID of foreman thread.
+   **/
+  tmb::client_id getBusClientID() const {
+    return foreman_client_id_;
+  }
+
+ protected:
+  void run() override = 0;
+
+  tmb::MessageBus *bus_;
+
+  tmb::client_id foreman_client_id_;
+
+  // The ID of the CPU that the Foreman thread can optionally be pinned to.
+  const int cpu_id_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ForemanLite);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_QUERY_EXECUTION_FOREMAN_LITE_HPP_

--- a/query_execution/tests/Foreman_unittest.cpp
+++ b/query_execution/tests/Foreman_unittest.cpp
@@ -45,10 +45,8 @@
 
 #include "gtest/gtest.h"
 
-#include "tmb/address.h"
 #include "tmb/id_typedefs.h"
 #include "tmb/message_bus.h"
-#include "tmb/message_style.h"
 #include "tmb/tagged_message.h"
 
 using std::move;
@@ -228,6 +226,7 @@ class ForemanTest : public ::testing::Test {
     query_plan_.reset(new QueryPlan());
 
     bus_.Initialize();
+
     foreman_.reset(new Foreman(&bus_, db_.get(), storage_manager_.get()));
 
     // This thread acts both as Foreman as well as Worker. Foreman connects to
@@ -241,9 +240,6 @@ class ForemanTest : public ::testing::Test {
     bus_.RegisterClientAsReceiver(worker_client_id_, kWorkOrderMessage);
     bus_.RegisterClientAsReceiver(worker_client_id_, kRebuildWorkOrderMessage);
     bus_.RegisterClientAsReceiver(worker_client_id_, kPoisonMessage);
-
-    // Cache foreman's address.
-    foreman_address_.AddRecipient(foreman_->getBusClientID());
 
     std::vector<client_id> worker_client_ids;
     worker_client_ids.push_back(worker_client_id_);
@@ -323,9 +319,6 @@ class ForemanTest : public ::testing::Test {
 
   unique_ptr<Foreman> foreman_;
   MessageBusImpl bus_;
-
-  Address foreman_address_;
-  MessageStyle single_receiver_style_;
 
   client_id worker_client_id_;
 


### PR DESCRIPTION
This PR introduces `ForemanLite`, the base class for various `Foreman` implementations for different cases, including the single node version and the distributed one in the near future.

It also has some clean-ups in `Foreman` unit test.