### PR TITLE
Fixing the arguments to DCheck

### DIFF
--- a/query_optimizer/logical/Project.cpp
+++ b/query_optimizer/logical/Project.cpp
@@ -35,7 +35,7 @@ namespace E = ::quickstep::optimizer::expressions;
 
 LogicalPtr Project::copyWithNewChildren(
     const std::vector<LogicalPtr> &new_children) const {
-  DCHECK_EQ(new_children.size(), children().size());
+  DCHECK_EQ(children().size(), new_children.size());
   return Project::Create(new_children[0], project_expressions_);
 }
 


### PR DESCRIPTION
This PR fixes the order of arguments being passed to DCHECK in logical/Project.cpp