### PR TITLE
Index creation for Compound Keys

### DIFF
--- a/catalog/Catalog.proto
+++ b/catalog/Catalog.proto
@@ -75,7 +75,7 @@ message NUMAPlacementScheme {
 message IndexScheme {
   message IndexEntry {
     required string index_name = 1;
-    repeated IndexSubBlockDescription index_description = 2;
+    required IndexSubBlockDescription index_description = 2;
   }
   repeated IndexEntry index_entries = 1;
 }

--- a/catalog/tests/Catalog_unittest.cpp
+++ b/catalog/tests/Catalog_unittest.cpp
@@ -535,25 +535,22 @@ TEST_F(CatalogTest, CatalogIndexTest) {
 
   rel->setDefaultStorageBlockLayout(new StorageBlockLayout(*rel, layout_description));
 
-  std::vector<IndexSubBlockDescription> index_descriptions;
   IndexSubBlockDescription index_description;
   index_description.set_sub_block_type(IndexSubBlockDescription::CSB_TREE);
   index_description.add_indexed_attribute_ids(rel->getAttributeByName("attr_idx1")->getID());
-  index_descriptions.emplace_back(index_description);
 
-  EXPECT_TRUE(rel->addIndex("idx1", index_descriptions));
+  EXPECT_TRUE(rel->addIndex("idx1", std::move(index_description)));
   EXPECT_TRUE(rel->hasIndexWithName("idx1"));
   // Adding an index with duplicate name should return false.
-  EXPECT_FALSE(rel->addIndex("idx1", index_descriptions));
+  EXPECT_FALSE(rel->addIndex("idx1", std::move(index_description)));
   // Adding an index of same type with different name on the same attribute should return false.
-  EXPECT_FALSE(rel->addIndex("idx2", index_descriptions));
+  EXPECT_FALSE(rel->addIndex("idx2", std::move(index_description)));
 
-  index_descriptions.clear();
+  index_description.Clear();
   index_description.set_sub_block_type(IndexSubBlockDescription::CSB_TREE);
   index_description.add_indexed_attribute_ids(rel->getAttributeByName("attr_idx2")->getID());
-  index_descriptions.emplace_back(index_description);
 
-  EXPECT_TRUE(rel->addIndex("idx2", index_descriptions));
+  EXPECT_TRUE(rel->addIndex("idx2", std::move(index_description)));
   EXPECT_TRUE(rel->hasIndexWithName("idx2"));
 
   checkCatalogSerialization();

--- a/query_optimizer/tests/execution_generator/Index.test
+++ b/query_optimizer/tests/execution_generator/Index.test
@@ -24,9 +24,19 @@ SELECT * FROM foo3;
 ==
 CREATE INDEX idx2 ON foo3(col1) USING CSBTREE;
 --
-ERROR: The relation foo3 already defines this index on col1
+ERROR: The relation foo3 already defines this index on the given attribute(s).
 ==
 CREATE INDEX idx2 ON foo3(col2) USING CSBTREE;
+SELECT * FROM foo3;
+--
++-----------+-----------+
+|col1       |col2       |
++-----------+-----------+
++-----------+-----------+
+==
+# Compound index creation should succeed, even when
+# separate indices are defined on individual attributes.
+CREATE INDEX idx3 ON foo3(col1, col2) USING CSBTREE;
 SELECT * FROM foo3;
 --
 +-----------+-----------+
@@ -41,7 +51,7 @@ ERROR: Bloom Filter index is not yet implemented (1 : 48)
 ...INDEX bloomIndex ON test(int_col) USING BLOOMFILTER
                                            ^
 ==
-# SMA Index creation is not supported using CREATE INDEX
+# SMA Index creation is not supported using CREATE INDEX.
 CREATE INDEX smaIndex ON test USING SMA
 --
 ERROR: syntax error (1 : 37)

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -90,11 +90,8 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       tmb)
 target_link_libraries(quickstep_relationaloperators_CreateIndexOperator
                       glog
-                      quickstep_catalog_CatalogAttribute
-                      quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
-                      quickstep_relationaloperators_RelationalOperator
-                      quickstep_storage_StorageBlockLayout
+                      quickstep_relationaloperators_RelationalOperator                      
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_utility_Macros
                       tmb)

--- a/relational_operators/CreateIndexOperator.cpp
+++ b/relational_operators/CreateIndexOperator.cpp
@@ -1,6 +1,6 @@
 /**
- *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2016 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,8 +17,7 @@
 
 #include "relational_operators/CreateIndexOperator.hpp"
 
-#include "catalog/CatalogDatabase.hpp"
-#include "catalog/CatalogRelation.hpp"
+#include <utility>
 
 #include "tmb/id_typedefs.h"
 
@@ -33,7 +32,7 @@ bool CreateIndexOperator::getAllWorkOrders(WorkOrdersContainer *container,
 }
 
 void CreateIndexOperator::updateCatalogOnCompletion() {
-  relation_->addIndex(index_name_, index_descriptions_);
+  relation_->addIndex(index_name_, std::move(index_description_));
 }
 
 }  // namespace quickstep

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -1,6 +1,6 @@
 /**
- *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2016 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -19,13 +19,9 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_CREATE_INDEX_OPERATOR_HPP_
 
 #include <string>
-#include <vector>
 
-#include "catalog/CatalogAttribute.hpp"
-#include "catalog/CatalogDatabase.hpp"
 #include "catalog/CatalogRelation.hpp"
 #include "relational_operators/RelationalOperator.hpp"
-#include "storage/StorageBlockLayout.hpp"
 #include "storage/StorageBlockLayout.pb.h"
 #include "utility/Macros.hpp"
 
@@ -37,7 +33,6 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
-class CatalogDatabase;
 class CatalogRelation;
 class QueryContext;
 class StorageManager;
@@ -55,19 +50,16 @@ class CreateIndexOperator : public RelationalOperator {
   /**
    * @brief Constructor.
    *
-   * TODO (ssaurabh): Modify the current placeholder implementation to
-   * take an index protobuf message as an input, instead of just name.
-   *
    * @param relation The relation to create index upon.
    * @param index_name The index to create.
-   * @param index_descriptions Set of index_descriptions associated with this index.
+   * @param index_description The index_description associated with this index.
    **/
   CreateIndexOperator(CatalogRelation *relation,
                       const std::string &index_name,
-                      const std::vector<IndexSubBlockDescription> &index_descriptions)
+                      IndexSubBlockDescription &&index_description)  // NOLINT(whitespace/operators)
       : relation_(DCHECK_NOTNULL(relation)),
         index_name_(index_name),
