### PR TITLE
Use different storage_path for each ExecutionGeneratorTest instance

### DIFF
--- a/query_optimizer/tests/execution_generator/CMakeLists.txt
+++ b/query_optimizer/tests/execution_generator/CMakeLists.txt
@@ -17,39 +17,39 @@ add_test(quickstep_queryoptimizer_tests_executiongenerator_create
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Create.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Create.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/Create/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_delete
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Delete.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Delete.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/Delete/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_drop
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Drop.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Drop.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/Drop/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_insert
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Insert.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Insert.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/Insert/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_select
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Select.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Select.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/Select/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_stringpatternmatching
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/StringPatternMatching.test"
          "${CMAKE_CURRENT_BINARY_DIR}/StringPatternMatching.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/StringPatternMatching/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_tablegenerator
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/TableGenerator.test"
          "${CMAKE_CURRENT_BINARY_DIR}/TableGenerator.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/TableGenerator/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_update
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Update.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Update.test"
-         "${CMAKE_CURRENT_BINARY_DIR}/")
+         "${CMAKE_CURRENT_BINARY_DIR}/Update/")


### PR DESCRIPTION
This PR fixes a bug that will potentially occur when multiple `ExecutionGeneratorTest`'s are running in parallel.

That is, when multiple `ExecutionGeneratorTest`'s are running in parallel, each test will create a bunch of storage blocks to store the test relation. These storage blocks will be placed under the same folder. So there are **naming collisions**. One simple scenario that will incur the bug is as follows:
```
-- During time interval (1, 2]:
Process 1 evicted block (1, 1) and wrote it to
  tests/execution_generator/qsblk_0001_0000000000000000001.qsb

-- During time interval (2, 3]
Process 2 evicted block (1, 1) and started writing it to
  tests/execution_generator/qsblk_0001_0000000000000000001.qsb
but suppose that this writing was slow and just half of the file had been written until time 3.

-- At time point 3:
Process 1 wanted to get block (1, 1). But the block had been evicted. So it started loading
  tests/execution_generator/qsblk_0001_0000000000000000001.qsb
and Process 1 will see that the file was corrupted.
```

The solution is to simply create a different storage path for each `ExecutionGeneratorTest` instance.