### PR TITLE
Added CatalogDatabaseLite.

### DIFF
--- a/catalog/CMakeLists.txt
+++ b/catalog/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_Catalog_proto
+                      quickstep_storage_StorageConstants
                       quickstep_threading_Mutex
                       quickstep_threading_SharedMutex
                       quickstep_threading_SpinSharedMutex

--- a/catalog/CMakeLists.txt
+++ b/catalog/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(quickstep_catalog_Catalog Catalog.cpp Catalog.hpp)
 add_library(quickstep_catalog_Catalog_proto ${catalog_Catalog_proto_srcs})
 add_library(quickstep_catalog_CatalogAttribute CatalogAttribute.cpp CatalogAttribute.hpp)
 add_library(quickstep_catalog_CatalogDatabase CatalogDatabase.cpp CatalogDatabase.hpp)
+add_library(quickstep_catalog_CatalogDatabaseLite ../empty_src.cpp CatalogDatabaseLite.hpp)
 add_library(quickstep_catalog_CatalogErrors ../empty_src.cpp CatalogErrors.hpp)
 add_library(quickstep_catalog_CatalogRelation CatalogRelation.cpp CatalogRelation.hpp)
 add_library(quickstep_catalog_CatalogRelationSchema
@@ -66,6 +67,7 @@ target_link_libraries(quickstep_catalog_CatalogAttribute
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_catalog_CatalogDatabase
                       glog
+                      quickstep_catalog_CatalogDatabaseLite
                       quickstep_catalog_CatalogErrors
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
@@ -77,6 +79,9 @@ target_link_libraries(quickstep_catalog_CatalogDatabase
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
                       quickstep_utility_StringUtil)
+target_link_libraries(quickstep_catalog_CatalogDatabaseLite
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_catalog_CatalogRelation
                       glog
                       quickstep_catalog_CatalogAttribute
@@ -151,6 +156,7 @@ target_link_libraries(quickstep_catalog
                       quickstep_catalog_Catalog_proto
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogDatabase
+                      quickstep_catalog_CatalogDatabaseLite
                       quickstep_catalog_CatalogErrors
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationSchema

--- a/catalog/CatalogDatabase.cpp
+++ b/catalog/CatalogDatabase.cpp
@@ -55,7 +55,8 @@ bool CatalogDatabase::ProtoIsValid(const serialization::CatalogDatabase &proto) 
 }
 
 CatalogDatabase::CatalogDatabase(const serialization::CatalogDatabase &proto)
-    : name_(proto.name()),
+    : parent_(nullptr),
+      name_(proto.name()),
       status_(Status::kConsistent) {
   DCHECK(ProtoIsValid(proto))
       << "Attempted to create CatalogDatabase from an invalid proto description:\n"

--- a/catalog/CatalogDatabase.cpp
+++ b/catalog/CatalogDatabase.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "catalog/Catalog.pb.h"
 #include "catalog/CatalogErrors.hpp"
@@ -85,7 +86,7 @@ const CatalogRelation* CatalogDatabase::getRelationByName(const string &rel_name
 
 CatalogRelation* CatalogDatabase::getRelationByNameMutable(const string &rel_name) {
   SpinSharedMutexSharedLock<false> lock(relations_mutex_);
-  std::unordered_map<string, CatalogRelation*>::const_iterator it = rel_map_.find(ToLower(rel_name));
+  std::unordered_map<string, CatalogRelation*>::iterator it = rel_map_.find(ToLower(rel_name));
   if (it == rel_map_.end()) {
     return nullptr;
   } else {

--- a/catalog/CatalogDatabase.hpp
+++ b/catalog/CatalogDatabase.hpp
@@ -189,8 +189,10 @@ class CatalogDatabase : public CatalogDatabaseLite {
     return hasRelationWithIdUnsafe(id);
   }
 
-  const CatalogRelationSchema* getRelationSchemaById(const relation_id id) const override {
-    return getRelationById(id);
+  const CatalogRelationSchema& getRelationSchemaById(const relation_id id) const override {
+    SpinSharedMutexSharedLock<false> lock(relations_mutex_);
+    DCHECK(hasRelationWithIdUnsafe(id));
+    return rel_vec_[id];
   }
 
   /**

--- a/catalog/CatalogDatabase.hpp
+++ b/catalog/CatalogDatabase.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include "catalog/Catalog.pb.h"
 #include "catalog/CatalogRelation.hpp"
 #include "catalog/CatalogTypedefs.hpp"
+#include "storage/StorageConstants.hpp"
 #include "threading/Mutex.hpp"
 #include "threading/SharedMutex.hpp"
 #include "threading/SpinSharedMutex.hpp"
@@ -450,7 +451,7 @@ class CatalogDatabase {
 
   // Indicate the status of this database (i.e., consistent or not).
   Status status_;
-  mutable SpinSharedMutex<false> status_mutex_;
+  alignas(kCacheLineBytes) mutable SpinSharedMutex<false> status_mutex_;
 
   // A vector of relations. NULL if the relation has dropped from the database.
   PtrVector<CatalogRelation, true> rel_vec_;
@@ -462,7 +463,7 @@ class CatalogDatabase {
   std::unordered_map<std::string, CatalogRelation*> rel_map_;
 
   // Concurrency protection for 'rel_vec_' and 'rel_map_'.
-  mutable SpinSharedMutex<false> relations_mutex_;
+  alignas(kCacheLineBytes) mutable SpinSharedMutex<false> relations_mutex_;
 
   friend class Catalog;
 

--- a/catalog/CatalogDatabaseLite.hpp
+++ b/catalog/CatalogDatabaseLite.hpp
@@ -1,0 +1,101 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_CATALOG_CATALOG_DATABASE_LITE_HPP_
+#define QUICKSTEP_CATALOG_CATALOG_DATABASE_LITE_HPP_
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+class CatalogRelationSchema;
+
+/** \addtogroup Catalog
+ *  @{
+ */
+
+/**
+ * @brief A base class that the catalog database implements for both the master
+ *        Catalog, and the CatalogCache in the distributed version.
+ *
+ * @note This class only contains virtual methods related to the relation id and
+ *       CatalogRelationSchema.
+ **/
+class CatalogDatabaseLite {
+ public:
+  /**
+   * @brief Virtual destructor which recursively destroys children.
+   **/
+  virtual ~CatalogDatabaseLite() {
+  }
+
+  /**
+   * @brief Get this database's ID.
+   *
+   * @return This database's ID.
+   **/
+  database_id getID() const {
+    return id_;
+  }
+
+  /**
+   * @brief Check whether a relation with the given id exists.
+   *
+   * @param id The id to check for.
+   * @return Whether the relation exists.
+   **/
+  virtual bool hasRelationWithId(const relation_id id) const = 0;
+
+  /**
+   * @brief Get a relation schema by ID.
+   *
+   * @param id The id to search for.
+   * @return The relation schema with the given ID.
+   **/
+  virtual const CatalogRelationSchema* getRelationSchemaById(const relation_id id) const = 0;
+
+  /**
+   * @brief Drop (delete) a relation by id.
+   *
+   * @param id The ID of the relation to drop.
+   **/
+  virtual void dropRelationById(const relation_id id) = 0;
+
+ protected:
+  /**
+   * @brief Create a new database.
+   *
+   * @param parent The catalog this database belongs to.
+   * @param name This database's name.
+   * @param id This database's ID (defaults to -1, which means invalid/unset).
+   **/
+  explicit CatalogDatabaseLite(const database_id id = -1)
+      : id_(id) {
+  }
+
+  // The database id in Catalog.
+  database_id id_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(CatalogDatabaseLite);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_CATALOG_CATALOG_DATABASE_LITE_HPP_

--- a/catalog/CatalogDatabaseLite.hpp
+++ b/catalog/CatalogDatabaseLite.hpp
@@ -66,7 +66,7 @@ class CatalogDatabaseLite {
    * @param id The id to search for.
    * @return The relation schema with the given ID.
    **/
-  virtual const CatalogRelationSchema* getRelationSchemaById(const relation_id id) const = 0;
+  virtual const CatalogRelationSchema& getRelationSchemaById(const relation_id id) const = 0;
 
   /**
    * @brief Drop (delete) a relation by id.

--- a/expressions/CMakeLists.txt
+++ b/expressions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ add_library(quickstep_expressions_Expressions_proto
 
 target_link_libraries(quickstep_expressions_ExpressionFactories
                       glog
-                      quickstep_catalog_CatalogDatabase
-                      quickstep_catalog_CatalogRelation
+                      quickstep_catalog_CatalogDatabaseLite
+                      quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_predicate_ComparisonPredicate

--- a/expressions/ExpressionFactories.cpp
+++ b/expressions/ExpressionFactories.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
 #include <utility>
 #include <vector>
 
-#include "catalog/CatalogDatabase.hpp"
-#include "catalog/CatalogRelation.hpp"
+#include "catalog/CatalogDatabaseLite.hpp"
+#include "catalog/CatalogRelationSchema.hpp"
 #include "catalog/CatalogTypedefs.hpp"
 #include "expressions/Expressions.pb.h"
 #include "expressions/predicate/ComparisonPredicate.hpp"
@@ -52,7 +52,7 @@ namespace quickstep {
 class Type;
 
 Predicate* PredicateFactory::ReconstructFromProto(const serialization::Predicate &proto,
-                                                  const CatalogDatabase &database) {
+                                                  const CatalogDatabaseLite &database) {
   DCHECK(ProtoIsValid(proto, database))
       << "Attempted to create Predicate from an invalid proto description:\n"
       << proto.DebugString();
@@ -98,7 +98,7 @@ Predicate* PredicateFactory::ReconstructFromProto(const serialization::Predicate
 }
 
 bool PredicateFactory::ProtoIsValid(const serialization::Predicate &proto,
-                                    const CatalogDatabase &database) {
+                                    const CatalogDatabaseLite &database) {
   // Check that proto is fully initialized.
   if (!proto.IsInitialized()) {
     return false;
@@ -147,7 +147,7 @@ bool PredicateFactory::ProtoIsValid(const serialization::Predicate &proto,
 }
 
 Scalar* ScalarFactory::ReconstructFromProto(const serialization::Scalar &proto,
-                                            const CatalogDatabase &database) {
+                                            const CatalogDatabaseLite &database) {
   DCHECK(ProtoIsValid(proto, database))
       << "Attempted to create Scalar from an invalid proto description:\n"
       << proto.DebugString();
@@ -161,7 +161,7 @@ Scalar* ScalarFactory::ReconstructFromProto(const serialization::Scalar &proto,
       const relation_id rel_id = proto.GetExtension(serialization::ScalarAttribute::relation_id);
 
       DCHECK(database.hasRelationWithId(rel_id));
-      return new ScalarAttribute(*database.getRelationById(rel_id)->getAttributeById(
+      return new ScalarAttribute(*database.getRelationSchemaById(rel_id).getAttributeById(
           proto.GetExtension(serialization::ScalarAttribute::attribute_id)));
     }
     case serialization::Scalar::UNARY_EXPRESSION: {
@@ -214,7 +214,7 @@ Scalar* ScalarFactory::ReconstructFromProto(const serialization::Scalar &proto,
 }
 
 bool ScalarFactory::ProtoIsValid(const serialization::Scalar &proto,
-                                 const CatalogDatabase &database) {
+                                 const CatalogDatabaseLite &database) {
   // Check that proto is fully initialized.
   if (!proto.IsInitialized()) {
     return false;
@@ -235,7 +235,7 @@ bool ScalarFactory::ProtoIsValid(const serialization::Scalar &proto,
         const attribute_id attr_id = proto.GetExtension(serialization::ScalarAttribute::attribute_id);
 
         return database.hasRelationWithId(rel_id)
-               && database.getRelationById(rel_id)->hasAttributeWithId(attr_id);
+               && database.getRelationSchemaById(rel_id).hasAttributeWithId(attr_id);
       }
       break;
     }

--- a/expressions/ExpressionFactories.hpp
+++ b/expressions/ExpressionFactories.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 namespace quickstep {
 
-class CatalogDatabase;
+class CatalogDatabaseLite;
 class Predicate;
 class Scalar;
 
@@ -51,7 +51,7 @@ class PredicateFactory {
    * @return A new Predicate reconstructed from the supplied Protocol Buffer.
    **/
   static Predicate* ReconstructFromProto(const serialization::Predicate &proto,
-                                         const CatalogDatabase &database);
+                                         const CatalogDatabaseLite &database);
 
   /**
    * @brief Check whether a serialization::Predicate is fully-formed and
@@ -64,7 +64,7 @@ class PredicateFactory {
    * @return Whether proto is fully-formed and valid.
    **/
   static bool ProtoIsValid(const serialization::Predicate &proto,
-                           const CatalogDatabase &database);
+                           const CatalogDatabaseLite &database);
 
  private:
   // Undefined default constructor. Class is all-static and should not be
@@ -89,7 +89,7 @@ class ScalarFactory {
    * @return A new Scalar reconstructed from the supplied Protocol Buffer.
    **/
   static Scalar* ReconstructFromProto(const serialization::Scalar &proto,
-                                      const CatalogDatabase &database);
+                                      const CatalogDatabaseLite &database);
 
   /**
    * @brief Check whether a serialization::Scalar is fully-formed and
@@ -102,7 +102,7 @@ class ScalarFactory {
    * @return Whether proto is fully-formed and valid.
    **/
   static bool ProtoIsValid(const serialization::Scalar &proto,
-                           const CatalogDatabase &database);
+                           const CatalogDatabaseLite &database);
 
  private:
   // Undefined default constructor. Class is all-static and should not be

--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -70,20 +70,22 @@ target_link_libraries(quickstep_queryexecution_ForemanLite
                       tmb)
 target_link_libraries(quickstep_queryexecution_QueryContext
                       glog
-                      quickstep_catalog_CatalogDatabase
-                      quickstep_catalog_CatalogRelation
+                      quickstep_catalog_CatalogDatabaseLite
+                      quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_ExpressionFactories
                       quickstep_expressions_predicate_Predicate
                       quickstep_expressions_scalar_Scalar
                       quickstep_expressions_tablegenerator_GeneratorFunctionFactory
                       quickstep_expressions_tablegenerator_GeneratorFunctionHandle
+                      quickstep_expressions_tablegenerator_GeneratorFunction_proto
                       quickstep_queryexecution_QueryContext_proto
                       quickstep_storage_AggregationOperationState
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableFactory
                       quickstep_storage_InsertDestination
                       quickstep_storage_InsertDestination_proto
+                      quickstep_types_TypedValue
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros
                       quickstep_utility_SortConfiguration)

--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -208,7 +208,8 @@ void Foreman::run() {
 
         const block_id block = proto.block_id();
 
-        CatalogRelation *relation = catalog_database_->getRelationByIdMutable(proto.relation_id());
+        CatalogRelation *relation =
+            static_cast<CatalogDatabase*>(catalog_database_)->getRelationByIdMutable(proto.relation_id());
         relation->addBlock(block);
 
         if (proto.has_partition_id()) {

--- a/query_execution/Foreman.hpp
+++ b/query_execution/Foreman.hpp
@@ -43,7 +43,7 @@
 
 namespace quickstep {
 
-class CatalogDatabase;
+class CatalogDatabaseLite;
 class StorageManager;
 class WorkerDirectory;
 
@@ -73,7 +73,7 @@ class Foreman final : public ForemanLite {
    *       around on different CPUs by the OS.
   **/
   Foreman(tmb::MessageBus *bus,
-          CatalogDatabase *catalog_database,
+          CatalogDatabaseLite *catalog_database,
           StorageManager *storage_manager,
           const int cpu_id = -1,
           const int num_numa_nodes = 1)
@@ -449,7 +449,7 @@ class Foreman final : public ForemanLite {
    **/
   void getRebuildWorkOrders(const dag_node_index index, WorkOrdersContainer *container);
 
-  CatalogDatabase *catalog_database_;
+  CatalogDatabaseLite *catalog_database_;
   StorageManager *storage_manager_;
 
   DAG<RelationalOperator, bool> *query_dag_;

--- a/query_execution/QueryContext.cpp
+++ b/query_execution/QueryContext.cpp
@@ -1,4 +1,3 @@
-
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015-2016 Pivotal Software, Inc.
@@ -23,10 +22,11 @@
 #include <utility>
 #include <vector>
 
-#include "catalog/CatalogDatabase.hpp"
-#include "catalog/CatalogRelation.hpp"
+#include "catalog/CatalogDatabaseLite.hpp"
+#include "catalog/CatalogRelationSchema.hpp"
 #include "catalog/CatalogTypedefs.hpp"
 #include "expressions/ExpressionFactories.hpp"
+#include "expressions/table_generator/GeneratorFunction.pb.h"
 #include "expressions/table_generator/GeneratorFunctionFactory.hpp"
 #include "expressions/table_generator/GeneratorFunctionHandle.hpp"
 #include "query_execution/QueryContext.pb.h"
@@ -35,6 +35,7 @@
 #include "storage/HashTableFactory.hpp"
 #include "storage/InsertDestination.hpp"
 #include "storage/InsertDestination.pb.h"
+#include "types/TypedValue.hpp"
 #include "types/containers/Tuple.hpp"
 #include "utility/SortConfiguration.hpp"
 
@@ -49,7 +50,7 @@ using std::vector;
 namespace quickstep {
 
 QueryContext::QueryContext(const serialization::QueryContext &proto,
-                           CatalogDatabase *database,
+                           CatalogDatabaseLite *database,
                            StorageManager *storage_manager,
                            const tmb::client_id foreman_client_id,
                            tmb::MessageBus *bus) {
@@ -82,7 +83,7 @@ QueryContext::QueryContext(const serialization::QueryContext &proto,
     const serialization::InsertDestination &insert_destination_proto = proto.insert_destinations(i);
     insert_destinations_.emplace_back(
         InsertDestination::ReconstructFromProto(insert_destination_proto,
-                                                *database->getRelationByIdMutable(
+                                                database->getRelationSchemaById(
                                                     insert_destination_proto.relation_id()),
                                                 storage_manager,
                                                 foreman_client_id,
@@ -134,7 +135,7 @@ QueryContext::QueryContext(const serialization::QueryContext &proto,
 }
 
 bool QueryContext::ProtoIsValid(const serialization::QueryContext &proto,
-                                const CatalogDatabase &database) {
+                                const CatalogDatabaseLite &database) {
   for (int i = 0; i < proto.aggregation_states_size(); ++i) {
     if (!AggregationOperationState::ProtoIsValid(proto.aggregation_states(i), database)) {
       return false;
@@ -164,7 +165,7 @@ bool QueryContext::ProtoIsValid(const serialization::QueryContext &proto,
 
     if (!database.hasRelationWithId(rel_id) ||
         !InsertDestination::ProtoIsValid(insert_destination_proto,
-                                         *database.getRelationById(rel_id))) {
+                                         database.getRelationSchemaById(rel_id))) {
       return false;
     }
   }
@@ -203,13 +204,13 @@ bool QueryContext::ProtoIsValid(const serialization::QueryContext &proto,
     if (!database.hasRelationWithId(rel_id)) {
       return false;
     }
-    const CatalogRelation *rel = database.getRelationById(rel_id);
+    const CatalogRelationSchema &rel = database.getRelationSchemaById(rel_id);
 
     for (int j = 0; j < update_group_proto.update_assignments_size(); ++j) {
       const serialization::QueryContext::UpdateGroup::UpdateAssignment &update_assignment_proto =
           update_group_proto.update_assignments(j);
 
-      if (!rel->hasAttributeWithId(update_assignment_proto.attribute_id()) ||
+      if (!rel.hasAttributeWithId(update_assignment_proto.attribute_id()) ||
           !ScalarFactory::ProtoIsValid(update_assignment_proto.scalar(), database)) {
         return false;
       }

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -43,7 +43,7 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
+class CatalogDatabaseLite;
 class StorageManager;
 
 namespace serialization { class QueryContext; }
@@ -125,7 +125,7 @@ class QueryContext {
    * @param bus A pointer to the TMB.
    **/
   QueryContext(const serialization::QueryContext &proto,
-               CatalogDatabase *database,
+               CatalogDatabaseLite *database,
                StorageManager *storage_manager,
                const tmb::client_id foreman_client_id,
                tmb::MessageBus *bus);
@@ -143,7 +143,7 @@ class QueryContext {
    * @return Whether proto is fully-formed and valid.
    **/
   static bool ProtoIsValid(const serialization::QueryContext &proto,
-                           const CatalogDatabase &database);
+                           const CatalogDatabaseLite &database);
 
   /**
    * @brief Get the AggregationOperationState.

--- a/storage/AggregationOperationState.cpp
+++ b/storage/AggregationOperationState.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include "catalog/CatalogDatabase.hpp"
+#include "catalog/CatalogDatabaseLite.hpp"
 #include "catalog/CatalogRelationSchema.hpp"
 #include "catalog/CatalogTypedefs.hpp"
 #include "expressions/ExpressionFactories.hpp"
@@ -137,7 +137,7 @@ AggregationOperationState::AggregationOperationState(
 
 AggregationOperationState* AggregationOperationState::ReconstructFromProto(
     const serialization::AggregationOperationState &proto,
-    const CatalogDatabase &database,
+    const CatalogDatabaseLite &database,
     StorageManager *storage_manager) {
   DCHECK(ProtoIsValid(proto, database));
 
@@ -175,7 +175,7 @@ AggregationOperationState* AggregationOperationState::ReconstructFromProto(
                                                database));
   }
 
-  return new AggregationOperationState(*database.getRelationById(proto.relation_id()),
+  return new AggregationOperationState(database.getRelationSchemaById(proto.relation_id()),
                                        aggregate_functions,
                                        std::move(arguments),
                                        std::move(group_by_expressions),
@@ -186,7 +186,7 @@ AggregationOperationState* AggregationOperationState::ReconstructFromProto(
 }
 
 bool AggregationOperationState::ProtoIsValid(const serialization::AggregationOperationState &proto,
-                                             const CatalogDatabase &database) {
+                                             const CatalogDatabaseLite &database) {
   if (!proto.IsInitialized() ||
       !database.hasRelationWithId(proto.relation_id()) ||
       (proto.aggregates_size() <= 0)) {

--- a/storage/AggregationOperationState.hpp
+++ b/storage/AggregationOperationState.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
 namespace quickstep {
 
 class AggregateFunction;
-class CatalogDatabase;
+class CatalogDatabaseLite;
 class CatalogRelationSchema;
 class InsertDestination;
 class StorageManager;
@@ -79,7 +79,7 @@ class AggregationOperationState {
    * @param arguments For each entry in aggregate_functions, a corresponding
    *        list of argument expressions to that aggregate. This is moved-from,
    *        with AggregationOperationState taking ownership.
-   * @param group_by A list of expressions to compute the GROUP BY values. If 
+   * @param group_by A list of expressions to compute the GROUP BY values. If
    *        empty, no grouping is used. This is moved-from, with
    *        AggregationOperationState taking ownership.
    * @param predicate The predicate to be applied prior to aggregation. nullptr
@@ -120,7 +120,7 @@ class AggregationOperationState {
    **/
   static AggregationOperationState* ReconstructFromProto(
       const serialization::AggregationOperationState &proto,
-      const CatalogDatabase &database,
+      const CatalogDatabaseLite &database,
       StorageManager *storage_manager);
 
   /**
@@ -134,7 +134,7 @@ class AggregationOperationState {
    * @return Whether proto is fully-formed and valid.
    **/
   static bool ProtoIsValid(const serialization::AggregationOperationState &proto,
-                           const CatalogDatabase &database);
+                           const CatalogDatabaseLite &database);
 
   /**
    * @brief Compute aggregates on the tuples of the given storage block,

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -220,7 +220,7 @@ add_library(quickstep_storage_ValueAccessorUtil ../empty_src.cpp ValueAccessorUt
 # Link dependencies:
 target_link_libraries(quickstep_storage_AggregationOperationState
                       glog
-                      quickstep_catalog_CatalogDatabase
+                      quickstep_catalog_CatalogDatabaseLite
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_ExpressionFactories
@@ -557,7 +557,7 @@ target_link_libraries(quickstep_storage_IndexSubBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_storage_IndexSubBlockDescriptionFactory                      
+target_link_libraries(quickstep_storage_IndexSubBlockDescriptionFactory
                       quickstep_storage_StorageBlockLayout
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_InsertDestination

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -215,6 +215,7 @@ target_link_libraries(quickstep_utility_SqlError
 target_link_libraries(quickstep_utility_SortConfiguration
                       glog
                       quickstep_expressions_ExpressionFactories
+                      quickstep_expressions_Expressions_proto
                       quickstep_expressions_scalar_Scalar
                       quickstep_utility_PtrVector
                       quickstep_utility_SortConfiguration_proto)

--- a/utility/SortConfiguration.cpp
+++ b/utility/SortConfiguration.cpp
@@ -1,5 +1,5 @@
 /**
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "expressions/ExpressionFactories.hpp"
+#include "expressions/Expressions.pb.h"
 #include "expressions/scalar/Scalar.hpp"
 #include "utility/PtrVector.hpp"
 #include "utility/SortConfiguration.pb.h"
@@ -33,7 +34,7 @@ using std::vector;
 namespace quickstep {
 
 SortConfiguration* SortConfiguration::ReconstructFromProto(const serialization::SortConfiguration &proto,
-                                                           const CatalogDatabase &database) {
+                                                           const CatalogDatabaseLite &database) {
   DCHECK(ProtoIsValid(proto, database));
 
   PtrVector<Scalar> order_by;
@@ -52,7 +53,7 @@ SortConfiguration* SortConfiguration::ReconstructFromProto(const serialization::
 }
 
 bool SortConfiguration::ProtoIsValid(const serialization::SortConfiguration &proto,
-                                     const CatalogDatabase &database) {
+                                     const CatalogDatabaseLite &database) {
   for (int i = 0; i < proto.order_by_list_size(); ++i) {
     const serialization::SortConfiguration::OrderBy &order_by_proto = proto.order_by_list(i);
 

--- a/utility/SortConfiguration.hpp
+++ b/utility/SortConfiguration.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
 namespace quickstep {
 
-class CatalogDatabase;
+class CatalogDatabaseLite;
 
 namespace serialization { class SortConfiguration; }
 
@@ -86,7 +86,7 @@ class SortConfiguration {
    *         Buffer.
    **/
   static SortConfiguration* ReconstructFromProto(const serialization::SortConfiguration &proto,
-                                                 const CatalogDatabase &database);
+                                                 const CatalogDatabaseLite &database);
 
   /**
    * @brief Check whether a serialization::SortConfiguration is fully-formed and
@@ -100,7 +100,7 @@ class SortConfiguration {
    * @return Whether proto is fully-formed and valid.
    **/
   static bool ProtoIsValid(const serialization::SortConfiguration &proto,
-                           const CatalogDatabase &database);
+                           const CatalogDatabaseLite &database);
 
   /**
    * @brief Get the vector of sort ordering for each ORDER BY column.


### PR DESCRIPTION
This PR added the abstraction class called `CatalogDatabaseLite` for the catalog database, so that both the master `CatalogDatabase` and `CatalogDatabaseCache`, reconstructed by `Shiftboss` in the distributed version could be used to reconstruct `QueryContext` and its elements.

It also has minor fixes for `CatalogDatabase`, including variable alignments, and a bug fix when getting mutable relations by name.

Note that refactoring how `CatalogDatabase` stores `CatalogRelation`s (to avoid holes in the vector after relation deletions, and simplify deserialization) is not included by this PR.