### PR TITLE
Inform InsertDestination of LayoutDescription

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -778,6 +778,8 @@ void ExecutionGenerator::convertCopyFrom(
 
   insert_destination_proto->set_insert_destination_type(S::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(output_relation->getID());
+  insert_destination_proto->mutable_layout()->MergeFrom(
+      output_relation->getDefaultStorageBlockLayout().getDescription());
 
   const vector<block_id> blocks(physical_plan->catalog_relation()->getBlocksSnapshot());
   for (const block_id block : blocks) {
@@ -993,12 +995,13 @@ void ExecutionGenerator::convertInsertTuple(
 
   insert_destination_proto->set_insert_destination_type(S::InsertDestinationType::BLOCK_POOL);
   insert_destination_proto->set_relation_id(input_relation.getID());
+  insert_destination_proto->mutable_layout()->MergeFrom(
+      input_relation.getDefaultStorageBlockLayout().getDescription());
 
   const vector<block_id> blocks(input_relation.getBlocksSnapshot());
   for (const block_id block : blocks) {
     insert_destination_proto->AddExtension(S::BlockPoolInsertDestination::blocks, block);
   }
-
 
   const QueryPlan::DAGNodeIndex insert_operator_index =
       execution_plan_->addRelationalOperator(


### PR DESCRIPTION
From #101 (closed)
>I noticed that BlockProperties were not being correctly instantiated because the associated StorageBlockLayoutDescription proto was not being selected by the InsertDestination.

>This was due to a change in how the InsertDestination was used in #97

**This PR properly hands-off the layout description to the InsertDestination** It changes the ExecutionGeneration to include some extra info in the `InsertDestination` proto.