### PR TITLE
Refactored StorageManager's createBlock API.

### DIFF
--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -138,7 +138,7 @@ class AggregationOperatorTest : public ::testing::Test {
     MutableBlockReference storage_block;
     for (tuple_id i = 0; i < kNumTuples; i += kNumTuplesPerBlock) {
       // Create block
-      block_id block_id = storage_manager_->createBlock(*table_, layout.get());
+      block_id block_id = storage_manager_->createBlock(*table_, *layout);
       storage_block = storage_manager_->getBlockMutable(block_id, *table_);
       table_->addBlock(block_id);
 

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -132,7 +132,7 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
     MutableBlockReference storage_block;
     for (tuple_id i = 0; i < kNumDimTuples; i += kBlockSize) {
       // Create block.
-      block_id block_id = storage_manager_->createBlock(*dim_table_, dim_layout.get());
+      block_id block_id = storage_manager_->createBlock(*dim_table_, *dim_layout);
       storage_block = storage_manager_->getBlockMutable(block_id, *dim_table_);
       dim_table_->addBlock(block_id);
 
@@ -152,7 +152,7 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
     // Insert tuples to fact table.
     for (tuple_id i = 0; i < kNumFactTuples; i += kBlockSize) {
       // Create block
-      block_id block_id = storage_manager_->createBlock(*fact_table_, fact_layout.get());
+      block_id block_id = storage_manager_->createBlock(*fact_table_, *fact_layout);
       storage_block = storage_manager_->getBlockMutable(block_id, *fact_table_);
       fact_table_->addBlock(block_id);
 

--- a/relational_operators/tests/SortMergeRunOperator_unittest.cpp
+++ b/relational_operators/tests/SortMergeRunOperator_unittest.cpp
@@ -312,7 +312,7 @@ TEST_F(RunTest, IterateTuples) {
   MutableBlockReference storage_block;
   for (tuple_id i = 0; i < kNumTuples; i += kNumTuplesPerBlock) {
     // Create block
-    block_id block_id = storage_manager_->createBlock(*table_, nullptr);
+    block_id block_id = storage_manager_->createBlock(*table_, table_->getDefaultStorageBlockLayout());
     storage_block = storage_manager_->getBlockMutable(block_id, *table_);
     table_->addBlock(block_id);
     run_.push_back(block_id);
@@ -328,7 +328,7 @@ TEST_F(RunTest, IterateTuples) {
     storage_block->rebuild();
 
     // Create empty block
-    block_id = storage_manager_->createBlock(*table_, nullptr);
+    block_id = storage_manager_->createBlock(*table_, table_->getDefaultStorageBlockLayout());
     storage_block = storage_manager_->getBlockMutable(block_id, *table_);
     table_->addBlock(block_id);
     run_.push_back(block_id);
@@ -494,7 +494,7 @@ class RunMergerTest : public ::testing::Test {
       for (std::size_t id = 0; id < kNumBlocksPerRun; ++id) {
         std::string run_name = "run[" + std::to_string(run_id) + "]";
         // Create block.
-        block_id block_id = storage_manager_->createBlock(*table_, nullptr);
+        block_id block_id = storage_manager_->createBlock(*table_, table_->getDefaultStorageBlockLayout());
         storage_block = storage_manager_->getBlockMutable(block_id, *table_);
         table_->addBlock(block_id);
         input_runs_.back().push_back(block_id);
@@ -1362,7 +1362,7 @@ class SortMergeRunOperatorTest : public ::testing::Test {
       }
 
       // Create block.
-      block_id block_id = storage_manager_->createBlock(*input_table_, nullptr);
+      block_id block_id = storage_manager_->createBlock(*input_table_, input_table_->getDefaultStorageBlockLayout());
       storage_block = storage_manager_->getBlockMutable(block_id, *input_table_);
       input_table_->addBlock(block_id);
 

--- a/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
+++ b/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
@@ -243,7 +243,7 @@ class SortRunGenerationOperatorTest : public ::testing::Test {
     expect_num_tuples_ = 0;
     for (std::size_t bid = 0; bid < num_blocks; ++bid) {
       // Create block.
-      block_id block_id = storage_manager_->createBlock(*input_table_, nullptr);
+      block_id block_id = storage_manager_->createBlock(*input_table_, input_table_->getDefaultStorageBlockLayout());
       storage_block = storage_manager_->getBlockMutable(block_id, *input_table_);
       input_table_->addBlock(block_id);
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -783,8 +783,6 @@ target_link_libraries(quickstep_storage_StorageManager
                       gflags_nothreads-static
                       glog
                       gtest
-                      quickstep_catalog_CatalogRelation
-                      quickstep_catalog_CatalogRelationSchema
                       quickstep_storage_CountedReference
                       quickstep_storage_EvictionPolicy
                       quickstep_storage_FileManager
@@ -794,6 +792,7 @@ target_link_libraries(quickstep_storage_StorageManager
                       quickstep_storage_StorageBlockBase
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageBlockLayout
+                      quickstep_storage_StorageBlockLayout_proto
                       quickstep_storage_StorageConstants
                       quickstep_storage_StorageErrors
                       quickstep_threading_SpinSharedMutex

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -803,6 +803,10 @@ if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
 target_link_libraries(quickstep_storage_StorageManager
                       quickstep_storage_FileManagerHdfs)
 endif()
+if (QUICKSTEP_HAVE_LIBNUMA)
+  target_link_libraries(quickstep_storage_StorageManager
+                        ${LIBNUMA_LIBRARY})
+endif()
 target_link_libraries(quickstep_storage_SubBlockTypeRegistry
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_utility_Macros)

--- a/storage/InsertDestination.hpp
+++ b/storage/InsertDestination.hpp
@@ -84,7 +84,7 @@ class InsertDestination : public InsertDestinationInterface {
    **/
   InsertDestination(StorageManager *storage_manager,
                     CatalogRelation *relation,
-                    StorageBlockLayout *layout,
+                    const StorageBlockLayout *layout,
                     const std::size_t relational_op_index,
                     const tmb::client_id foreman_client_id,
                     tmb::MessageBus *bus);
@@ -257,7 +257,7 @@ class InsertDestination : public InsertDestinationInterface {
   CatalogRelation *relation_;
 
   // NOTE(zuyu): null means to use the default layout in the CatalogRelation.
-  std::unique_ptr<StorageBlockLayout> layout_;
+  std::unique_ptr<const StorageBlockLayout> layout_;
   const std::size_t relational_op_index_;
 
   tmb::client_id foreman_client_id_;
@@ -285,7 +285,7 @@ class AlwaysCreateBlockInsertDestination : public InsertDestination {
  public:
   AlwaysCreateBlockInsertDestination(StorageManager *storage_manager,
                                      CatalogRelation *relation,
-                                     StorageBlockLayout *layout,
+                                     const StorageBlockLayout *layout,
                                      const std::size_t relational_op_index,
                                      const tmb::client_id foreman_client_id,
                                      tmb::MessageBus *bus)
@@ -337,7 +337,7 @@ class BlockPoolInsertDestination : public InsertDestination {
    **/
   BlockPoolInsertDestination(StorageManager *storage_manager,
                              CatalogRelation *relation,
-                             StorageBlockLayout *layout,
+                             const StorageBlockLayout *layout,
                              const std::size_t relational_op_index,
                              const tmb::client_id foreman_client_id,
                              tmb::MessageBus *bus)
@@ -359,7 +359,7 @@ class BlockPoolInsertDestination : public InsertDestination {
    **/
   BlockPoolInsertDestination(StorageManager *storage_manager,
                              CatalogRelation *relation,
-                             StorageBlockLayout *layout,
+                             const StorageBlockLayout *layout,
                              std::vector<block_id> &&blocks,
                              const std::size_t relational_op_index,
                              const tmb::client_id foreman_client_id,
@@ -402,7 +402,7 @@ class PartitionAwareInsertDestination : public InsertDestination {
  public:
   PartitionAwareInsertDestination(StorageManager *storage_manager,
                                   CatalogRelation *relation,
-                                  StorageBlockLayout *layout,
+                                  const StorageBlockLayout *layout,
                                   std::vector<std::vector<block_id>> &&partitions,
                                   const std::size_t relational_op_index,
                                   const tmb::client_id foreman_client_id,

--- a/storage/StorageManager.cpp
+++ b/storage/StorageManager.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "catalog/CatalogRelation.hpp"
-#include "catalog/CatalogRelationSchema.hpp"
 #include "storage/CountedReference.hpp"
 #include "storage/EvictionPolicy.hpp"
 #include "storage/FileManagerLocal.hpp"
@@ -62,6 +60,7 @@
 #include "storage/StorageBlockBase.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageBlockLayout.hpp"
+#include "storage/StorageBlockLayout.pb.h"
 #include "storage/StorageConstants.hpp"
 #include "storage/StorageErrors.hpp"
 #include "threading/SpinSharedMutex.hpp"
@@ -154,14 +153,10 @@ StorageManager::~StorageManager() {
   }
 }
 
-block_id StorageManager::createBlock(const CatalogRelation &relation,
-                                     const StorageBlockLayout *layout,
+block_id StorageManager::createBlock(const CatalogRelationSchema &relation,
+                                     const StorageBlockLayout &layout,
                                      const int numa_node) {
-  if (layout == NULL) {
-    layout = &(relation.getDefaultStorageBlockLayout());
-  }
-
-  size_t num_slots = layout->getDescription().num_slots();
+  const size_t num_slots = layout.getDescription().num_slots();
 
   BlockHandle new_block_handle;
   const block_id new_block_id =
@@ -169,7 +164,7 @@ block_id StorageManager::createBlock(const CatalogRelation &relation,
 
   new_block_handle.block = new StorageBlock(relation,
                                             new_block_id,
-                                            *layout,
+                                            layout,
                                             true,
                                             new_block_handle.block_memory,
                                             kSlotSizeBytes * num_slots);

--- a/storage/StorageManager.hpp
+++ b/storage/StorageManager.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ DECLARE_uint64(buffer_pool_slots);
 DECLARE_bool(use_hdfs);
 #endif
 
-class CatalogRelation;
 class CatalogRelationSchema;
 class StorageBlockLayout;
 
@@ -171,16 +170,15 @@ class StorageManager {
    *
    * @param relation The relation which the new block will belong to (you must
    *                 also call addBlock() on the relation).
-   * @param layout The StorageBlockLayout to use for the new block. If NULL,
-   *               the default layout from relation will be used.
+   * @param layout The StorageBlockLayout to use for the new block.
    * @param numa_node The NUMA node on which the block should be created. The
    *                  default value is -1 and it means that the Catalog
    *                  Relation has no NUMAPlacementScheme associated with it
    *                  and hence the block will be created as per the OS policy.
    * @return The id of the newly-created block.
    **/
-  block_id createBlock(const CatalogRelation &relation,
-                       const StorageBlockLayout *layout,
+  block_id createBlock(const CatalogRelationSchema &relation,
+                       const StorageBlockLayout &layout,
                        const int numa_node = -1);
 
   /**
@@ -405,8 +403,8 @@ class StorageManager {
    *
    * @param slots Number of slots to make room for.
    * @param locked_block_id Reference to the block id for which room is being made.
-   *                        The parent has a lock in the sharded lock manager for the 
-   *                        "locked_block_id,"  so need to pass this through to the 
+   *                        The parent has a lock in the sharded lock manager for the
+   *                        "locked_block_id,"  so need to pass this through to the
    *                        EvictionPolicy to avoid a deadlock if the block that is
    *                        being cleared out hashes to the same hash entry.
    */

--- a/storage/tests/StorageBlockSort_unittest.cpp
+++ b/storage/tests/StorageBlockSort_unittest.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ class StorageBlockSortTest : public ::testing::Test {
     table_->addAttribute(new CatalogAttribute(table_.get(), "col-4", int_type));
 
     std::unique_ptr<StorageBlockLayout> layout(StorageBlockLayout::GenerateDefaultLayout(*table_, false));
-    block_id_ = storage_manager_->createBlock(*table_, layout.get());
+    block_id_ = storage_manager_->createBlock(*table_, *layout);
     MutableBlockReference block = storage_manager_->getBlockMutable(block_id_, *table_);
     table_->addBlock(block_id_);
 


### PR DESCRIPTION
This small PR refactors `createBlock` in `StorageManager`, as a part of replacing `CatalogRelation` with the read-only `CatalogRelationSchema` in `InsertDestination`.