### PR TITLE
Fixes InsertDestination layout creation

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -775,6 +775,7 @@ target_link_libraries(quickstep_storage_StorageBlockInfo
                       quickstep_utility_StringUtil)
 target_link_libraries(quickstep_storage_StorageBlockLayout
                       glog
+                      quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageBlockLayout_proto

--- a/storage/InsertDestination.cpp
+++ b/storage/InsertDestination.cpp
@@ -68,7 +68,7 @@ InsertDestination::InsertDestination(const CatalogRelationSchema &relation,
       foreman_client_id_(foreman_client_id),
       bus_(DCHECK_NOTNULL(bus)) {
   if (layout_ == nullptr) {
-    layout_.reset(StorageBlockLayout::GenerateDefaultLayout(relation, relation.isVariableLength()));
+    layout_.reset(StorageBlockLayout::GenerateLayout(relation));
   }
 }
 

--- a/storage/StorageBlockLayout.hpp
+++ b/storage/StorageBlockLayout.hpp
@@ -69,6 +69,23 @@ class StorageBlockLayout {
 
   /**
    * @brief Static method to generate a default layout for a particular
+   *        relation. This may either be the default specified by the user
+   *        with BLOCKPROPERTIES, or the layout generated using the default
+   *        layout policy.
+   * @note The default policy is that a default layout takes up one slot, uses
+   *       PackedRowStoreTupleStorageSubBlock for fixed-length relations or
+   *       SplitRowStoreTupleStorageSubBlock for variable-length relations, and
+   *       has no indices.
+   *
+   * @param relationSchema The relation to generate a layout for.
+   * @return A new StorageBlockLayout for the relation, according to the
+   *         default policies. Caller takes ownership.
+   **/
+  static StorageBlockLayout* GenerateLayout(
+      const CatalogRelationSchema &relationSchema);
+
+  /**
+   * @brief Static method to generate a default layout for a particular
    *        relation.
    * @note The current policy is that a default layout takes up one slot, uses
    *       PackedRowStoreTupleStorageSubBlock for fixed-length relations or


### PR DESCRIPTION
I noticed that BlockProperties were not being correctly instantiated because the associated StorageBlockLayoutDescription proto was not being selected by the InsertDestination. 

This was due to a change in how the InsertDestination was used in #97 