### PR TITLE
Initialize a database without worrying about the catalog.pb.bin file

### DIFF
--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -142,7 +142,7 @@ DEFINE_string(worker_affinities, "",
               "the affinity mask of the Quickstep process, which typically "
               "means that they will all be runable on any CPU according to "
               "the kernel's own scheduling policy).");
-DEFINE_bool(initialize_db, true, "If true, initialize a database.");
+DEFINE_bool(initialize_db, false, "If true, initialize a database.");
 }  // namespace quickstep
 
 int main(int argc, char* argv[]) {

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -211,20 +211,20 @@ int main(int argc, char* argv[]) {
     // TODO(jmp): At some point, likely in C++-17, we will just have the
     //            filesystem path, and we can clean this up
 #ifdef QUICKSTEP_OS_WINDOWS
-    std::filesystem::create_directories(quickstep::FLAGS_storage_path);
-    LOG(FATAL) << "Failed when attempting to create the directory: " << quickstep::FLAGS_storage_path << "\n";
+    std::filesystem::create_directories(fixed_storage_path);
+    LOG(FATAL) << "Failed when attempting to create the directory: " << fixed_storage_path << "\n";
     LOG(FATAL) << "Check if the directory already exists. If so, delete it or move it before initializing \n";
 #else
     {
-      string path_name = "mkdir " + quickstep::FLAGS_storage_path;
+      string path_name = "mkdir " + fixed_storage_path;
       if (std::system(path_name.c_str())) {
-        LOG(FATAL) << "Failed when attempting to create the directory: " << quickstep::FLAGS_storage_path << "\n";
+        LOG(FATAL) << "Failed when attempting to create the directory: " << fixed_storage_path << "\n";
       }
     }
 #endif
 
     // Create the defaulty catalog file.
-    std::ofstream catalog_file(quickstep::FLAGS_storage_path + "catalog.pb.bin");
+    std::ofstream catalog_file(fixed_storage_path + "catalog.pb.bin");
     if (!catalog_file.good()) {
       LOG(FATAL) << "ERROR: Unable to open catalog.pb.bin for writing.\n";
     }

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -25,6 +25,14 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <fstream>
+
+// TODO(jmp): If filesystem shows up in C++-17, we can switch to just using that.
+#ifdef QUICKSTEP_OS_WINDOWS
+#include <filesystem>
+#else
+#include <stdlib.h>
+#endif
 
 #include "cli/CliConfig.h"  // For QUICKSTEP_USE_LINENOISE.
 #include "cli/DropRelation.hpp"
@@ -127,13 +135,14 @@ DEFINE_bool(preload_buffer_pool, false,
             "accepting queries (should also set --buffer_pool_slots to be "
             "large enough to accomodate the entire database).");
 DEFINE_string(storage_path, kDefaultStoragePath,
-              "Filesystem path for quickstep database storage.");
+              "Filesystem path to store the Quickstep database.");
 DEFINE_string(worker_affinities, "",
               "A comma-separated list of CPU IDs to pin worker threads to "
               "(leaving this empty will cause all worker threads to inherit "
               "the affinity mask of the Quickstep process, which typically "
               "means that they will all be runable on any CPU according to "
               "the kernel's own scheduling policy).");
+DEFINE_bool(initialize_db, true, "If true, initialize a database.");
 }  // namespace quickstep
 
 int main(int argc, char* argv[]) {
@@ -189,6 +198,48 @@ int main(int argc, char* argv[]) {
 
   string catalog_path(fixed_storage_path);
   catalog_path.append("catalog.pb.bin");
+  if (quickstep::FLAGS_initialize_db) { // Initialize the database
+
+    std::cout << "Initializing the database" << std::endl;
+
+    // TODO(jmp): Refactor to remove the code in catalog/GenerateInitialDefaultCatalog.cpp
+    //            as that may no longer be needed.
+    // TODO(jmp): Refactor the code in this file!
+    LOG(INFO) << "Initializing the database, creating a new catalog file and storage directory\n";
+
+    // Create the directory
+    // TODO(jmp): At some point, likely in C++-17, we will just have the
+    //            filesystem path, and we can clean this up
+#ifdef QUICKSTEP_OS_WINDOWS
+    std::filesystem::create_directories(quickstep::FLAGS_storage_path);
+    LOG(FATAL) << "Failed when attempting to create the directory: " << quickstep::FLAGS_storage_path << "\n";
+    LOG(FATAL) << "Check if the directory already exists. If so, delete it or move it before initializing \n";
+#else
+    {
+      string path_name = "mkdir " + quickstep::FLAGS_storage_path;
+      if (std::system(path_name.c_str())) {
+        LOG(FATAL) << "Failed when attempting to create the directory: " << quickstep::FLAGS_storage_path << "\n";
+      }
+    }
+#endif
+
+    // Create the defaulty catalog file.
+    std::ofstream catalog_file(quickstep::FLAGS_storage_path + "catalog.pb.bin");
+    if (!catalog_file.good()) {
+      LOG(FATAL) << "ERROR: Unable to open catalog.pb.bin for writing.\n";
+    }
+
+    quickstep::Catalog catalog;
+    catalog.addDatabase(new quickstep::CatalogDatabase(nullptr, "default"));
+
+    if (!catalog.getProto().SerializeToOstream(&catalog_file)) {
+      LOG(FATAL) << "ERROR: Unable to serialize catalog proto to file catalog.pb.bin\n";
+      return 1;
+    }
+
+    // Close the catalog file - it will be reopened below by the QueryProcessor.
+    catalog_file.close();
+  }
 
   // Setup QueryProcessor, including CatalogDatabase and StorageManager.
   std::unique_ptr<QueryProcessor> query_processor;

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -198,10 +198,7 @@ int main(int argc, char* argv[]) {
 
   string catalog_path(fixed_storage_path);
   catalog_path.append("catalog.pb.bin");
-  if (quickstep::FLAGS_initialize_db) { // Initialize the database
-
-    std::cout << "Initializing the database" << std::endl;
-
+  if (quickstep::FLAGS_initialize_db) {  // Initialize the database
     // TODO(jmp): Refactor to remove the code in catalog/GenerateInitialDefaultCatalog.cpp
     //            as that may no longer be needed.
     // TODO(jmp): Refactor the code in this file!

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -220,8 +220,8 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
-    // Create the defaulty catalog file.
-    std::ofstream catalog_file(fixed_storage_path + "catalog.pb.bin");
+    // Create the default catalog file.
+    std::ofstream catalog_file(catalog_path);
     if (!catalog_file.good()) {
       LOG(FATAL) << "ERROR: Unable to open catalog.pb.bin for writing.\n";
     }


### PR DESCRIPTION
Has this every happened to you, where you type in `./quickstep_cli_shell` and get and error message `Unable to read catalog from file qsstor/catalog.pb.bin`? 

If all you were trying to do is to start Quickstep and initialize an empty database, now you can do the following: `./quickstep_cli_shell -initialize_db=true` or ``./quickstep_cli_shell  -storage_path=./dbtest -initialize_db=true`. These commands will create the directories `./qsstor` or `./dbtest` respectively, **and** automatically create the required `catalog.pb.bin` file in that directory. If any of these directories already exist, then a fatal error is thrown, so that the user does not accidentally overwrite an existing database.

Notes:
- In a later PR, we should remove the catalog.pb.bin.orig file and the code that is used to generate it.
- The code in QuickstepCli.cpp is also ripe for refactoring. This should be another PR. 