### PR TITLE
Allows GROUP BY without aggregate expressions

### DIFF
--- a/expressions/aggregation/AggregationHandleDistinct.cpp
+++ b/expressions/aggregation/AggregationHandleDistinct.cpp
@@ -1,0 +1,80 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "expressions/aggregation/AggregationHandleDistinct.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+#include <utility>
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "storage/HashTable.hpp"
+#include "storage/HashTableFactory.hpp"
+
+#include "types/TypedValue.hpp"
+
+namespace quickstep {
+
+class ColumnVector;
+class StorageManager;
+class Type;
+class ValueAccessor;
+
+AggregationStateHashTableBase* AggregationHandleDistinct::createGroupByHashTable(
+    const HashTableImplType hash_table_impl,
+    const std::vector<const Type*> &group_by_types,
+    const std::size_t estimated_num_groups,
+    StorageManager *storage_manager) const {
+  return AggregationStateHashTableFactory<bool>::CreateResizable(
+      hash_table_impl,
+      group_by_types,
+      estimated_num_groups,
+      storage_manager);
+}
+
+void AggregationHandleDistinct::aggregateValueAccessorIntoHashTable(
+    ValueAccessor *accessor,
+    const std::vector<attribute_id> &argument_ids,
+    const std::vector<attribute_id> &group_by_key_ids,
+    AggregationStateHashTableBase *hash_table) const {
+  DCHECK_EQ(argument_ids.size(), 0u);
+
+  const auto noop_upserter = [](const auto &accessor, const bool *value) -> void {};
+  static_cast<AggregationStateHashTable<bool>*>(hash_table)->upsertValueAccessorCompositeKey(
+      accessor,
+      group_by_key_ids,
+      true,
+      true, /* Initial value */
+      &noop_upserter);
+}
+
+ColumnVector* AggregationHandleDistinct::finalizeHashTable(
+    const AggregationStateHashTableBase &hash_table,
+    std::vector<std::vector<TypedValue>> *group_by_keys) const {
+  DCHECK(group_by_keys->empty());
+
+  const auto keys_retriever = [&group_by_keys](std::vector<TypedValue> &group_by_key,
+                                               const bool &dumb_placeholder) -> void {
+    group_by_keys->emplace_back(std::move(group_by_key));
+  };
+  static_cast<const AggregationStateHashTable<bool>&>(hash_table).forEachCompositeKey(&keys_retriever);
+
+  return nullptr;
+}
+
+}  // namespace quickstep