-        index_descriptions_(index_descriptions) {}
+        index_description_(index_description) {}
 
   ~CreateIndexOperator() override {}
 
@@ -85,7 +77,7 @@ class CreateIndexOperator : public RelationalOperator {
  private:
   CatalogRelation *relation_;
   const std::string &index_name_;
-  const std::vector<IndexSubBlockDescription> index_descriptions_;
+  IndexSubBlockDescription index_description_;
 
   DISALLOW_COPY_AND_ASSIGN(CreateIndexOperator);
 };


### PR DESCRIPTION
This is a small PR that changes the previous behaviour of CREATE INDEX from creating separate indices on each attribute to now creating an index with compound keys, when multiple attributes are specified. Effectively all the following SQL statements will succeed without error now:

```
CREATE TABLE foo (col1 INT, col2 INT);
CREATE INDEX csb_1 ON foo(col1) USING CSBTREE;
CREATE INDEX csb_2 ON foo(col2) USING CSBTREE;
CREATE INDEX csb_compound ON foo(col1, col2) USING CSBTREE;

```
The last SQL statement creates a CSB index with compound key made up of two attributes. 

Please also note that the following statement will now have the effect of creating a single index with a compound key made up of all attributes in the table:

`CREATE INDEX csb_compound ON foo USING CSBTREE;`

