### PR TITLE
Added the query id in QueryHandle.

### DIFF
--- a/query_optimizer/QueryHandle.hpp
+++ b/query_optimizer/QueryHandle.hpp
@@ -40,12 +40,24 @@ class QueryHandle {
  public:
   /**
    * @brief Constructor.
+   *
+   * @param The given query id.
    */
-  QueryHandle()
-      : query_plan_(new QueryPlan()),
+  explicit QueryHandle(const std::size_t query_id)
+      : query_id_(query_id),
+        query_plan_(new QueryPlan()),
         query_result_relation_(nullptr) {}
 
   ~QueryHandle() {}
+
+  /**
+   * @brief Get the query id.
+   *
+   * @return The query id.
+   */
+  std::size_t query_id() const {
+    return query_id_;
+  }
 
   /**
    * @return The mutable query plan.
@@ -83,6 +95,8 @@ class QueryHandle {
   }
 
  private:
+  const std::size_t query_id_;
+
   std::unique_ptr<QueryPlan> query_plan_;
 
   serialization::QueryContext query_context_proto_;

--- a/query_optimizer/QueryProcessor.cpp
+++ b/query_optimizer/QueryProcessor.cpp
@@ -37,7 +37,7 @@ using std::ofstream;
 namespace quickstep {
 
 QueryHandle* QueryProcessor::generateQueryHandle(const ParseStatement &statement) {
-  std::unique_ptr<QueryHandle> query_handle(new QueryHandle());
+  std::unique_ptr<QueryHandle> query_handle(new QueryHandle(query_id_));
 
   optimizer::Optimizer optimizer(query_id_, getDefaultDatabase(), storage_manager_.get());
   optimizer.generateQueryHandle(statement, query_handle.get());

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
@@ -80,7 +80,7 @@ void ExecutionGeneratorTestRunner::runTestCase(
     } else {
       std::printf("%s\n", result.parsed_statement->toString().c_str());
       try {
-        QueryHandle query_handle;
+        QueryHandle query_handle(optimizer_context.query_id());
         LogicalGenerator logical_generator(&optimizer_context);
         PhysicalGenerator physical_generator;
         ExecutionGenerator execution_generator(&optimizer_context,


### PR DESCRIPTION
This small PR adds the query id in `QueryHandle`, which will be used to detect different queries once supporting concurrent queries.