--- a/expressions/aggregation/AggregationHandleDistinct.hpp
+++ b/expressions/aggregation/AggregationHandleDistinct.hpp
@@ -1,0 +1,106 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_EXPRESSIONS_AGGREGATION_AGGREGATION_HANDLE_DISTINCT_HPP_
+#define QUICKSTEP_EXPRESSIONS_AGGREGATION_AGGREGATION_HANDLE_DISTINCT_HPP_
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationHandle.hpp"
+#include "storage/HashTableBase.hpp"
+#include "types/TypedValue.hpp"
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+class ColumnVector;
+class StorageManager;
+class Type;
+class ValueAccessor;
+
+/** \addtogroup Expressions
+ *  @{
+ */
+
+class AggregationHandleDistinct : public AggregationHandle{
+ public:
+  /**
+   * @brief Constructor.
+   **/
+  AggregationHandleDistinct() {
+  }
+
+  AggregationState* createInitialState() const override {
+    LOG(FATAL) << "AggregationHandleDistinct does not support createInitialState().";
+  }
+
+  AggregationState* accumulateNullary(const std::size_t num_tuples) const override {
+    LOG(FATAL) << "AggregationHandleDistinct does not support accumulateNullary().";
+  }
+
+  AggregationState* accumulateColumnVectors(
+      const std::vector<std::unique_ptr<ColumnVector>> &column_vectors) const override {
+    LOG(FATAL) << "AggregationHandleDistinct does not support accumulateColumnVectors().";
+  }
+
+#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
+  AggregationState* accumulateValueAccessor(
+      ValueAccessor *accessor,
+      const std::vector<attribute_id> &accessor_ids) const override {
+    LOG(FATAL) << "AggregationHandleDistinct does not support accumulateValueAccessor().";
+  }
+#endif
+
+  void mergeStates(const AggregationState &source,
+                   AggregationState *destination) const override {
+    LOG(FATAL) << "AggregationHandleDistinct does not support mergeStates().";
+  }
+
+  TypedValue finalize(const AggregationState &state) const override {
+    LOG(FATAL) << "AggregationHandleDistinct does not support finalize().";
+  }
+
+  AggregationStateHashTableBase* createGroupByHashTable(
+      const HashTableImplType hash_table_impl,
+      const std::vector<const Type*> &group_by_types,
+      const std::size_t estimated_num_groups,
+      StorageManager *storage_manager) const override;
+
+  void aggregateValueAccessorIntoHashTable(
+      ValueAccessor *accessor,
+      const std::vector<attribute_id> &argument_ids,
+      const std::vector<attribute_id> &group_by_key_ids,
+      AggregationStateHashTableBase *hash_table) const override;
+
+  ColumnVector* finalizeHashTable(
+      const AggregationStateHashTableBase &hash_table,
+      std::vector<std::vector<TypedValue>> *group_by_keys) const override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(AggregationHandleDistinct);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_EXPRESSIONS_AGGREGATION_AGGREGATION_HANDLE_DISTINCT_HPP_

--- a/expressions/aggregation/CMakeLists.txt
+++ b/expressions/aggregation/CMakeLists.txt
@@ -50,6 +50,9 @@ add_library(quickstep_expressions_aggregation_AggregationHandleAvg
 add_library(quickstep_expressions_aggregation_AggregationHandleCount
             AggregationHandleCount.cpp
             AggregationHandleCount.hpp)
+add_library(quickstep_expressions_aggregation_AggregationHandleDistinct
+            AggregationHandleDistinct.cpp
+            AggregationHandleDistinct.hpp)
 add_library(quickstep_expressions_aggregation_AggregationHandleMax
             AggregationHandleMax.cpp
             AggregationHandleMax.hpp)
@@ -172,6 +175,15 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleCount
                       quickstep_types_containers_ColumnVector
                       quickstep_types_containers_ColumnVectorUtil
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_expressions_aggregation_AggregationHandleDistinct
+                      glog
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationHandle
+                      quickstep_storage_HashTable
+                      quickstep_storage_HashTableBase
+                      quickstep_storage_HashTableFactory
+                      quickstep_types_TypedValue
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleMax
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -233,6 +245,7 @@ target_link_libraries(quickstep_expressions_aggregation
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_expressions_aggregation_AggregationHandleAvg
                       quickstep_expressions_aggregation_AggregationHandleCount
+                      quickstep_expressions_aggregation_AggregationHandleDistinct
                       quickstep_expressions_aggregation_AggregationHandleMax
                       quickstep_expressions_aggregation_AggregationHandleMin
                       quickstep_expressions_aggregation_AggregationHandleSum

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -1099,13 +1099,6 @@ void ExecutionGenerator::convertUpdateTable(
 
 void ExecutionGenerator::convertAggregate(
     const P::AggregatePtr &physical_plan) {
-  // TODO(quickstep-team): The AggregationOperator and FinalizeAggregationOperator
-  //                       should be able to handle GROUP BY without aggregate expressions,
-  //                       or we may implement a DISTINCT operator.
-  if (physical_plan->aggregate_expressions().empty()) {
-    THROW_SQL_ERROR() << "GROUP BY without any aggregate expression is not supported yet";
-  }
-
   // Create aggr state proto.
   const QueryContext::aggregation_state_id aggr_state_index =
       query_context_proto_->aggregation_states_size();

--- a/query_optimizer/tests/execution_generator/Select.test
+++ b/query_optimizer/tests/execution_generator/Select.test
@@ -476,7 +476,32 @@ SELECT int_col
 FROM test
 GROUP BY int_col;
 --
-ERROR: GROUP BY without any aggregate expression is not supported yet
++-----------+
+|int_col    |
++-----------+
+|          2|
+|          4|
+|          6|
+|          8|
+|         12|
+|         14|
+|         16|
+|         18|
+|         22|
+|         24|
+|        -23|
+|        -21|
+|        -19|
+|        -17|
+|        -15|
+|        -13|
+|        -11|
+|         -9|
+|         -7|
+|         -5|
+|         -3|
+|         -1|
++-----------+
 ==
 
 SELECT COUNT(*),

--- a/storage/AggregationOperationState.cpp
+++ b/storage/AggregationOperationState.cpp
@@ -32,6 +32,7 @@
 #include "expressions/aggregation/AggregateFunction.hpp"
 #include "expressions/aggregation/AggregateFunctionFactory.hpp"
 #include "expressions/aggregation/AggregationHandle.hpp"
+#include "expressions/aggregation/AggregationHandleDistinct.hpp"
 #include "expressions/aggregation/AggregationID.hpp"
 #include "expressions/predicate/Predicate.hpp"
 #include "expressions/scalar/Scalar.hpp"
@@ -68,9 +69,7 @@ AggregationOperationState::AggregationOperationState(
       group_by_list_(std::move(group_by)),
       arguments_(std::move(arguments)),
       storage_manager_(storage_manager) {
-  // Sanity checks: at least one aggregate is specified, and each aggregate has
-  // a corresponding list of arguments.
-  DCHECK(!aggregate_functions.empty());
+  // Sanity checks: each aggregate has a corresponding list of arguments.
   DCHECK(aggregate_functions.size() == arguments_.size());
 
   // Get the types of GROUP BY expressions for creating HashTables below.
@@ -79,58 +78,73 @@ AggregationOperationState::AggregationOperationState(
     group_by_types.emplace_back(&group_by_element->getType());
   }
 
-  // Set up each individual aggregate in this operation.
-  std::vector<const AggregateFunction*>::const_iterator agg_func_it
-      = aggregate_functions.begin();
-  std::vector<std::vector<std::unique_ptr<const Scalar>>>::const_iterator args_it
-      = arguments_.begin();
-  for (; agg_func_it != aggregate_functions.end(); ++agg_func_it, ++args_it) {
-    // Get the Types of this aggregate's arguments so that we can create an
-    // AggregationHandle.
-    std::vector<const Type*> argument_types;
-    for (const std::unique_ptr<const Scalar> &argument : *args_it) {
-      argument_types.emplace_back(&argument->getType());
-    }
+  if (aggregate_functions.size() == 0) {
+    // If there is no aggregation function, then it is a distinctify operation
+    // on the group-by expressions.
+    DCHECK_GT(group_by_list_.size(), 0u);
 
-    // Sanity checks: aggregate function exists and can apply to the specified
-    // arguments.
-    DCHECK(*agg_func_it != nullptr);
-    DCHECK((*agg_func_it)->canApplyToTypes(argument_types));
+    handles_.emplace_back(new AggregationHandleDistinct());
+    arguments_.push_back({});
 
-    // Have the AggregateFunction create an AggregationHandle that we can use
-    // to do actual aggregate computation.
-    handles_.emplace_back((*agg_func_it)->createHandle(argument_types));
-
-    if (!group_by_list_.empty()) {
-      // Aggregation with GROUP BY: create a HashTable for per-group states.
-      group_by_hashtables_.emplace_back(handles_.back()->createGroupByHashTable(
-          hash_table_impl_type,
-          group_by_types,
-          estimated_num_entries,
-          storage_manager_));
-    } else {
-      // Aggregation without GROUP BY: create a single global state.
-      single_states_.emplace_back(handles_.back()->createInitialState());
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-      // See if all of this aggregate's arguments are attributes in the input
-      // relation. If so, remember the attribute IDs so that we can do copy
-      // elision when actually performing the aggregation.
-      std::vector<attribute_id> local_arguments_as_attributes;
-      local_arguments_as_attributes.reserve(args_it->size());
+    group_by_hashtables_.emplace_back(handles_.back()->createGroupByHashTable(
+        hash_table_impl_type,
+        group_by_types,
+        estimated_num_entries,
+        storage_manager_));
+  } else {
+    // Set up each individual aggregate in this operation.
+    std::vector<const AggregateFunction*>::const_iterator agg_func_it
+        = aggregate_functions.begin();
+    std::vector<std::vector<std::unique_ptr<const Scalar>>>::const_iterator args_it
+        = arguments_.begin();
+    for (; agg_func_it != aggregate_functions.end(); ++agg_func_it, ++args_it) {
+      // Get the Types of this aggregate's arguments so that we can create an
+      // AggregationHandle.
+      std::vector<const Type*> argument_types;
       for (const std::unique_ptr<const Scalar> &argument : *args_it) {
-        const attribute_id argument_id = argument->getAttributeIdForValueAccessor();
-        if (argument_id == -1) {
-          local_arguments_as_attributes.clear();
-          break;
-        } else {
-          DCHECK_EQ(input_relation_.getID(), argument->getRelationIdForValueAccessor());
-          local_arguments_as_attributes.push_back(argument_id);
-        }
+        argument_types.emplace_back(&argument->getType());
       }
 
-      arguments_as_attributes_.emplace_back(std::move(local_arguments_as_attributes));
+      // Sanity checks: aggregate function exists and can apply to the specified
+      // arguments.
+      DCHECK(*agg_func_it != nullptr);
+      DCHECK((*agg_func_it)->canApplyToTypes(argument_types));
+
+      // Have the AggregateFunction create an AggregationHandle that we can use
+      // to do actual aggregate computation.
+      handles_.emplace_back((*agg_func_it)->createHandle(argument_types));
+
+      if (!group_by_list_.empty()) {
+        // Aggregation with GROUP BY: create a HashTable for per-group states.
+        group_by_hashtables_.emplace_back(handles_.back()->createGroupByHashTable(
+            hash_table_impl_type,
+            group_by_types,
+            estimated_num_entries,
+            storage_manager_));
+      } else {
+        // Aggregation without GROUP BY: create a single global state.
+        single_states_.emplace_back(handles_.back()->createInitialState());
+
+#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
+        // See if all of this aggregate's arguments are attributes in the input
+        // relation. If so, remember the attribute IDs so that we can do copy
+        // elision when actually performing the aggregation.
+        std::vector<attribute_id> local_arguments_as_attributes;
+        local_arguments_as_attributes.reserve(args_it->size());
+        for (const std::unique_ptr<const Scalar> &argument : *args_it) {
+          const attribute_id argument_id = argument->getAttributeIdForValueAccessor();
+          if (argument_id == -1) {
+            local_arguments_as_attributes.clear();
+            break;
+          } else {
+            DCHECK_EQ(input_relation_.getID(), argument->getRelationIdForValueAccessor());
+            local_arguments_as_attributes.push_back(argument_id);
+          }
+        }
+
+        arguments_as_attributes_.emplace_back(std::move(local_arguments_as_attributes));
 #endif
+      }
     }
   }
 }
@@ -189,7 +203,7 @@ bool AggregationOperationState::ProtoIsValid(const serialization::AggregationOpe
                                              const CatalogDatabaseLite &database) {
   if (!proto.IsInitialized() ||
       !database.hasRelationWithId(proto.relation_id()) ||
-      (proto.aggregates_size() <= 0)) {
+      (proto.aggregates_size() < 0)) {
     return false;
   }
 
@@ -349,9 +363,12 @@ void AggregationOperationState::finalizeHashTable(InsertDestination *output_dest
   for (std::size_t agg_idx = 0;
        agg_idx < handles_.size();
        ++agg_idx) {
-    final_values.emplace_back(
+    ColumnVector* col =
         handles_[agg_idx]->finalizeHashTable(*group_by_hashtables_[agg_idx],
-                                             &group_by_keys));
+                                             &group_by_keys);
+    if (col != nullptr) {
+      final_values.emplace_back(col);
+    }
   }
 
   // Reorganize 'group_by_keys' in column-major order so that we can make a

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -228,6 +228,7 @@ target_link_libraries(quickstep_storage_AggregationOperationState
                       quickstep_expressions_aggregation_AggregateFunction
                       quickstep_expressions_aggregation_AggregateFunctionFactory
                       quickstep_expressions_aggregation_AggregationHandle
+                      quickstep_expressions_aggregation_AggregationHandleDistinct
                       quickstep_expressions_aggregation_AggregationID
                       quickstep_expressions_predicate_Predicate
                       quickstep_expressions_scalar_Scalar

--- a/storage/tests/AggregationOperationState_unittest.cpp
+++ b/storage/tests/AggregationOperationState_unittest.cpp
@@ -58,11 +58,11 @@ TEST_F(AggregationOperationStateProtoTest, InvalidRelationIdTest) {
   EXPECT_FALSE(AggregationOperationState::ProtoIsValid(proto, *database_.get()));
 }
 
-TEST_F(AggregationOperationStateProtoTest, InvalidAggregateSizeTest) {
+TEST_F(AggregationOperationStateProtoTest, ZeroAggregateSizeTest) {
   serialization::AggregationOperationState proto;
   proto.set_relation_id(rel_id_);
   proto.set_estimated_num_entries(0);
-  EXPECT_FALSE(AggregationOperationState::ProtoIsValid(proto, *database_.get()));
+  EXPECT_TRUE(AggregationOperationState::ProtoIsValid(proto, *database_.get()));
 }
 
 }  // namespace quickstep


### PR DESCRIPTION
This PR allows `GROUP BY` without aggregate expressions in a query, e.g.
```
SELECT x, y + z
FROM some_relation
GROUP BY x, y, z;
```

It is a pre-PR for the distinct aggregation feature.
Tests will be added shortly after.