### PR TITLE
Refactor catalog-changing operators.

### DIFF
--- a/relational_operators/CreateIndexOperator.cpp
+++ b/relational_operators/CreateIndexOperator.cpp
@@ -28,11 +28,11 @@ bool CreateIndexOperator::getAllWorkOrders(WorkOrdersContainer *container,
                                            StorageManager *storage_manager,
                                            const tmb::client_id foreman_client_id,
                                            tmb::MessageBus *bus) {
-  if (!work_generated_) {
-    work_generated_ = true;
-    relation_->addIndex(index_name_);
-  }
   return true;
+}
+
+void CreateIndexOperator::updateCatalogOnCompletion() {
+  relation_->addIndex(index_name_);
 }
 
 }  // namespace quickstep

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -57,8 +57,7 @@ class CreateIndexOperator : public RelationalOperator {
   CreateIndexOperator(CatalogRelation *relation,
                       const std::string &index_name)
       : relation_(DCHECK_NOTNULL(relation)),
-        index_name_(index_name),
-        work_generated_(false) {}
+        index_name_(index_name) {}
 
   ~CreateIndexOperator() override {}
 
@@ -71,10 +70,11 @@ class CreateIndexOperator : public RelationalOperator {
                         const tmb::client_id foreman_client_id,
                         tmb::MessageBus *bus) override;
 
+  void updateCatalogOnCompletion() override;
+
  private:
   CatalogRelation *relation_;
   const std::string &index_name_;
-  bool work_generated_;
 
   DISALLOW_COPY_AND_ASSIGN(CreateIndexOperator);
 };

--- a/relational_operators/CreateTableOperator.cpp
+++ b/relational_operators/CreateTableOperator.cpp
@@ -31,11 +31,11 @@ bool CreateTableOperator::getAllWorkOrders(
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
     tmb::MessageBus *bus) {
-  if (!work_generated_) {
-    work_generated_ = true;
-    database_->addRelation(relation_.release());
-  }
   return true;
+}
+
+void CreateTableOperator::updateCatalogOnCompletion() {
+  database_->addRelation(relation_.release());
 }
 
 }  // namespace quickstep

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -57,8 +57,7 @@ class CreateTableOperator : public RelationalOperator {
   CreateTableOperator(CatalogRelation *relation,
                       CatalogDatabase *database)
       : relation_(DCHECK_NOTNULL(relation)),
-        database_(DCHECK_NOTNULL(database)),
-        work_generated_(false) {}
+        database_(DCHECK_NOTNULL(database)) {}
 
   ~CreateTableOperator() override {}
 
@@ -71,11 +70,11 @@ class CreateTableOperator : public RelationalOperator {
                         const tmb::client_id foreman_client_id,
                         tmb::MessageBus *bus) override;
 
+  void updateCatalogOnCompletion() override;
+
  private:
   std::unique_ptr<CatalogRelation> relation_;
   CatalogDatabase *database_;
-
-  bool work_generated_;
 
   DISALLOW_COPY_AND_ASSIGN(CreateTableOperator);
 };


### PR DESCRIPTION
This small PR moves the catalog-changing operations (e.g., in `CreateTable` and `CreateIndex`) to the dedicate method.