### PR TITLE
Remove unused argu in getAllWorkOrders.

### DIFF
--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -422,7 +422,6 @@ bool Foreman::fetchNormalWorkOrders(const dag_node_index index) {
         workorders_container_->getNumNormalWorkOrders(index);
     done_gen_[index] =
         query_dag_->getNodePayloadMutable(index)->getAllWorkOrders(workorders_container_.get(),
-                                                                   catalog_database_,
                                                                    query_context_.get(),
                                                                    storage_manager_,
                                                                    foreman_client_id_,

--- a/query_execution/tests/Foreman_unittest.cpp
+++ b/query_execution/tests/Foreman_unittest.cpp
@@ -141,7 +141,6 @@ class MockOperator: public RelationalOperator {
   // Override methods from the base class.
   bool getAllWorkOrders(
       WorkOrdersContainer *container,
-      CatalogDatabase *catalog_database,
       QueryContext *query_context,
       StorageManager *storage_manager,
       const tmb::client_id foreman_client_id,

--- a/relational_operators/AggregationOperator.cpp
+++ b/relational_operators/AggregationOperator.cpp
@@ -30,7 +30,6 @@ namespace quickstep {
 
 bool AggregationOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -37,7 +37,6 @@ namespace tmb { class MessageBus; }
 namespace quickstep {
 
 class AggregationOperationState;
-class CatalogDatabase;
 class StorageManager;
 class WorkOrdersContainer;
 
@@ -73,7 +72,6 @@ class AggregationOperator : public RelationalOperator {
   ~AggregationOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/BuildHashOperator.cpp
+++ b/relational_operators/BuildHashOperator.cpp
@@ -58,7 +58,6 @@ class TupleReferenceGenerator {
 
 bool BuildHashOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -36,7 +36,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class StorageManager;
 class WorkOrdersContainer;
@@ -88,7 +87,6 @@ class BuildHashOperator : public RelationalOperator {
   ~BuildHashOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/CreateIndexOperator.cpp
+++ b/relational_operators/CreateIndexOperator.cpp
@@ -24,7 +24,6 @@
 namespace quickstep {
 
 bool CreateIndexOperator::getAllWorkOrders(WorkOrdersContainer *container,
-                                           CatalogDatabase *catalog_database,
                                            QueryContext *query_context,
                                            StorageManager *storage_manager,
                                            const tmb::client_id foreman_client_id,

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -32,7 +32,6 @@ namespace tmb { class MessageBus; }
 namespace quickstep {
 
 class CatalogRelation;
-class CatalogDatabase;
 class QueryContext;
 class StorageManager;
 class WorkOrdersContainer;
@@ -67,7 +66,6 @@ class CreateIndexOperator : public RelationalOperator {
    * @note no WorkOrder generated for this operator.
    **/
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/CreateTableOperator.cpp
+++ b/relational_operators/CreateTableOperator.cpp
@@ -27,7 +27,6 @@ namespace quickstep {
 
 bool CreateTableOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -66,7 +66,6 @@ class CreateTableOperator : public RelationalOperator {
    * @note no WorkOrder generated for this operator.
    **/
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/DeleteOperator.cpp
+++ b/relational_operators/DeleteOperator.cpp
@@ -43,7 +43,6 @@ namespace quickstep {
 
 bool DeleteOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -38,7 +38,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class Predicate;
 class StorageManager;
@@ -77,7 +76,6 @@ class DeleteOperator : public RelationalOperator {
   ~DeleteOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -26,7 +26,6 @@ namespace quickstep {
 
 bool DestroyHashOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -31,7 +31,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class StorageManager;
 class WorkOrdersContainer;
 
@@ -56,7 +55,6 @@ class DestroyHashOperator : public RelationalOperator {
   ~DestroyHashOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/DropTableOperator.cpp
+++ b/relational_operators/DropTableOperator.cpp
@@ -33,7 +33,6 @@ namespace quickstep {
 
 bool DropTableOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -68,7 +68,6 @@ class DropTableOperator : public RelationalOperator {
   ~DropTableOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/FinalizeAggregationOperator.cpp
+++ b/relational_operators/FinalizeAggregationOperator.cpp
@@ -29,7 +29,6 @@ namespace quickstep {
 
 bool FinalizeAggregationOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -36,7 +36,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class InsertDestination;
 class StorageManager;
 class WorkOrdersContainer;
@@ -70,7 +69,6 @@ class FinalizeAggregationOperator : public RelationalOperator {
   ~FinalizeAggregationOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/HashJoinOperator.cpp
+++ b/relational_operators/HashJoinOperator.cpp
@@ -187,7 +187,6 @@ class VectorBasedJoinedTupleCollector {
 
 bool HashJoinOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -39,7 +39,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class Predicate;
@@ -127,7 +126,6 @@ class HashJoinOperator : public RelationalOperator {
   ~HashJoinOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/InsertOperator.cpp
+++ b/relational_operators/InsertOperator.cpp
@@ -31,7 +31,6 @@ namespace quickstep {
 
 bool InsertOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/InsertOperator.hpp
+++ b/relational_operators/InsertOperator.hpp
@@ -36,7 +36,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class InsertDestination;
 class StorageManager;
 class WorkOrdersContainer;
@@ -69,7 +68,6 @@ class InsertOperator : public RelationalOperator {
   ~InsertOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/NestedLoopsJoinOperator.cpp
+++ b/relational_operators/NestedLoopsJoinOperator.cpp
@@ -66,7 +66,6 @@ void NestedLoopsJoinOperator::feedInputBlock(const block_id input_block_id, cons
 
 bool NestedLoopsJoinOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -38,7 +38,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class Predicate;
@@ -109,7 +108,6 @@ class NestedLoopsJoinOperator : public RelationalOperator {
   ~NestedLoopsJoinOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -35,7 +35,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class StorageManager;
 class WorkOrdersContainer;
 
@@ -67,7 +66,6 @@ class RelationalOperator {
    *
    * @param container A pointer to a WorkOrdersContainer to be used to store the
    *        generated WorkOrders.
-   * @param catalog_database The catalog database where this query is executed.
    * @param query_context The QueryContext that stores query execution states.
    * @param storage_manager The StorageManager to use.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
@@ -78,7 +76,6 @@ class RelationalOperator {
    *         one pending work order has finished executing.
    **/
   virtual bool getAllWorkOrders(WorkOrdersContainer *container,
-                                CatalogDatabase *catalog_database,
                                 QueryContext *query_context,
                                 StorageManager *storage_manager,
                                 const tmb::client_id foreman_client_id,

--- a/relational_operators/SaveBlocksOperator.cpp
+++ b/relational_operators/SaveBlocksOperator.cpp
@@ -29,7 +29,6 @@ namespace quickstep {
 
 bool SaveBlocksOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -34,7 +34,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class QueryContext;
 class StorageManager;
 class WorkOrdersContainer;
@@ -61,7 +60,6 @@ class SaveBlocksOperator : public RelationalOperator {
   ~SaveBlocksOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/SelectOperator.cpp
+++ b/relational_operators/SelectOperator.cpp
@@ -37,7 +37,6 @@ class Predicate;
 
 bool SelectOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -37,7 +37,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class Predicate;
@@ -130,7 +129,6 @@ class SelectOperator : public RelationalOperator {
   ~SelectOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/SortMergeRunOperator.cpp
+++ b/relational_operators/SortMergeRunOperator.cpp
@@ -42,7 +42,6 @@ using merge_run_operator::MergeTree;
 
 bool SortMergeRunOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/SortMergeRunOperator.hpp
+++ b/relational_operators/SortMergeRunOperator.hpp
@@ -41,7 +41,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class StorageManager;
@@ -124,7 +123,6 @@ class SortMergeRunOperator : public RelationalOperator {
   ~SortMergeRunOperator() {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/SortRunGenerationOperator.cpp
+++ b/relational_operators/SortRunGenerationOperator.cpp
@@ -36,7 +36,6 @@ namespace quickstep {
 
 bool SortRunGenerationOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -37,7 +37,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class StorageManager;
@@ -103,7 +102,6 @@ class SortRunGenerationOperator : public RelationalOperator {
   ~SortRunGenerationOperator() {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/TableGeneratorOperator.cpp
+++ b/relational_operators/TableGeneratorOperator.cpp
@@ -30,12 +30,8 @@
 
 namespace quickstep {
 
-class CatalogDatabase;
-class StorageManager;
-
 bool TableGeneratorOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -37,7 +37,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class GeneratorFunctionHandle;
 class InsertDestination;
 class StorageManager;
@@ -75,7 +74,6 @@ class TableGeneratorOperator : public RelationalOperator {
   ~TableGeneratorOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/TextScanOperator.cpp
+++ b/relational_operators/TextScanOperator.cpp
@@ -140,7 +140,6 @@ inline unsigned DetectRowTerminator(const char *search_string,
 
 bool TextScanOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/TextScanOperator.hpp
+++ b/relational_operators/TextScanOperator.hpp
@@ -45,7 +45,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class StorageManager;
@@ -155,7 +154,6 @@ class TextScanOperator : public RelationalOperator {
   ~TextScanOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/UpdateOperator.cpp
+++ b/relational_operators/UpdateOperator.cpp
@@ -44,7 +44,6 @@ namespace quickstep {
 
 bool UpdateOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
-    CatalogDatabase *catalog_database,
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,

--- a/relational_operators/UpdateOperator.hpp
+++ b/relational_operators/UpdateOperator.hpp
@@ -40,7 +40,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelationSchema;
 class InsertDestination;
 class Predicate;
@@ -91,7 +90,6 @@ class UpdateOperator : public RelationalOperator {
   ~UpdateOperator() override {}
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
-                        CatalogDatabase *catalog_database,
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -351,7 +351,6 @@ class AggregationOperatorTest : public ::testing::Test {
     const std::size_t op_index = 0;
     WorkOrdersContainer op_container(1, 0);
     op_->getAllWorkOrders(&op_container,
-                          db_.get(),
                           query_context_.get(),
                           storage_manager_.get(),
                           tmb::kClientIdNone /* foreman_client_id */,
@@ -368,7 +367,6 @@ class AggregationOperatorTest : public ::testing::Test {
     WorkOrdersContainer finalize_op_container(1, 0);
     const std::size_t finalize_op_index = 0;
     finalize_op_->getAllWorkOrders(&finalize_op_container,
-                                   db_.get(),
                                    query_context_.get(),
                                    storage_manager_.get(),
                                    tmb::kClientIdNone /* foreman_client_id */,

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -230,7 +230,6 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
     WorkOrdersContainer container(1, 0);
     const std::size_t op_index = 0;
     op->getAllWorkOrders(&container,
-                         db_.get(),
                          query_context_.get(),
                          storage_manager_.get(),
                          tmb::kClientIdNone /* foreman_client_id */,

--- a/relational_operators/tests/SortMergeRunOperator_unittest.cpp
+++ b/relational_operators/tests/SortMergeRunOperator_unittest.cpp
@@ -1429,7 +1429,6 @@ class SortMergeRunOperatorTest : public ::testing::Test {
     WorkOrdersContainer container(kOpIndex + 1, 0);
     do {
       done = merge_op_->getAllWorkOrders(&container,
-                                         db_.get(),
                                          query_context_.get(),
                                          storage_manager_.get(),
                                          foreman_client_id_,
@@ -1450,7 +1449,6 @@ class SortMergeRunOperatorTest : public ::testing::Test {
       if (!done) {
         // Find work orders to execute, if not done already.
         done = merge_op_->getAllWorkOrders(&container,
-                                           db_.get(),
                                            query_context_.get(),
                                            storage_manager_.get(),
                                            foreman_client_id_,

--- a/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
+++ b/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
@@ -280,7 +280,6 @@ class SortRunGenerationOperatorTest : public ::testing::Test {
   void executeOperator(RelationalOperator *op) {
     WorkOrdersContainer container(kOpIndex + 1, 0);
     op->getAllWorkOrders(&container,
-                         db_.get(),
                          query_context_.get(),
                          storage_manager_.get(),
                          thread_client_id_,

--- a/relational_operators/tests/TextScanOperator_unittest.cpp
+++ b/relational_operators/tests/TextScanOperator_unittest.cpp
@@ -87,7 +87,6 @@ class TextScanOperatorTest : public ::testing::Test {
     const std::size_t op_index = 0;
     op->informAllBlockingDependenciesMet();
     op->getAllWorkOrders(&container,
-                         db_.get(),
                          query_context_.get(),
                          storage_manager_.get(),
                          tmb::kClientIdNone /* foreman_client_id */,


### PR DESCRIPTION
This small PR removed the unused argument in `getAllWorkOrders` introduced in #53.