### PR TITLE
Optimized BulkInsert code.

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015-2016 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -609,6 +611,7 @@ target_link_libraries(quickstep_storage_LinearOpenAddressingHashTable
 target_link_libraries(quickstep_storage_PackedRowStoreTupleStorageSubBlock
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelationSchema
+                      quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_predicate_PredicateCost
                       quickstep_storage_PackedRowStoreValueAccessor
                       quickstep_storage_StorageBlockInfo

--- a/storage/PackedRowStoreTupleStorageSubBlock.cpp
+++ b/storage/PackedRowStoreTupleStorageSubBlock.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,6 +25,7 @@
 
 #include "catalog/CatalogAttribute.hpp"
 #include "catalog/CatalogRelationSchema.hpp"
+#include "catalog/CatalogTypedefs.hpp"
 #include "storage/PackedRowStoreValueAccessor.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageBlockLayout.pb.h"
@@ -143,46 +146,66 @@ tuple_id PackedRowStoreTupleStorageSubBlock::bulkInsertTuples(ValueAccessor *acc
   InvokeOnAnyValueAccessor(
       accessor,
       [&](auto *accessor) -> void {  // NOLINT(build/c++11)
+    const std::size_t num_attrs = relation_.size();
+    // We keep track of the total size of a tuple in the case that we do a
+    // 'fast path' insertion later in the code.
+    std::size_t attrs_total_size = 0;
+    // Create a vector containing the maximum sizes of the to-be extracted
+    // attributes.
+    // NOTE(Marc): This is an optimization so that we need not use an iterator
+    // object in the following inner loops.
+    std::vector<std::size_t> attrs_max_size;
+    for (CatalogRelationSchema::const_iterator attr_it = relation_.begin();
+         attr_it != relation_.end();
+         ++attr_it) {
+      attrs_max_size.push_back(attr_it->getType().maximumByteLength());
+      attrs_total_size += attrs_max_size.back();
+    }
+
     if (num_nullable_attrs != 0) {
       while (this->hasSpaceToInsert<true>(1) && accessor->next()) {
-        attribute_id accessor_attr_id = 0;
-        for (CatalogRelationSchema::const_iterator attr_it = relation_.begin();
-             attr_it != relation_.end();
-             ++attr_it) {
-          const std::size_t attr_size = attr_it->getType().maximumByteLength();
-          const int nullable_idx = relation_.getNullableAttributeIndex(
-              attr_it->getID());
-          if (nullable_idx != -1) {
+        for (std::size_t curr_attr = 0; curr_attr < num_attrs; ++curr_attr) {
+          const std::size_t attr_size = attrs_max_size[curr_attr];
+          const attribute_id nullable_idx = relation_.getNullableAttributeIndex(curr_attr);
+          // If this attribute is nullable, check for a returned null value.
+          if (nullable_idx != kInvalidCatalogId) {
             const void *attr_value
-                = accessor->template getUntypedValue<true>(accessor_attr_id);
+                = accessor->template getUntypedValue<true>(curr_attr);
             if (attr_value == nullptr) {
-              null_bitmap_->setBit(header_->num_tuples * num_nullable_attrs + nullable_idx,
-                                   true);
+              null_bitmap_->setBit(
+                  header_->num_tuples * num_nullable_attrs + nullable_idx,
+                  true);
             } else {
               memcpy(dest_addr, attr_value, attr_size);
             }
           } else {
             memcpy(dest_addr,
-                   accessor->template getUntypedValue<false>(accessor_attr_id),
+                   accessor->template getUntypedValue<false>(curr_attr),
                    attr_size);
           }
-          ++accessor_attr_id;
           dest_addr += attr_size;
         }
         ++(header_->num_tuples);
       }
     } else {
+      // If the accessor is from a packed row store, we can optimize the
+      // memcpy by avoiding iterating over each attribute.
+      const bool fast_copy =
+          (accessor->getImplementationType() ==
+              ValueAccessor::Implementation::kCompressedPackedRowStore);
       while (this->hasSpaceToInsert<false>(1) && accessor->next()) {
-        attribute_id accessor_attr_id = 0;
-        for (CatalogRelationSchema::const_iterator attr_it = relation_.begin();
-             attr_it != relation_.end();
-             ++attr_it) {
-          const std::size_t attr_size = attr_it->getType().maximumByteLength();
+        if (fast_copy) {
           memcpy(dest_addr,
-                 accessor->template getUntypedValue<false>(accessor_attr_id),
-                 attr_size);
-          ++accessor_attr_id;
-          dest_addr += attr_size;
+                 accessor->template getUntypedValue<false>(0),
+                 attrs_total_size);
+        } else {
+          for (std::size_t curr_attr = 0; curr_attr < num_attrs; ++curr_attr) {
+            const std::size_t attr_size = attrs_max_size[curr_attr];
+            memcpy(dest_addr,
+                   accessor->template getUntypedValue<false>(curr_attr),
+                   attr_size);
+            dest_addr += attr_size;
+          }
         }
         ++(header_->num_tuples);
       }
@@ -205,45 +228,50 @@ tuple_id PackedRowStoreTupleStorageSubBlock::bulkInsertTuplesWithRemappedAttribu
   InvokeOnAnyValueAccessor(
       accessor,
       [&](auto *accessor) -> void {  // NOLINT(build/c++11)
+    const std::size_t num_attrs = relation_.size();
+    // Create a vector containing the maximum sizes of the to-be extracted
+    // attributes.
+    // NOTE(Marc): This is an optimization so that we need not use an iterator
+    // object in the following inner loops.
+    std::vector<std::size_t> attrs_max_size;
+    for (CatalogRelationSchema::const_iterator attr_it = relation_.begin();
+         attr_it != relation_.end();
+         ++attr_it) {
+      attrs_max_size.push_back(attr_it->getType().maximumByteLength());
+    }
+
     if (num_nullable_attrs != 0) {
       while (this->hasSpaceToInsert<true>(1) && accessor->next()) {
-        std::vector<attribute_id>::const_iterator attribute_map_it = attribute_map.begin();
-        for (CatalogRelationSchema::const_iterator attr_it = relation_.begin();
-             attr_it != relation_.end();
-             ++attr_it) {
-          const std::size_t attr_size = attr_it->getType().maximumByteLength();
-          const int nullable_idx = relation_.getNullableAttributeIndex(
-              attr_it->getID());
-          if (nullable_idx != -1) {
+        for (std::size_t curr_attr = 0; curr_attr < num_attrs; ++curr_attr) {
+          const std::size_t attr_size = attrs_max_size[curr_attr];
+          const attribute_id nullable_idx = relation_.getNullableAttributeIndex(curr_attr);
+          // If this attribute is nullable, check for a returned null value.
+          if (nullable_idx != kInvalidCatalogId) {
             const void *attr_value
-                = accessor->template getUntypedValue<true>(*attribute_map_it);
+                = accessor->template getUntypedValue<true>(attribute_map[curr_attr]);
             if (attr_value == nullptr) {
-              null_bitmap_->setBit(header_->num_tuples * num_nullable_attrs + nullable_idx,
-                                   true);
+              null_bitmap_->setBit(
+                  header_->num_tuples * num_nullable_attrs + nullable_idx,
+                  true);
             } else {
               memcpy(dest_addr, attr_value, attr_size);
             }
           } else {
             memcpy(dest_addr,
-                   accessor->template getUntypedValue<false>(*attribute_map_it),
+                   accessor->template getUntypedValue<false>(attribute_map[curr_attr]),
                    attr_size);
           }
-          ++attribute_map_it;
           dest_addr += attr_size;
         }
         ++(header_->num_tuples);
       }
     } else {
       while (this->hasSpaceToInsert<false>(1) && accessor->next()) {
-        std::vector<attribute_id>::const_iterator attribute_map_it = attribute_map.begin();
-        for (CatalogRelationSchema::const_iterator attr_it = relation_.begin();
-             attr_it != relation_.end();
-             ++attr_it) {
-          const std::size_t attr_size = attr_it->getType().maximumByteLength();
+        for (std::size_t curr_attr = 0; curr_attr < num_attrs; ++curr_attr) {
+          const std::size_t attr_size = attrs_max_size[curr_attr];
           memcpy(dest_addr,
-                 accessor->template getUntypedValue<false>(*attribute_map_it),
+                 accessor->template getUntypedValue<false>(attribute_map[curr_attr]),
                  attr_size);
-          ++attribute_map_it;
           dest_addr += attr_size;
         }
         ++(header_->num_tuples);


### PR DESCRIPTION
This minor change to the `bulkInsert` methods of PackedRowStore improves performance by as much as 70%.

Results can be viewed on [this spreadsheet](https://docs.google.com/spreadsheets/d/1FGJr6HqUVkuVAqJwo9EI0CYKw2-cezt9x03aZlXy_NY/edit?usp=sharing). Click to the tab called **Optimize RowstoreInsert** and the changes here are refered to a 'Opt # 2'.

*Note:* I tried the same technique on SplitRowStore, and the result was a slight slow-down. Therefore, I have not included them in this PR but the changes for SplitRow exist in the branch `Optimize-PackedRowstore`. Results are on the [same spreadsheet](https://docs.google.com/spreadsheets/d/1FGJr6HqUVkuVAqJwo9EI0CYKw2-cezt9x03aZlXy_NY/edit?usp=sharing), under the tab "Insert SplitRow".