### PR TITLE
Refactored IndexSubBlockDescription and IWYU.

### DIFF
--- a/catalog/tests/Catalog_unittest.cpp
+++ b/catalog/tests/Catalog_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ QUICKSTEP_FORCE_SUB_BLOCK_REGISTRATION(CSBTreeIndexSubBlock);
 QUICKSTEP_FORCE_SUB_BLOCK_REGISTRATION(CompressedColumnStoreTupleStorageSubBlock);
 QUICKSTEP_FORCE_SUB_BLOCK_REGISTRATION(CompressedPackedRowStoreTupleStorageSubBlock);
 QUICKSTEP_FORCE_SUB_BLOCK_REGISTRATION(PackedRowStoreTupleStorageSubBlock);
+QUICKSTEP_FORCE_SUB_BLOCK_REGISTRATION(SMAIndexSubBlock);
 QUICKSTEP_FORCE_SUB_BLOCK_REGISTRATION(SplitRowStoreTupleStorageSubBlock);
 
 class CatalogTest : public ::testing::Test {
@@ -123,22 +124,10 @@ class CatalogTest : public ::testing::Test {
       const IndexSubBlockDescription &expected,
       const IndexSubBlockDescription &checked) {
     EXPECT_EQ(expected.sub_block_type(), checked.sub_block_type());
-    switch (expected.sub_block_type()) {
-      case IndexSubBlockDescription::CSB_TREE:
-        ASSERT_EQ(
-            expected.ExtensionSize(CSBTreeIndexSubBlockDescription::indexed_attribute_id),
-            checked.ExtensionSize(CSBTreeIndexSubBlockDescription::indexed_attribute_id));
 
-        for (int i = 0;
-             i < expected.ExtensionSize(CSBTreeIndexSubBlockDescription::indexed_attribute_id);
-             ++i) {
-          EXPECT_EQ(
-              expected.GetExtension(CSBTreeIndexSubBlockDescription::indexed_attribute_id, i),
-              checked.GetExtension(CSBTreeIndexSubBlockDescription::indexed_attribute_id, i));
-        }
-        break;
-      default:
-        FATAL_ERROR("Unknown IndexSubBlockType encountered in CompareIndexSubBlockDescription");
+    ASSERT_EQ(expected.indexed_attribute_ids_size(), checked.indexed_attribute_ids_size());
+    for (int i = 0; i < expected.indexed_attribute_ids_size(); ++i) {
+      EXPECT_EQ(expected.indexed_attribute_ids(i), checked.indexed_attribute_ids(i));
     }
   }
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -439,14 +439,15 @@ target_link_libraries(quickstep_storage_CountedReference
 target_link_libraries(quickstep_storage_CSBTreeIndexSubBlock
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelationSchema
+                      quickstep_catalog_CatalogTypedefs
                       quickstep_compression_CompressionDictionary
                       quickstep_expressions_predicate_ComparisonPredicate
-                      quickstep_expressions_predicate_Predicate
                       quickstep_expressions_predicate_PredicateCost
                       quickstep_expressions_scalar_Scalar
                       quickstep_expressions_scalar_ScalarAttribute
                       quickstep_storage_CompressedTupleStorageSubBlock
                       quickstep_storage_IndexSubBlock
+                      quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_storage_StorageConstants
                       quickstep_storage_StorageErrors
@@ -455,7 +456,6 @@ target_link_libraries(quickstep_storage_CSBTreeIndexSubBlock
                       quickstep_storage_TupleIdSequence
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_types_Type
-                      quickstep_types_TypeFactory
                       quickstep_types_TypedValue
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory
@@ -664,7 +664,6 @@ target_link_libraries(quickstep_storage_SMAIndexSubBlock
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_types_operations_comparisons_ComparisonUtil
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector)
 target_link_libraries(quickstep_storage_SeparateChainingHashTable
@@ -1108,13 +1107,12 @@ target_link_libraries(CSBTreeIndexSubBlock_unittest
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_predicate_ComparisonPredicate
-                      quickstep_expressions_predicate_TrivialPredicates
-                      quickstep_expressions_scalar_Scalar
                       quickstep_expressions_scalar_ScalarAttribute
                       quickstep_expressions_scalar_ScalarLiteral
                       quickstep_storage_CSBTreeIndexSubBlock
                       quickstep_storage_CompressedPackedRowStoreTupleStorageSubBlock
                       quickstep_storage_CompressedTupleStorageSubBlock
+                      quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_storage_StorageErrors
                       quickstep_storage_TupleIdSequence
@@ -1122,7 +1120,6 @@ target_link_libraries(CSBTreeIndexSubBlock_unittest
                       quickstep_types_CharType
                       quickstep_types_FloatType
                       quickstep_types_LongType
-                      quickstep_types_Type
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID
                       quickstep_types_TypedValue
@@ -1132,8 +1129,8 @@ target_link_libraries(CSBTreeIndexSubBlock_unittest
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_types_operations_comparisons_ComparisonUtil
+                      quickstep_utility_BitVector
                       quickstep_utility_Macros
-                      quickstep_utility_PtrVector
                       quickstep_utility_ScopedBuffer
                       ${LIBS})
 add_test(CSBTreeIndexSubBlock_unittest CSBTreeIndexSubBlock_unittest)
@@ -1219,21 +1216,18 @@ target_link_libraries(SMAIndexSubBlock_unittest
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_predicate_ComparisonPredicate
-                      quickstep_expressions_scalar_Scalar
                       quickstep_expressions_scalar_ScalarAttribute
                       quickstep_expressions_scalar_ScalarLiteral
                       quickstep_storage_CompressedColumnStoreTupleStorageSubBlock
-                      quickstep_storage_CompressedTupleStorageSubBlock
                       quickstep_storage_SMAIndexSubBlock
+                      quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageBlockLayout_proto
-                      quickstep_storage_StorageErrors
                       quickstep_storage_TupleIdSequence
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_types_CharType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_LongType
-                      quickstep_types_Type
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID
                       quickstep_types_TypedValue
@@ -1242,8 +1236,6 @@ target_link_libraries(SMAIndexSubBlock_unittest
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_types_operations_comparisons_ComparisonUtil
-                      quickstep_utility_Macros
                       quickstep_utility_ScopedBuffer
                       ${LIBS})
 add_test(SMAIndexSubBlock_unittest SMAIndexSubBlock_unittest)

--- a/storage/CSBTreeIndexSubBlock.hpp
+++ b/storage/CSBTreeIndexSubBlock.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,11 +24,12 @@
 #include <memory>
 #include <vector>
 
+#include "catalog/CatalogTypedefs.hpp"
 #include "expressions/predicate/PredicateCost.hpp"
 #include "storage/IndexSubBlock.hpp"
+#include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageConstants.hpp"
 #include "storage/SubBlockTypeRegistryMacros.hpp"
-#include "types/TypedValue.hpp"
 #include "types/operations/comparisons/Comparison.hpp"
 #include "types/operations/comparisons/ComparisonID.hpp"
 #include "utility/BitVector.hpp"
@@ -37,14 +38,14 @@
 
 namespace quickstep {
 
-class CSBTreeIndexSubBlockTest;
-class CSBTreePrettyPrinter;
 class CSBTreeIndexSubBlock;
+class CatalogRelationSchema;
 class ComparisonPredicate;
 class IndexSubBlockDescription;
-template <typename T, bool null_allowed> class PtrVector;
-class ScopedBuffer;
+class TupleIdSequence;
+class TupleStorageSubBlock;
 class Type;
+class TypedValue;
 
 QUICKSTEP_DECLARE_SUB_BLOCK_TYPE_REGISTERED(CSBTreeIndexSubBlock);
 

--- a/storage/SMAIndexSubBlock.hpp
+++ b/storage/SMAIndexSubBlock.hpp
@@ -17,8 +17,8 @@
 #ifndef QUICKSTEP_STORAGE_SMA_INDEX_SUB_BLOCK_HPP_
 #define QUICKSTEP_STORAGE_SMA_INDEX_SUB_BLOCK_HPP_
 
-#include <stdint.h>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 
@@ -29,9 +29,6 @@
 #include "storage/SubBlockTypeRegistryMacros.hpp"
 #include "types/TypeID.hpp"
 #include "types/TypedValue.hpp"
-#include "types/operations/binary_operations/BinaryOperation.hpp"
-#include "types/operations/comparisons/Comparison.hpp"
-#include "types/operations/comparisons/ComparisonFactory.hpp"
 #include "types/operations/comparisons/ComparisonID.hpp"
 #include "utility/Macros.hpp"
 #include "utility/PtrVector.hpp"
@@ -40,12 +37,19 @@
 
 namespace quickstep {
 
+class CatalogRelationSchema;
+class ComparisonPredicate;
+class IndexSubBlockDescription;
+class TupleIdSequence;
+class TupleStorageSubBlock;
+class Type;
+class UncheckedBinaryOperator;
+class UncheckedComparator;
+
 /**
- * @brief 'Small Materialized Aggregates' Index. This  class holds count, min,
+ * @brief 'Small Materialized Aggregates' Index. This class holds count, min,
  *        max, and sum aggregates for attributes in a block.
  */
-class SMAIndexSubBlock;
-
 QUICKSTEP_DECLARE_SUB_BLOCK_TYPE_REGISTERED(SMAIndexSubBlock);
 
 /**
@@ -82,7 +86,7 @@ enum class Selectivity {
  * @param max The maximum value associated with that attribute.
  * @param less_comparator The less comparator for the attribute type.
  * @param equals_comparator  The equals comparator for the attribute type.
- * 
+ *
  * @return Selectivity of this predicate.
  */
 Selectivity getSelectivity(const TypedValue &literal,
@@ -176,7 +180,7 @@ class SMAIndexSubBlock : public IndexSubBlock {
  public:
   /**
    * @brief Constructor.
-   * 
+   *
    * @param tuple_store The TupleStorageSubBlock whose contents are indexed by
    *                    this IndexSubBlock.
    * @param description A description containing any parameters needed to
@@ -195,11 +199,11 @@ class SMAIndexSubBlock : public IndexSubBlock {
 
   /**
    * @brief Frees data associated with variable length attributes.
-   * 
+   *
    * Several of the data structures in this index are on the heap, therefore it is
    * important that the destructor be called when evicted. The variables which
    * are held out of line (on the heap_ are the variable length TypedValues and
-   * the comparators. 
+   * the comparators.
    */
   ~SMAIndexSubBlock();
 
@@ -293,7 +297,7 @@ class SMAIndexSubBlock : public IndexSubBlock {
   /**
    * @brief Gives an estimate of how long it will take to evaluate the predicate
    *        on this StorageBlock.
-   * 
+   *
    * The SMA index will detect if one of the following cases is true:
    *   1) Complete match: all the tuples in this subblock will match the predicate
    *   2) Empty match:    none of the tuples will match
@@ -303,7 +307,7 @@ class SMAIndexSubBlock : public IndexSubBlock {
    * and should be used.
    *
    * @param predicate A simple predicate too be evaluated.
-   * 
+   *
    * @return The cost associated with the type of match. Empty matches are constant,
    *         partial matches require a scan, and complete matches require something
    *         less than a regular scan (because we don't need to do the comparison
@@ -335,7 +339,7 @@ class SMAIndexSubBlock : public IndexSubBlock {
    *        entry for it.
    *
    * @param attribute The ID of the attribute to check.
-   * 
+   *
    * @return \c true if this index contains an entry.
    */
   bool hasEntryForAttribute(attribute_id attribute) const;
@@ -400,7 +404,7 @@ class SMAIndexSubBlock : public IndexSubBlock {
   // A value of -1 indicates that that attribute is not indexed.
   std::unique_ptr<int> attribute_to_entry_;
   // Number of indexed attributes.
-  std::size_t num_indexed_attributes_;
+  const std::size_t num_indexed_attributes_;
   // True if the index has gone through the initialization process.
   // The key aspect of initialization is the creation of the comparators and
   // binary operators which are used to update the SMAEntries on insertion
@@ -429,6 +433,6 @@ class SMAIndexSubBlock : public IndexSubBlock {
   DISALLOW_COPY_AND_ASSIGN(SMAIndexSubBlock);
 };
 
-} /* namespace quickstep */
+}  // namespace quickstep
 
-#endif /* QUICKSTEP_STORAGE_SMA_INDEX_SUB_BLOCK_HPP_ */
+#endif  // QUICKSTEP_STORAGE_SMA_INDEX_SUB_BLOCK_HPP_

--- a/storage/StorageBlockLayout.proto
+++ b/storage/StorageBlockLayout.proto
@@ -1,5 +1,5 @@
 //   Copyright 2011-2015 Quickstep Technologies LLC.
-//   Copyright 2015 Pivotal Software, Inc.
+//   Copyright 2015-2016 Pivotal Software, Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -66,21 +66,11 @@ message IndexSubBlockDescription {
 
   required IndexSubBlockType sub_block_type = 1;
 
+  repeated int32 indexed_attribute_ids = 2;
+
   // The convention for extension numbering is that extensions for a particular
   // TupleStorageSubBlock type should begin from (sub_block_type + 1) * 32.
   extensions 32 to max;
-}
-
-message CSBTreeIndexSubBlockDescription {
-  extend IndexSubBlockDescription {
-    repeated int32 indexed_attribute_id = 32;
-  }
-}
-
-message SMAIndexSubBlockDescription {
-  extend IndexSubBlockDescription {
-    repeated int32 indexed_attribute_id = 128;
-  }
 }
 
 // A complete logical description of a layout.

--- a/storage/tests/CSBTreeIndexSubBlock_unittest.cpp
+++ b/storage/tests/CSBTreeIndexSubBlock_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -33,13 +33,12 @@
 #include "catalog/CatalogRelation.hpp"
 #include "catalog/CatalogTypedefs.hpp"
 #include "expressions/predicate/ComparisonPredicate.hpp"
-#include "expressions/predicate/TrivialPredicates.hpp"
-#include "expressions/scalar/Scalar.hpp"
 #include "expressions/scalar/ScalarAttribute.hpp"
 #include "expressions/scalar/ScalarLiteral.hpp"
+#include "storage/CSBTreeIndexSubBlock.hpp"
 #include "storage/CompressedPackedRowStoreTupleStorageSubBlock.hpp"
 #include "storage/CompressedTupleStorageSubBlock.hpp"
-#include "storage/CSBTreeIndexSubBlock.hpp"
+#include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageBlockLayout.pb.h"
 #include "storage/StorageErrors.hpp"
 #include "storage/TupleIdSequence.hpp"
@@ -47,7 +46,6 @@
 #include "types/CharType.hpp"
 #include "types/FloatType.hpp"
 #include "types/LongType.hpp"
-#include "types/Type.hpp"
 #include "types/TypeFactory.hpp"
 #include "types/TypedValue.hpp"
 #include "types/TypeID.hpp"
@@ -57,6 +55,8 @@
 #include "types/operations/comparisons/ComparisonFactory.hpp"
 #include "types/operations/comparisons/ComparisonID.hpp"
 #include "types/operations/comparisons/ComparisonUtil.hpp"
+#include "utility/BitVector.hpp"
+#include "utility/Macros.hpp"
 #include "utility/ScopedBuffer.hpp"
 
 using std::binary_search;
@@ -170,8 +170,7 @@ class CSBTreeIndexSubBlockTest : public ::testing::Test {
     for (vector<attribute_id>::const_iterator attr_it = index_attrs.begin();
          attr_it != index_attrs.end();
          ++attr_it) {
-      index_description_->AddExtension(CSBTreeIndexSubBlockDescription::indexed_attribute_id,
-                                       *attr_it);
+      index_description_->add_indexed_attribute_ids(*attr_it);
     }
 
     index_memory_.reset(index_memory_size);
@@ -1406,7 +1405,7 @@ TEST_F(CSBTreeIndexSubBlockTest, NullableCompositeKeyRebuildTest) {
 
 TEST_F(CSBTreeIndexSubBlockDeathTest, UnsetSubBlockTypeTest) {
   index_description_.reset(new IndexSubBlockDescription());
-  index_description_->AddExtension(CSBTreeIndexSubBlockDescription::indexed_attribute_id, 0);
+  index_description_->add_indexed_attribute_ids(0);
 
   index_memory_.reset(kIndexSubBlockSize);
 
@@ -1486,7 +1485,7 @@ TEST_F(CSBTreeIndexSubBlockTest, TruncatedCompressedKeyTest) {
   // Create an index on the compressed tuple store.
   IndexSubBlockDescription compressed_index_description;
   compressed_index_description.set_sub_block_type(IndexSubBlockDescription::CSB_TREE);
-  compressed_index_description.AddExtension(CSBTreeIndexSubBlockDescription::indexed_attribute_id, 0);
+  compressed_index_description.add_indexed_attribute_ids(0);
 
   index_memory_.reset(kIndexSubBlockSize);
   std::memset(index_memory_.get(), 0x0, kIndexSubBlockSize);
@@ -1709,7 +1708,7 @@ TEST_F(CSBTreeIndexSubBlockTest, DictionaryCompressedKeyTest) {
   // Create an index on the compressed tuple store.
   IndexSubBlockDescription compressed_index_description;
   compressed_index_description.set_sub_block_type(IndexSubBlockDescription::CSB_TREE);
-  compressed_index_description.AddExtension(CSBTreeIndexSubBlockDescription::indexed_attribute_id, 0);
+  compressed_index_description.add_indexed_attribute_ids(0);
 
   index_memory_.reset(kIndexSubBlockSize);
   std::memset(index_memory_.get(), 0x0, kIndexSubBlockSize);

--- a/storage/tests/SMAIndexSubBlock_unittest.cpp
+++ b/storage/tests/SMAIndexSubBlock_unittest.cpp
@@ -17,12 +17,12 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 #include <memory>
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "catalog/CatalogAttribute.hpp"
@@ -52,6 +52,7 @@
 #include "types/operations/comparisons/ComparisonID.hpp"
 #include "utility/ScopedBuffer.hpp"
 
+#include "glog/logging.h"
 #include "gtest/gtest.h"
 
 using std::binary_search;
@@ -168,8 +169,7 @@ class SMAIndexSubBlockTest : public ::testing::Test {
     index_description_.reset(new IndexSubBlockDescription());
     index_description_->set_sub_block_type(IndexSubBlockDescription::SMA);
     for (std::size_t i = 0; i < indexed_attrs.size(); ++i) {
-      index_description_->AddExtension(SMAIndexSubBlockDescription::indexed_attribute_id,
-                                       indexed_attrs[i]);
+      index_description_->add_indexed_attribute_ids(indexed_attrs[i]);
     }
     index_memory_.reset(index_memory_size);
     index_.reset(new SMAIndexSubBlock(*tuple_store_,
@@ -322,9 +322,7 @@ TEST_F(SMAIndexSubBlockTest, DescriptionIsValidTest) {
         new IndexSubBlockDescription());
     index_description_->set_sub_block_type(
         IndexSubBlockDescription::SMA);
-    index_description_->AddExtension(
-        SMAIndexSubBlockDescription::indexed_attribute_id,
-        attr.getID());
+    index_description_->add_indexed_attribute_ids(attr.getID());
     if (std::find(valid_attrs.begin(), valid_attrs.end(), attr.getID()) != valid_attrs.end()) {
       EXPECT_TRUE(SMAIndexSubBlock::DescriptionIsValid(
           *relation_,
@@ -615,8 +613,8 @@ TEST_F(SMAIndexSubBlockTest, TestWithCompressedColumnStore) {
   // Create an index on the compressed tuple store.
   IndexSubBlockDescription compressed_index_description;
   compressed_index_description.set_sub_block_type(IndexSubBlockDescription::SMA);
-  compressed_index_description.AddExtension(SMAIndexSubBlockDescription::indexed_attribute_id, 0);
-  compressed_index_description.AddExtension(SMAIndexSubBlockDescription::indexed_attribute_id, 1);
+  compressed_index_description.add_indexed_attribute_ids(0);
+  compressed_index_description.add_indexed_attribute_ids(1);
 
   // Compressed blocks should be valid.
   ASSERT_TRUE(SMAIndexSubBlock::DescriptionIsValid(*relation_, compressed_index_description));


### PR DESCRIPTION
This PR refactored `IndexSubBlockDescription` and its derived class `SMAIndexSubBlockDescription` (merged in #35).

This PR also fixes the style issues including IWYU and the trailing whitespaces.