### PR TITLE
Added blocks to InsertDestination directly.

### DIFF
--- a/catalog/Catalog.proto
+++ b/catalog/Catalog.proto
@@ -1,5 +1,5 @@
 //   Copyright 2011-2015 Quickstep Technologies LLC.
-//   Copyright 2015 Pivotal Software, Inc.
+//   Copyright 2015-2016 Pivotal Software, Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ message CatalogAttribute {
   optional string display_name = 3;
 }
 
+message Partition {
+  repeated fixed64 blocks = 1 [packed=true];
+}
+
 message PartitionScheme {
   required uint32 num_partitions = 1;
   required uint32 partition_attribute_id = 2;
@@ -37,10 +41,6 @@ message PartitionScheme {
   }
 
   required PartitionType partition_type = 3;
-
-  message Partition {
-    repeated fixed64 blocks = 1;
-  }
 
   repeated Partition partitions = 4;
 

--- a/query_execution/tests/Foreman_unittest.cpp
+++ b/query_execution/tests/Foreman_unittest.cpp
@@ -707,7 +707,6 @@ TEST_F(ForemanTest, TwoNodesDAGPartiallyFilledBlocksTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(id1);
 
   MockOperator *op1_mutable =

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -278,7 +278,6 @@ void ExecutionGenerator::createTemporaryCatalogRelation(
 
   insert_destination_proto->set_insert_destination_type(S::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_rel_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(true);
 }
 
 void ExecutionGenerator::dropAllTemporaryRelations() {
@@ -733,7 +732,11 @@ void ExecutionGenerator::convertCopyFrom(
 
   insert_destination_proto->set_insert_destination_type(S::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation->getID());
-  insert_destination_proto->set_need_to_add_blocks_from_relation(true);
+
+  const vector<block_id> blocks(physical_plan->catalog_relation()->getBlocksSnapshot());
+  for (const block_id block : blocks) {
+    insert_destination_proto->AddExtension(S::BlockPoolInsertDestination::blocks, block);
+  }
 
   const QueryPlan::DAGNodeIndex scan_operator_index =
       execution_plan_->addRelationalOperator(
@@ -913,7 +916,12 @@ void ExecutionGenerator::convertInsertTuple(
 
   insert_destination_proto->set_insert_destination_type(S::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(input_relation->getID());
-  insert_destination_proto->set_need_to_add_blocks_from_relation(true);
+
+  const vector<block_id> blocks(input_relation->getBlocksSnapshot());
+  for (const block_id block : blocks) {
+    insert_destination_proto->AddExtension(S::BlockPoolInsertDestination::blocks, block);
+  }
+
 
   const QueryPlan::DAGNodeIndex insert_operator_index =
       execution_plan_->addRelationalOperator(
@@ -952,7 +960,6 @@ void ExecutionGenerator::convertUpdateTable(
 
   relocation_destination_proto->set_insert_destination_type(S::InsertDestinationType::BLOCK_POOL);
   relocation_destination_proto->set_relation_id(input_rel_id);
-  relocation_destination_proto->set_need_to_add_blocks_from_relation(false);
 
   // Convert the predicate proto.
   QueryContext::predicate_id execution_predicate_index = QueryContext::kInvalidPredicateId;

--- a/query_optimizer/tests/TestDatabaseLoader.cpp
+++ b/query_optimizer/tests/TestDatabaseLoader.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -92,7 +92,6 @@ void TestDatabaseLoader::loadTestRelation() {
                                          0 /* dummy op index */,
                                          tmb::kClientIdNone /* foreman_client_id */,
                                          nullptr /* TMB */);
-  destination.addAllBlocksFromRelation();
   int sign = 1;
   for (int x = 0; x < 25; ++x) {
     // Column values: ((-1)^x*x, x^2, sqrt(x), (-1)^x*x*sqrt(x),

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -246,7 +246,6 @@ class AggregationOperatorTest : public ::testing::Test {
 
     insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
     insert_destination_proto->set_relation_id(result_table_->getID());
-    insert_destination_proto->set_need_to_add_blocks_from_relation(false);
     insert_destination_proto->set_relational_op_index(kOpIndex);
 
     finalize_op_.reset(
@@ -327,7 +326,6 @@ class AggregationOperatorTest : public ::testing::Test {
 
     insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
     insert_destination_proto->set_relation_id(result_table_->getID());
-    insert_destination_proto->set_need_to_add_blocks_from_relation(false);
     insert_destination_proto->set_relational_op_index(kOpIndex);
 
     finalize_op_.reset(

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -316,7 +316,6 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(kOpIndex);
 
   unique_ptr<HashJoinOperator> prober(
@@ -459,7 +458,6 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(kOpIndex);
 
   unique_ptr<HashJoinOperator> prober(
@@ -610,7 +608,6 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(kOpIndex);
 
   unique_ptr<HashJoinOperator> prober(
@@ -746,7 +743,6 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(kOpIndex);
 
   unique_ptr<HashJoinOperator> prober(
@@ -912,7 +908,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(kOpIndex);
 
   std::vector<attribute_id> fact_key_attrs;
@@ -1083,7 +1078,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
 
   insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation_id);
-  insert_destination_proto->set_need_to_add_blocks_from_relation(false);
   insert_destination_proto->set_relational_op_index(kOpIndex);
 
   // Include a residual predicate that selects a subset of the joined tuples.

--- a/relational_operators/tests/SortMergeRunOperator_unittest.cpp
+++ b/relational_operators/tests/SortMergeRunOperator_unittest.cpp
@@ -1239,7 +1239,6 @@ class SortMergeRunOperatorTest : public ::testing::Test {
 
     insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
     insert_destination_proto->set_relation_id(result_table_id);
-    insert_destination_proto->set_need_to_add_blocks_from_relation(false);
     insert_destination_proto->set_relational_op_index(kOpIndex);
 
     // Create run_table_, owned by db_.
@@ -1259,7 +1258,6 @@ class SortMergeRunOperatorTest : public ::testing::Test {
 
     insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
     insert_destination_proto->set_relation_id(run_table_id);
-    insert_destination_proto->set_need_to_add_blocks_from_relation(false);
     insert_destination_proto->set_relational_op_index(kOpIndex);
 
     // Set up the QueryContext.

--- a/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
+++ b/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
@@ -303,7 +303,6 @@ class SortRunGenerationOperatorTest : public ::testing::Test {
 
     insert_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
     insert_destination_proto->set_relation_id(result_table_->getID());
-    insert_destination_proto->set_need_to_add_blocks_from_relation(false);
     insert_destination_proto->set_relational_op_index(kOpIndex);
 
     // Setup the SortConfiguration proto.

--- a/relational_operators/tests/TextScanOperator_unittest.cpp
+++ b/relational_operators/tests/TextScanOperator_unittest.cpp
@@ -143,7 +143,6 @@ TEST_F(TextScanOperatorTest, ScanTest) {
 
   output_destination_proto->set_insert_destination_type(serialization::InsertDestinationType::BLOCK_POOL);
   output_destination_proto->set_relation_id(relation_->getID());
-  output_destination_proto->set_need_to_add_blocks_from_relation(false);
   output_destination_proto->set_relational_op_index(kOpIndex);
 
   std::unique_ptr<TextScanOperator> text_scan_op(

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -560,6 +560,7 @@ target_link_libraries(quickstep_storage_InsertDestination
                       gtest
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_Catalog_proto
                       quickstep_catalog_PartitionScheme
                       quickstep_queryexecution_QueryExecutionMessages_proto
                       quickstep_queryexecution_QueryExecutionTypedefs
@@ -582,6 +583,7 @@ target_link_libraries(quickstep_storage_InsertDestinationInterface
                       quickstep_catalog_CatalogTypedefs
                       quickstep_types_containers_Tuple)
 target_link_libraries(quickstep_storage_InsertDestination_proto
+                      quickstep_catalog_Catalog_proto
                       quickstep_storage_StorageBlockLayout_proto
                       ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_storage_LinearOpenAddressingHashTable

--- a/storage/InsertDestination.cpp
+++ b/storage/InsertDestination.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "catalog/Catalog.pb.h"
 #include "catalog/CatalogRelation.hpp"
 #include "catalog/PartitionScheme.hpp"
 #include "storage/InsertDestination.pb.h"
@@ -38,6 +39,9 @@
 #include "glog/logging.h"
 
 #include "tmb/id_typedefs.h"
+
+using std::move;
+using std::vector;
 
 namespace tmb { class MessageBus; }
 
@@ -80,34 +84,40 @@ InsertDestination* InsertDestination::ReconstructFromProto(const serialization::
                                                     bus);
     }
     case serialization::InsertDestinationType::BLOCK_POOL: {
-      BlockPoolInsertDestination *insert_destination =
-          new BlockPoolInsertDestination(storage_manager,
-                                         relation,
-                                         layout,
-                                         proto.relational_op_index(),
-                                         foreman_client_id,
-                                         bus);
-
-      if (proto.need_to_add_blocks_from_relation()) {
-        insert_destination->addAllBlocksFromRelation();
+      vector<block_id> blocks;
+      for (int i = 0; i < proto.ExtensionSize(serialization::BlockPoolInsertDestination::blocks); ++i) {
+        blocks.push_back(proto.GetExtension(serialization::BlockPoolInsertDestination::blocks, i));
       }
 
-      return insert_destination;
+      return new BlockPoolInsertDestination(storage_manager,
+                                            relation,
+                                            layout,
+                                            move(blocks),
+                                            proto.relational_op_index(),
+                                            foreman_client_id,
+                                            bus);
     }
     case serialization::InsertDestinationType::PARTITION_AWARE: {
-      PartitionAwareInsertDestination *insert_destination =
-          new PartitionAwareInsertDestination(storage_manager,
-                                              relation,
-                                              layout,
-                                              proto.relational_op_index(),
-                                              foreman_client_id,
-                                              bus);
-
-      if (proto.need_to_add_blocks_from_relation()) {
-        insert_destination->addAllBlocksFromRelation();
+      vector<vector<block_id>> partitions;
+      for (int partition_index = 0;
+           partition_index < proto.ExtensionSize(serialization::PartitionAwareInsertDestination::partitions);
+           ++partition_index) {
+        vector<block_id> partition;
+        const serialization::Partition &proto_partition =
+            proto.GetExtension(serialization::PartitionAwareInsertDestination::partitions, partition_index);
+        for (int block_index = 0; block_index < proto_partition.blocks_size(); ++block_index) {
+          partition.push_back(proto_partition.blocks(block_index));
+        }
+        partitions.push_back(move(partition));
       }
 
-      return insert_destination;
+      return new PartitionAwareInsertDestination(storage_manager,
+                                                 relation,
+                                                 layout,
+                                                 move(partitions),
+                                                 proto.relational_op_index(),
+                                                 foreman_client_id,
+                                                 bus);
     }
     default: {
       LOG(FATAL) << "Unrecognized InsertDestinationType in proto";
@@ -258,16 +268,6 @@ MutableBlockReference BlockPoolInsertDestination::createNewBlock() {
   return storage_manager_->getBlockMutable(new_id, *relation_);
 }
 
-void BlockPoolInsertDestination::addAllBlocksFromRelation() {
-  SpinMutexLock lock(mutex_);
-  DEBUG_ASSERT(available_block_refs_.empty());
-  std::vector<block_id> available_blocks;
-  available_blocks = relation_->getBlocksSnapshot();
-  for (const block_id id : available_blocks) {
-    available_block_ids_.push_back(id);
-  }
-}
-
 void BlockPoolInsertDestination::getPartiallyFilledBlocks(std::vector<MutableBlockReference> *partial_blocks) {
   SpinMutexLock lock(mutex_);
   for (std::vector<MutableBlockReference>::size_type i = 0; i < available_block_refs_.size(); ++i) {
@@ -326,15 +326,16 @@ const std::vector<block_id>& BlockPoolInsertDestination::getTouchedBlocksInterna
 PartitionAwareInsertDestination::PartitionAwareInsertDestination(StorageManager *storage_manager,
                                                                  CatalogRelation *relation,
                                                                  StorageBlockLayout *layout,
+                                                                 vector<vector<block_id>> &&partitions,
                                                                  const std::size_t relational_op_index,
                                                                  const tmb::client_id foreman_client_id,
                                                                  tmb::MessageBus *bus)
-    : InsertDestination(storage_manager, relation, layout, relational_op_index, foreman_client_id, bus) {
+    : InsertDestination(storage_manager, relation, layout, relational_op_index, foreman_client_id, bus),
+      available_block_ids_(move(partitions)) {
   DEBUG_ASSERT(relation->hasPartitionScheme());
   const PartitionScheme &partition_scheme = relation->getPartitionScheme();
   const std::size_t num_partitions = partition_scheme.getNumPartitions();
   available_block_refs_.resize(num_partitions);
-  available_block_ids_.resize(num_partitions);
   done_block_ids_.resize(num_partitions);
   mutexes_for_partition_ = new SpinMutex[num_partitions];
 }
@@ -351,20 +352,6 @@ MutableBlockReference PartitionAwareInsertDestination::createNewBlockInPartition
   // Add the new block to it's corresponding partition.
   relation_->getPartitionSchemeMutable()->addBlockToPartition(new_id, part_id);
   return storage_manager_->getBlockMutable(new_id, *relation_);
-}
-
-void PartitionAwareInsertDestination::addAllBlocksFromRelation() {
-  const PartitionScheme &partition_scheme = relation_->getPartitionScheme();
-  const std::size_t num_partitions = partition_scheme.getNumPartitions();
-  // starting a new scope for SpinMutexLock
-  {
-    SpinMutexLock lock(mutex_);
-    // Iterate through each partition and add all the blocks present in it.
-    for (std::size_t partition_num = 0; partition_num < num_partitions; ++partition_num) {
-      DEBUG_ASSERT(available_block_ids_[partition_num].empty());
-      available_block_ids_[partition_num] = partition_scheme.getBlocksInPartition(partition_num);
-    }
-  }
 }
 
 const std::vector<block_id>& PartitionAwareInsertDestination::getTouchedBlocksInternal() {

--- a/storage/InsertDestination.proto
+++ b/storage/InsertDestination.proto
@@ -17,6 +17,7 @@ syntax = "proto2";
 
 package quickstep.serialization;
 
+import "catalog/Catalog.proto";
 import "storage/StorageBlockLayout.proto";
 
 enum InsertDestinationType {
@@ -29,11 +30,26 @@ message InsertDestination {
   required InsertDestinationType insert_destination_type = 1;
   required int32 relation_id = 2;
 
-  // Note(zuyu): false for UpdateOperator, and otherwise true.
-  required bool need_to_add_blocks_from_relation = 3;
-
   // Note(zuyu): the actual StorageBlockLayout for insertion, if set.
-  optional StorageBlockLayoutDescription layout = 4;
+  optional StorageBlockLayoutDescription layout = 3;
 
-  required uint64 relational_op_index = 5;
+  required uint64 relational_op_index = 4;
+
+  // The convention for extension numbering is that extensions for a particular
+  // tInsertDestinationType should begin from (insert_destination_type + 1) * 16.
+  extensions 16 to max;
+}
+
+message BlockPoolInsertDestination {
+  extend InsertDestination {
+    // NOTE(zuyu): empty for UpdateOperator, and otherwise all existing blocks
+    // from the relation.
+    repeated fixed64 blocks = 32 [packed=true];
+  }
+}
+
+message PartitionAwareInsertDestination {
+  extend InsertDestination {
+    repeated Partition partitions = 48;
+  }
 }


### PR DESCRIPTION
As a part of detaching `CatalogRelation` from `InsertDestination`, this PR adds blocks directly when constructing `InsertDestination`s.