### PR TITLE
Transaction Part 2: AccessMode, ResourceId, Lock

### DIFF
--- a/catalog/CatalogTypedefs.hpp
+++ b/catalog/CatalogTypedefs.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,6 +41,10 @@ typedef int numa_node_id;
 // This depends on all the above id types being typedefed to int, except for
 // partition_id.
 const int kCatalogMaxID = INT_MAX;
+
+// Catalog ids use negative values as invalid ids. Mark -1 as constant invalid
+// id for the catalog ids.
+constexpr int kInvalidCatalogId = -1;
 
 /** @} */
 

--- a/transaction/AccessMode.hpp
+++ b/transaction/AccessMode.hpp
@@ -1,0 +1,171 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TRANSACTION_ACCESS_MODE_HPP_
+#define QUICKSTEP_TRANSACTION_ACCESS_MODE_HPP_
+
+#include <cstdint>
+#include <type_traits>
+
+namespace quickstep {
+namespace transaction {
+
+/** \addtogroup Transaction
+ *  @{
+ */
+
+/**
+ * @brief Represents mode type. Possible options are NL, IS, IX, S, SIX, X.
+ **/
+enum class AccessModeType : std::uint8_t {
+  kNoLock = 0,
+  kIsLock,
+  kIxLock,
+  kSLock,
+  kSixLock,
+  kXLock,
+  kNumAccessModeTypes,
+};
+
+/**
+ * @brief Class for representing resource lock's access mode
+ **/
+class AccessMode {
+ public:
+  /**
+   * @brief Only constructor for access mode.
+   *
+   * @param access_mode Mode type of the object.
+   **/
+  explicit AccessMode(const AccessModeType access_mode)
+      : access_mode_(access_mode) {}
+
+  /**
+   * @brief Checks whether this access mode is compatible with the other.
+   *
+   * @param other Other access mode that will be checked against to this one.
+   * @return True if they are compatible, otherwise false.
+   **/
+  inline bool isCompatible(const AccessMode &other) const {
+    const access_mode_underlying_type this_mode =
+        static_cast<access_mode_underlying_type>(access_mode_);
+    const access_mode_underlying_type other_mode =
+        static_cast<access_mode_underlying_type>(other.access_mode_);
+    return AccessMode::kLockCompatibilityMatrix[this_mode][other_mode];
+  }
+
+  /**
+   * @brief Checks whether this access mode is IS mode.
+   *
+   * @return True if it is IS mode, false otherwise.
+   **/
+  inline bool isIntentionShareLock() const {
+    return access_mode_ == AccessModeType::kIsLock;
+  }
+
+  /**
+   * @brief Checks whether this access mode is IX mode.
+   *
+   * @return True if it is IX mode, false otherwise.
+   **/
+  inline bool isIntentionExclusiveLock() const {
+    return access_mode_ == AccessModeType::kIxLock;
+  }
+
+  /**
+   * @brief Checks whether this access mdoe is SIX mode.
+   *
+   * @return True if it is SIX mode, false otherwise.
+   **/
+  inline bool isShareAndIntentionExclusiveLock() const {
+    return access_mode_ == AccessModeType::kSixLock;
+  }
+
+  /**
+   * @brief Checks whether this access mode is S mode.
+   *
+   * @return True if it is S mode, false otherwise.
+   **/
+  inline bool isShareLock() const {
+    return access_mode_ == AccessModeType::kSLock;
+  }
+
+  /**
+   * @brief Checks whether this access mode is X mode.
+   *
+   * @return True if it is X mode, false otherwise.
+   **/
+  inline bool isExclusiveLock() const {
+    return access_mode_ == AccessModeType::kXLock;
+  }
+
+  /**
+   * @brief Checks whether this access mode is in
+   *        the same level with other mode.
+   *
+   * @return True if both modes have the same level.
+   **/
+  inline bool operator==(const AccessMode &other) const {
+    return access_mode_ == other.access_mode_;
+  }
+
+  /**
+   * @brief Checks whether this access mode is in
+   *        the different level with other mode.
+   *
+   * @return True if the modes have different levels.
+   **/
+  inline bool operator!=(const AccessMode &other) const {
+    return access_mode_ != other.access_mode_;
+  }
+
+ private:
+  typedef std::underlying_type<AccessModeType>::type
+      access_mode_underlying_type;
+
+  // The compatibility matrix should be N by N. kNumberLocks == N.
+  static constexpr std::uint64_t kNumberLocks =
+      static_cast<access_mode_underlying_type>(
+          AccessModeType::kNumAccessModeTypes);
+
+  // Compatibility matrix for checking access modes.
+  // True means they are compatible.
+  static constexpr bool kLockCompatibilityMatrix[kNumberLocks][kNumberLocks] = {
+/*           NL     IS     IX      S     SIX     X    */
+/*  NL  */ {true , true , true , true , true , true },
+/*  IS  */ {true , true , true , true , true , false},
+/*  IX  */ {true , true , true , false, false, false},
+/*  S   */ {true , true , false, true , false, false},
+/*  SIX */ {true , true , false, false, false, false},
+/*  X   */ {true , false, false, false, false, false}
+  };
+
+  // Type of access, the possible values are
+  // NoLock, IsLock, IxLock, SLock, SixLock, XLock
+  AccessModeType access_mode_;
+};
+
+/** @} */
+
+// static constexpr fields must be declared here, otherwise gcc
+// gives linkage errors.
+constexpr bool AccessMode::kLockCompatibilityMatrix[][kNumberLocks];
+
+}  // namespace transaction
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_TRANSACTION_ACCESS_MODE_HPP_

--- a/transaction/CMakeLists.txt
+++ b/transaction/CMakeLists.txt
@@ -13,9 +13,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+add_library(quickstep_transaction_AccessMode
+            ../empty_src.cpp
+            AccessMode.hpp)
 add_library(quickstep_transaction_DirectedGraph
             ../empty_src.cpp
             DirectedGraph.hpp)
+add_library(quickstep_transaction_Lock
+            ../empty_src.cpp
+            Lock.hpp)
+add_library(quickstep_transaction_ResourceId
+            ResourceId.cpp
+            ResourceId.hpp)
 add_library(quickstep_transaction_StronglyConnectedComponents
             StronglyConnectedComponents.cpp
             StronglyConnectedComponents.hpp)
@@ -24,9 +33,18 @@ add_library(quickstep_transaction_Transaction
             Transaction.hpp)
 
 target_link_libraries(quickstep_transaction_DirectedGraph
-	              glog
+                      glog
                       quickstep_transaction_Transaction
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_transaction_Lock
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_ResourceId)
+target_link_libraries(quickstep_transaction_ResourceId
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_storage_StorageBlockInfo
+                      quickstep_utility_HashPair)
+target_link_libraries(quickstep_transaction_ResourceId
+                      glog)
 target_link_libraries(quickstep_transaction_StronglyConnectedComponents
                       quickstep_transaction_DirectedGraph
                       quickstep_utility_Macros)
@@ -35,9 +53,20 @@ add_library(quickstep_transaction
             ../empty_src.cpp
             TransactionModule.hpp)
 target_link_libraries(quickstep_transaction
+                      quickstep_transaction_AccessMode
                       quickstep_transaction_DirectedGraph
+                      quickstep_transaction_Lock
+                      quickstep_transaction_ResourceId
                       quickstep_transaction_StronglyConnectedComponents
                       quickstep_transaction_Transaction)
+
+add_executable(AccessMode_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/AccessMode_unittest.cpp")
+target_link_libraries(AccessMode_unittest
+                      gtest
+                      gtest_main
+                      quickstep_transaction_AccessMode)
+add_test(AccessMode_unittest AccessMode_unittest)
 
 add_executable(DirectedGraph_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/DirectedGraph_unittest.cpp")
@@ -47,6 +76,24 @@ target_link_libraries(DirectedGraph_unittest
                       quickstep_transaction_DirectedGraph
                       quickstep_transaction_Transaction)
 add_test(DirectedGraph_unittest DirectedGraph_unittest)
+
+add_executable(Lock_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/Lock_unittest.cpp")
+target_link_libraries(Lock_unittest
+               gtest
+               gtest_main
+               quickstep_transaction_AccessMode
+               quickstep_transaction_Lock
+               quickstep_transaction_ResourceId)
+add_test(Lock_unittest Lock_unittest)
+
+add_executable(ResourceId_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/ResourceId_unittest.cpp")
+target_link_libraries(ResourceId_unittest
+                      gtest
+                      gtest_main
+                      quickstep_transaction_ResourceId)
+add_test(ResourceId_unittest ResourceId_unittest)
 
 add_executable(StronglyConnectedComponents_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/StronglyConnectedComponents_unittest.cpp")

--- a/transaction/DirectedGraph.hpp
+++ b/transaction/DirectedGraph.hpp
@@ -19,6 +19,8 @@
 #define QUICKSTEP_TRANSACTION_DIRECTED_GRAPH_HPP_
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <stack>
 #include <unordered_set>
@@ -30,7 +32,6 @@
 #include "glog/logging.h"
 
 namespace quickstep {
-
 namespace transaction {
 
 /** \addtogroup Transaction
@@ -200,7 +201,6 @@ class DirectedGraph {
 /** @} */
 
 }  // namespace transaction
-
 }  // namespace quickstep
 
 #endif  // QUICKSTEP_TRANSACTION_DIRECTED_GRAPH_HPP_

--- a/transaction/Lock.hpp
+++ b/transaction/Lock.hpp
@@ -1,0 +1,103 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TRANSACTION_LOCK_HPP_
+#define QUICKSTEP_TRANSACTION_LOCK_HPP_
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+/** \addtogroup Transaction
+ *  @{
+ */
+
+/**
+ * @brief Class for representing resource locks.
+ **/
+class Lock {
+ public:
+  /**
+   * @brief Constructor.
+   *
+   * @param rid Resource id of the resource on which the lock is taken.
+   * @param access_mode Mode of the lock access.
+   **/
+  Lock(const ResourceId &rid, const AccessMode &access_mode)
+      : rid_(rid),
+        access_mode_(access_mode) {
+  }
+
+  /**
+   * @brief Equality operator for lock.
+   *
+   * @param other Reference to the other Lock object that will be
+   *        compared against to this.
+   * @return True if both locks have equal resource ids
+   *         and access modes, false otherwise.
+   **/
+  inline bool operator==(const Lock &other) const {
+    return rid_ == other.rid_ && access_mode_ == other.access_mode_;
+  }
+
+  /**
+   * @brief Inequality operator for lock.
+   *
+   * @param other Reference to the other Lock object that will be
+   *        compared against to this.
+   * @return False if one of them has different resource id
+   *         or access mode, true otherwise.
+   **/
+  inline bool operator!=(const Lock &other) const {
+    return !(*this == other);
+  }
+
+  /**
+   * @brief Getter for resource id.
+   *
+   * @return Resource id of the lock.
+   **/
+  inline const ResourceId& getResourceId() const {
+    return rid_;
+  }
+
+  /**
+   * @brief Getter for access mode.
+   *
+   * @return Access mode of the lock.
+   **/
+  inline const AccessMode& getAccessMode() const {
+    return access_mode_;
+  }
+
+ private:
+  // Id of the resource that is locked.
+  const ResourceId rid_;
+
+  // Lock's access type.
+  AccessMode access_mode_;
+};
+
+/** @} */
+
+}  // namespace transaction
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_TRANSACTION_LOCK_HPP_

--- a/transaction/ResourceId.cpp
+++ b/transaction/ResourceId.cpp
@@ -1,0 +1,74 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/ResourceId.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <string>
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "storage/StorageBlockInfo.hpp"
+#include "utility/HashPair.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+namespace transaction {
+
+bool ResourceId::operator==(const ResourceId &other) const {
+  return db_id_ == other.db_id_
+      && rel_id_ == other.rel_id_
+      && block_id_ == other.block_id_
+      && tuple_id_ == other.tuple_id_;
+}
+
+ResourceId ResourceId::getParentResourceId() const {
+  if (isRelationAccess()) {
+    return ResourceId(db_id_);
+  } else if (isBlockAccess()) {
+    return ResourceId(db_id_, rel_id_);
+  } else if (isTupleAccess()) {
+    return ResourceId(db_id_, rel_id_, block_id_);
+  } else {
+    LOG(FATAL) << "Database level does not have any parent level.";
+  }
+}
+
+std::string ResourceId::toString() const {
+  return "ResourceId(" +
+    std::to_string(db_id_) + ", " +
+    std::to_string(rel_id_) + ", " +
+    std::to_string(block_id_) + ", " +
+    std::to_string(tuple_id_) + ")";
+}
+
+std::size_t
+ResourceId::ResourceIdHasher::operator()(const ResourceId &rid) const {
+  const std::size_t hash1 = std::hash<database_id>()(rid.db_id_);
+  const std::size_t hash2 = std::hash<relation_id>()(rid.rel_id_);
+  const std::size_t hash3 = std::hash<block_id>()(rid.block_id_);
+  const std::size_t hash4 = std::hash<tuple_id>()(rid.tuple_id_);
+
+  const std::size_t comb1 = CombineHashes(hash1, hash2);
+  const std::size_t comb2 = CombineHashes(hash3, hash4);
+
+  return CombineHashes(comb1, comb2);
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/ResourceId.hpp
+++ b/transaction/ResourceId.hpp
@@ -1,0 +1,216 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TRANSACTION_RESOURCE_ID_HPP_
+#define QUICKSTEP_TRANSACTION_RESOURCE_ID_HPP_
+
+#include <cstddef>
+#include <limits>
+#include <string>
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "storage/StorageBlockInfo.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+/** \addtogroup Transaction
+ *  @{
+ */
+
+/**
+ * @brief Class for representing unique id for each database resource
+ *        e.g Tuple, block, relation, database etc...
+ **/
+class ResourceId {
+ public:
+  /**
+   * @brief Constructor
+   *
+   * @param db_id Unique id of the database resource.
+   * @param rel_id Unique id of the relation resource in the database.
+   * @param block_id Unique id of the block resource in the relation.
+   * @param tuple_id Unique id of the tuple resource in the block.
+   **/
+  explicit ResourceId(const database_id db_id = kDatabaseIdPlaceholder,
+                      const relation_id rel_id = kRelationIdPlaceholder,
+                      const block_id block_id = kBlockIdPlaceholder,
+                      const tuple_id tuple_id = kTupleIdPlaceholder)
+      : db_id_(db_id),
+        rel_id_(rel_id),
+        block_id_(block_id),
+        tuple_id_(tuple_id) {
+  }
+
+  /**
+   * @brief Copy constructor.
+   *
+   * @param other The ResourceId that will be copied.
+   **/
+  ResourceId(const ResourceId &other)
+      : db_id_(other.db_id_),
+        rel_id_(other.rel_id_),
+        block_id_(other.block_id_),
+        tuple_id_(other.tuple_id_) {
+  }
+
+  /**
+   * @brief Hasher class for ResourceId class to use it in the hash map.
+   **/
+  struct ResourceIdHasher {
+    /**
+     * @brief Functor of the class.
+     *
+     * @param rid Resource id to be hashed.
+     * @return Hash of the resource id.
+     **/
+    std::size_t operator()(const ResourceId &rid) const;
+  };
+
+  /**
+   * @brief Equality operator for ResourceId class.
+   *
+   * @param other Resource to be compared.
+   * @return True if this and other are the id of the same
+   *         resource, false otherwise.
+   **/
+  bool operator==(const ResourceId &other) const;
+
+   /**
+   * @brief Inequality operator for ResourceId class.
+   *
+   * @param other Resource to be compared.
+   * @return True if this and other are the ids of the different
+   *         resources, false otherwise.
+   **/
+  inline bool operator!=(const ResourceId &other) const {
+    return !(*this == other);
+  }
+
+  /**
+   * @brief Checks whether this resource id has a parent in resource hierarchy.
+   *
+   * @return False if this resource id is database level, true otherwise.
+   **/
+  inline bool hasParent() const {
+    return !isDatabaseAccess();
+  }
+
+  /**
+   * @brief Getter for this resource id's parent in the hierarchy.
+   *
+   * @return The resource id of this resource id's parent.
+   **/
+  ResourceId getParentResourceId() const;
+
+  /**
+   * @brief Checks whether this is a database level resource id.
+   *
+   * @return True if this is a database level access, false otherwise.
+   **/
+  inline bool isDatabaseAccess() const {
+    return !isDatabaseIdPlaceholder()
+        && isRelationIdPlaceholder()
+        && isBlockIdPlaceholder()
+        && isTupleIdPlaceholder();
+  }
+
+  /**
+   * @brief Checks whether this is a relation level resource id.
+   *
+   * @return True if this is a relation level access, false otherwise.
+   **/
+  bool isRelationAccess() const {
+    return !isDatabaseIdPlaceholder()
+        && !isRelationIdPlaceholder()
+        && isBlockIdPlaceholder()
+        && isTupleIdPlaceholder();
+  }
+
+  /**
+   * @brief Checks whether this is a block level resource id.
+   *
+   * @return True if this is a block level access, false otherwise.
+   **/
+  bool isBlockAccess() const {
+    return !isDatabaseIdPlaceholder()
+        && !isRelationIdPlaceholder()
+        && !isBlockIdPlaceholder()
+        && isTupleIdPlaceholder();
+  }
+
+  /**
+   * @brief Checks whether this is a tuple level resource id.
+   *
+   * @return True if this is a tuple level access, false otherwise.
+   **/
+  bool isTupleAccess() const {
+    return !isDatabaseIdPlaceholder()
+        && !isRelationIdPlaceholder()
+        && !isBlockIdPlaceholder()
+        && !isTupleIdPlaceholder();
+  }
+
+  /**
+   * @brief This is a helper method for string representation
+   *        of the resource id.
+   *
+   * @return String representation of the reosurce id.
+   **/
+  std::string toString() const;
+
+ private:
+  // Negative value is invalid id for database id. Use -1 as placeholder.
+  static constexpr database_id kDatabaseIdPlaceholder = kInvalidCatalogId;
+
+  // Negative value is invalid id for relation id. Use -1 as placeholder.
+  static constexpr relation_id kRelationIdPlaceholder = kInvalidCatalogId;
+
+  // Zero is invalid id for block id. Use zero as the placeholder.
+  static constexpr block_id kBlockIdPlaceholder = kInvalidBlockId;
+
+  // Negative tuple id os invalid, therefore use a negative value.
+  static constexpr tuple_id kTupleIdPlaceholder = kInvalidCatalogId;
+
+  inline bool isDatabaseIdPlaceholder() const {
+    return db_id_ == kDatabaseIdPlaceholder;
+  }
+
+  inline bool isRelationIdPlaceholder() const {
+    return rel_id_ == kRelationIdPlaceholder;
+  }
+
+  inline bool isBlockIdPlaceholder() const {
+    return block_id_ == kBlockIdPlaceholder;
+  }
+
+  inline bool isTupleIdPlaceholder() const {
+    return tuple_id_ == kTupleIdPlaceholder;
+  }
+
+  const database_id db_id_;
+  const relation_id rel_id_;
+  const block_id block_id_;
+  const tuple_id tuple_id_;
+};
+
+/** @} */
+
+}  // namespace transaction
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_RESOURCE_ID_HPP_

--- a/transaction/StronglyConnectedComponents.cpp
+++ b/transaction/StronglyConnectedComponents.cpp
@@ -17,13 +17,15 @@
 
 #include "transaction/StronglyConnectedComponents.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <stack>
 #include <unordered_map>
 #include <vector>
 
-namespace quickstep {
+#include "transaction/DirectedGraph.hpp"
 
+namespace quickstep {
 namespace transaction {
 
 StronglyConnectedComponents::StronglyConnectedComponents(
@@ -118,5 +120,4 @@ std::unordered_map<std::uint64_t, std::vector<DirectedGraph::node_id>>
 }
 
 }  // namespace transaction
-
 }  // namespace quickstep

--- a/transaction/StronglyConnectedComponents.hpp
+++ b/transaction/StronglyConnectedComponents.hpp
@@ -28,7 +28,6 @@
 #include "utility/Macros.hpp"
 
 namespace quickstep {
-
 namespace transaction {
 
 /** \addtogroup Transaction
@@ -115,7 +114,6 @@ class StronglyConnectedComponents {
 /** @} */
 
 }  // namespace transaction
-
 }  // namespace quickstep
 
 #endif  // QUICKSTEP_TRANSACTION_STRONGLY_CONNECTED_COMPONENTS_HPP_

--- a/transaction/Transaction.hpp
+++ b/transaction/Transaction.hpp
@@ -23,7 +23,6 @@
 #include <functional>
 
 namespace quickstep {
-
 namespace transaction {
 
 /** \addtogroup Transaction
@@ -115,7 +114,6 @@ class Transaction {
 /** @} */
 
 }  // namespace transaction
-
 }  // namespace quickstep
 
 #endif  // QUICKSTEP_TRANSACTION_TRANSACTION_HPP_

--- a/transaction/tests/AccessMode_unittest.cpp
+++ b/transaction/tests/AccessMode_unittest.cpp
@@ -1,0 +1,171 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/AccessMode.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+namespace transaction {
+
+class AccessModeTest : public ::testing::Test {
+ protected:
+  AccessModeTest()
+      : nl_mode_(AccessModeType::kNoLock),
+        is_mode_(AccessModeType::kIsLock),
+        ix_mode_(AccessModeType::kIxLock),
+        s_mode_(AccessModeType::kSLock),
+        six_mode_(AccessModeType::kSixLock),
+        x_mode_(AccessModeType::kXLock) {
+  }
+
+  const AccessMode nl_mode_;
+  const AccessMode is_mode_;
+  const AccessMode ix_mode_;
+  const AccessMode s_mode_;
+  const AccessMode six_mode_;
+  const AccessMode x_mode_;
+};
+
+TEST_F(AccessModeTest, ModeCompatibilty) {
+  EXPECT_TRUE(nl_mode_.isCompatible(nl_mode_));
+  EXPECT_TRUE(nl_mode_.isCompatible(is_mode_));
+  EXPECT_TRUE(nl_mode_.isCompatible(ix_mode_));
+  EXPECT_TRUE(nl_mode_.isCompatible(s_mode_));
+  EXPECT_TRUE(nl_mode_.isCompatible(six_mode_));
+  EXPECT_TRUE(nl_mode_.isCompatible(x_mode_));
+
+  EXPECT_TRUE(is_mode_.isCompatible(nl_mode_));
+  EXPECT_TRUE(is_mode_.isCompatible(is_mode_));
+  EXPECT_TRUE(is_mode_.isCompatible(ix_mode_));
+  EXPECT_TRUE(is_mode_.isCompatible(s_mode_));
+  EXPECT_TRUE(is_mode_.isCompatible(six_mode_));
+  EXPECT_FALSE(is_mode_.isCompatible(x_mode_));
+
+  EXPECT_TRUE(ix_mode_.isCompatible(nl_mode_));
+  EXPECT_TRUE(ix_mode_.isCompatible(is_mode_));
+  EXPECT_TRUE(ix_mode_.isCompatible(ix_mode_));
+  EXPECT_FALSE(ix_mode_.isCompatible(s_mode_));
+  EXPECT_FALSE(ix_mode_.isCompatible(six_mode_));
+  EXPECT_FALSE(ix_mode_.isCompatible(x_mode_));
+
+  EXPECT_TRUE(s_mode_.isCompatible(nl_mode_));
+  EXPECT_TRUE(s_mode_.isCompatible(is_mode_));
+  EXPECT_FALSE(s_mode_.isCompatible(ix_mode_));
+  EXPECT_TRUE(s_mode_.isCompatible(s_mode_));
+  EXPECT_FALSE(s_mode_.isCompatible(six_mode_));
+  EXPECT_FALSE(s_mode_.isCompatible(x_mode_));
+
+  EXPECT_TRUE(six_mode_.isCompatible(nl_mode_));
+  EXPECT_TRUE(six_mode_.isCompatible(is_mode_));
+  EXPECT_FALSE(six_mode_.isCompatible(ix_mode_));
+  EXPECT_FALSE(six_mode_.isCompatible(s_mode_));
+  EXPECT_FALSE(six_mode_.isCompatible(six_mode_));
+  EXPECT_FALSE(six_mode_.isCompatible(x_mode_));
+
+  EXPECT_TRUE(x_mode_.isCompatible(nl_mode_));
+  EXPECT_FALSE(x_mode_.isCompatible(is_mode_));
+  EXPECT_FALSE(x_mode_.isCompatible(ix_mode_));
+  EXPECT_FALSE(x_mode_.isCompatible(s_mode_));
+  EXPECT_FALSE(x_mode_.isCompatible(six_mode_));
+  EXPECT_FALSE(x_mode_.isCompatible(x_mode_));
+}
+
+TEST_F(AccessModeTest, ModeQueryChecks) {
+  EXPECT_FALSE(nl_mode_.isIntentionShareLock());
+  EXPECT_FALSE(nl_mode_.isIntentionExclusiveLock());
+  EXPECT_FALSE(nl_mode_.isShareLock());
+  EXPECT_FALSE(nl_mode_.isShareAndIntentionExclusiveLock());
+  EXPECT_FALSE(nl_mode_.isExclusiveLock());
+
+  EXPECT_TRUE(is_mode_.isIntentionShareLock());
+  EXPECT_FALSE(is_mode_.isIntentionExclusiveLock());
+  EXPECT_FALSE(is_mode_.isShareLock());
+  EXPECT_FALSE(is_mode_.isShareAndIntentionExclusiveLock());
+  EXPECT_FALSE(is_mode_.isExclusiveLock());
+
+  EXPECT_FALSE(ix_mode_.isIntentionShareLock());
+  EXPECT_TRUE(ix_mode_.isIntentionExclusiveLock());
+  EXPECT_FALSE(ix_mode_.isShareLock());
+  EXPECT_FALSE(ix_mode_.isShareAndIntentionExclusiveLock());
+  EXPECT_FALSE(ix_mode_.isExclusiveLock());
+
+  EXPECT_FALSE(s_mode_.isIntentionShareLock());
+  EXPECT_FALSE(s_mode_.isIntentionExclusiveLock());
+  EXPECT_TRUE(s_mode_.isShareLock());
+  EXPECT_FALSE(s_mode_.isShareAndIntentionExclusiveLock());
+  EXPECT_FALSE(s_mode_.isExclusiveLock());
+
+  EXPECT_FALSE(six_mode_.isIntentionShareLock());
+  EXPECT_FALSE(six_mode_.isIntentionExclusiveLock());
+  EXPECT_FALSE(six_mode_.isShareLock());
+  EXPECT_TRUE(six_mode_.isShareAndIntentionExclusiveLock());
+  EXPECT_FALSE(six_mode_.isExclusiveLock());
+
+  EXPECT_FALSE(x_mode_.isIntentionShareLock());
+  EXPECT_FALSE(x_mode_.isIntentionExclusiveLock());
+  EXPECT_FALSE(x_mode_.isShareLock());
+  EXPECT_FALSE(x_mode_.isShareAndIntentionExclusiveLock());
+  EXPECT_TRUE(x_mode_.isExclusiveLock());
+}
+
+TEST_F(AccessModeTest, Equality) {
+  EXPECT_EQ(nl_mode_, nl_mode_);
+  EXPECT_NE(nl_mode_, is_mode_);
+  EXPECT_NE(nl_mode_, ix_mode_);
+  EXPECT_NE(nl_mode_, s_mode_);
+  EXPECT_NE(nl_mode_, six_mode_);
+  EXPECT_NE(nl_mode_, x_mode_);
+
+  EXPECT_NE(is_mode_, nl_mode_);
+  EXPECT_EQ(is_mode_, is_mode_);
+  EXPECT_NE(is_mode_, ix_mode_);
+  EXPECT_NE(is_mode_, s_mode_);
+  EXPECT_NE(is_mode_, six_mode_);
+  EXPECT_NE(is_mode_, x_mode_);
+
+  EXPECT_NE(ix_mode_, nl_mode_);
+  EXPECT_NE(ix_mode_, is_mode_);
+  EXPECT_EQ(ix_mode_, ix_mode_);
+  EXPECT_NE(ix_mode_, s_mode_);
+  EXPECT_NE(ix_mode_, six_mode_);
+  EXPECT_NE(ix_mode_, x_mode_);
+
+  EXPECT_NE(s_mode_, nl_mode_);
+  EXPECT_NE(s_mode_, is_mode_);
+  EXPECT_NE(s_mode_, ix_mode_);
+  EXPECT_EQ(s_mode_, s_mode_);
+  EXPECT_NE(s_mode_, six_mode_);
+  EXPECT_NE(s_mode_, x_mode_);
+
+  EXPECT_NE(six_mode_, nl_mode_);
+  EXPECT_NE(six_mode_, is_mode_);
+  EXPECT_NE(six_mode_, ix_mode_);
+  EXPECT_NE(six_mode_, s_mode_);
+  EXPECT_EQ(six_mode_, six_mode_);
+  EXPECT_NE(six_mode_, x_mode_);
+
+  EXPECT_NE(x_mode_, nl_mode_);
+  EXPECT_NE(x_mode_, is_mode_);
+  EXPECT_NE(x_mode_, ix_mode_);
+  EXPECT_NE(x_mode_, s_mode_);
+  EXPECT_NE(x_mode_, six_mode_);
+  EXPECT_EQ(x_mode_, x_mode_);
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/tests/DirectedGraph_unittest.cpp
+++ b/transaction/tests/DirectedGraph_unittest.cpp
@@ -24,7 +24,6 @@
 #include "gtest/gtest.h"
 
 namespace quickstep {
-
 namespace transaction {
 
 TEST(DirectedGraphTest, AddNode) {
@@ -127,5 +126,4 @@ TEST(DirectedGraphTest, GetAdjacentNodes) {
 }
 
 }  // namespace transaction
-
 }  // namespace quickstep

--- a/transaction/tests/Lock_unittest.cpp
+++ b/transaction/tests/Lock_unittest.cpp
@@ -1,0 +1,92 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/Lock.hpp"
+
+#include <cstddef>
+#include <vector>
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+namespace transaction {
+
+class LockTest : public ::testing::Test {
+ protected:
+  LockTest()
+      : modes_({AccessMode(AccessModeType::kNoLock),
+                AccessMode(AccessModeType::kIsLock),
+                AccessMode(AccessModeType::kIxLock),
+                AccessMode(AccessModeType::kSLock),
+                AccessMode(AccessModeType::kSixLock),
+                AccessMode(AccessModeType::kXLock)}),
+        resource_a_(3, 10, 2, 5),
+        resource_b_(4, 5, 3, 2),
+        locks_on_resource_a_({Lock(resource_a_, modes_[0]),
+                              Lock(resource_a_, modes_[1]),
+                              Lock(resource_a_, modes_[2]),
+                              Lock(resource_a_, modes_[3]),
+                              Lock(resource_a_, modes_[4]),
+                              Lock(resource_a_, modes_[5])}),
+        locks_on_resource_b_({Lock(resource_b_, modes_[0]),
+                             Lock(resource_b_, modes_[1]),
+                             Lock(resource_b_, modes_[2]),
+                             Lock(resource_b_, modes_[3]),
+                             Lock(resource_b_, modes_[4]),
+                             Lock(resource_b_, modes_[5])}) {
+  }
+
+  const std::vector<AccessMode> modes_;
+  const ResourceId resource_a_;
+  const ResourceId resource_b_;
+  const std::vector<Lock> locks_on_resource_a_;
+  const std::vector<Lock> locks_on_resource_b_;
+};
+
+TEST_F(LockTest, LockEquality) {
+  // Locks are equal if they are on the same resource with same
+  // access mode.
+  for (std::size_t i = 0; i < locks_on_resource_a_.size(); ++i) {
+    for (std::size_t j = 0; j < locks_on_resource_a_.size(); ++j) {
+      if (i == j) {
+        EXPECT_EQ(locks_on_resource_a_[i], locks_on_resource_a_[j]);
+      } else {
+        EXPECT_NE(locks_on_resource_a_[i], locks_on_resource_a_[j]);
+      }
+    }
+    // Locks are nver equal if they have different resource ids.
+    EXPECT_NE(locks_on_resource_a_[i], locks_on_resource_b_[i]);
+  }
+}
+
+TEST_F(LockTest, GetResourceId) {
+  for (std::size_t i = 0; i < locks_on_resource_a_.size(); ++i) {
+    EXPECT_EQ(resource_a_, locks_on_resource_a_[i].getResourceId());
+  }
+}
+
+TEST_F(LockTest, GetAccessMode) {
+  for (std::size_t i = 0; i < locks_on_resource_a_.size(); ++i) {
+    EXPECT_EQ(modes_[i], locks_on_resource_a_[i].getAccessMode());
+  }
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/tests/ResourceId_unittest.cpp
+++ b/transaction/tests/ResourceId_unittest.cpp
@@ -1,0 +1,113 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/ResourceId.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+namespace transaction {
+
+class ResourceIdTest : public ::testing::Test {
+ protected:
+  ResourceIdTest()
+      : db1_(1),
+        db2_(2),
+        db2_rel2_(2, 2),
+        db2_rel4_(2, 4),
+        db2_rel2_block2_(2, 2, 2),
+        db2_rel2_block3_(2, 2, 3),
+        db2_rel4_block5_(2, 4, 5),
+        db2_rel4_block7_(2, 4, 7),
+        db2_rel2_block2_tpl4_(2, 2, 2, 4),
+        db2_rel2_block2_tpl7_(2, 2, 2, 7),
+        db2_rel4_block5_tpl3_(2, 4, 5, 7),
+        db2_rel4_block5_tpl8_(2, 4, 5, 8) {
+  }
+
+  const ResourceId db1_;
+  const ResourceId db2_;
+  const ResourceId db2_rel2_;
+  const ResourceId db2_rel4_;
+  const ResourceId db2_rel2_block2_;
+  const ResourceId db2_rel2_block3_;
+  const ResourceId db2_rel4_block5_;
+  const ResourceId db2_rel4_block7_;
+  const ResourceId db2_rel2_block2_tpl4_;
+  const ResourceId db2_rel2_block2_tpl7_;
+  const ResourceId db2_rel4_block5_tpl3_;
+  const ResourceId db2_rel4_block5_tpl8_;
+};
+
+TEST_F(ResourceIdTest, CheckAccessLevels) {
+  EXPECT_TRUE(db2_.isDatabaseAccess());
+  EXPECT_FALSE(db2_rel4_.isDatabaseAccess());
+  EXPECT_FALSE(db2_rel4_block5_.isDatabaseAccess());
+  EXPECT_FALSE(db2_rel4_block5_tpl8_.isDatabaseAccess());
+
+  EXPECT_FALSE(db2_.isRelationAccess());
+  EXPECT_TRUE(db2_rel4_.isRelationAccess());
+  EXPECT_FALSE(db2_rel4_block5_.isRelationAccess());
+  EXPECT_FALSE(db2_rel4_block5_tpl8_.isRelationAccess());
+
+  EXPECT_FALSE(db2_.isBlockAccess());
+  EXPECT_FALSE(db2_rel4_.isBlockAccess());
+  EXPECT_TRUE(db2_rel4_block5_.isBlockAccess());
+  EXPECT_FALSE(db2_rel4_block5_tpl8_.isBlockAccess());
+
+  EXPECT_FALSE(db2_.isTupleAccess());
+  EXPECT_FALSE(db2_rel4_.isTupleAccess());
+  EXPECT_FALSE(db2_rel4_block5_.isTupleAccess());
+  EXPECT_TRUE(db2_rel4_block5_tpl8_.isTupleAccess());
+}
+
+TEST_F(ResourceIdTest, Equality) {
+  // Copy some resource ids.
+  const ResourceId db1_copy(db1_);
+  const ResourceId db2_rel2_copy(db2_rel2_);
+  const ResourceId db2_rel4_block5_copy(db2_rel4_block5_);
+  const ResourceId db2_rel4_block5_tpl8_copy(db2_rel4_block5_tpl8_);
+
+  // Self comparison must be equal.
+  EXPECT_EQ(db1_, db1_);
+  EXPECT_EQ(db2_rel2_, db2_rel2_);
+  EXPECT_EQ(db2_rel4_block5_, db2_rel4_block5_);
+  EXPECT_EQ(db2_rel4_block5_tpl3_, db2_rel4_block5_tpl3_);
+
+  // If resources are different, than it must have different ids.
+  EXPECT_NE(db1_, db2_);
+  EXPECT_NE(db2_rel2_, db2_rel4_);
+  EXPECT_NE(db2_rel4_block5_, db2_rel4_block7_);
+  EXPECT_NE(db2_rel4_block5_tpl3_, db2_rel4_block5_tpl8_);
+
+  // Comparison with a copy must be equal.
+  EXPECT_EQ(db1_copy, db1_);
+  EXPECT_EQ(db2_rel2_copy, db2_rel2_);
+  EXPECT_EQ(db2_rel4_block5_copy, db2_rel4_block5_);
+  EXPECT_EQ(db2_rel4_block5_tpl8_copy, db2_rel4_block5_tpl8_);
+}
+
+TEST_F(ResourceIdTest, ParentResourceIds) {
+  EXPECT_EQ(db2_, db2_rel2_.getParentResourceId());
+  EXPECT_EQ(db2_rel2_, db2_rel2_block2_.getParentResourceId());
+  EXPECT_EQ(db2_rel2_, db2_rel2_block3_.getParentResourceId());
+  EXPECT_EQ(db2_rel2_block2_, db2_rel2_block2_tpl4_.getParentResourceId());
+  EXPECT_EQ(db2_rel2_block2_, db2_rel2_block2_tpl7_.getParentResourceId());
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/tests/StronglyConnectedComponents_unittest.cpp
+++ b/transaction/tests/StronglyConnectedComponents_unittest.cpp
@@ -30,7 +30,6 @@
 #include "gtest/gtest.h"
 
 namespace quickstep {
-
 namespace transaction {
 
 class GraphConfiguration {
@@ -225,5 +224,4 @@ TEST_F(StronglyConnectedComponentsTest, GetComponentsMapping) {
 }
 
 }  // namespace transaction
-
 }  // namespace quickstep


### PR DESCRIPTION
This PR introduces new classes for transaction support.

- AccessMode: Represents access level of the lock such as S, X, IS, IX. Based on [[Gray et al.]](http://research.microsoft.com/en-us/um/people/gray/papers/Granularity%20of%20Locks%20and%20Degrees%20of%20Consistency%20RJ%201654.pdf)

- ResourceId: Each logical and physical section (database, relation, block) of DBMS has a unique resource id associated with it.

- Lock: Since the concurrency control will be based on Strict 2PL, we will need locks. In a simple manner, it is a tuple of AccessMode and ResourceId.
