### PR TITLE
Use OrderBy in a string matching test.

### DIFF
--- a/query_optimizer/tests/execution_generator/StringPatternMatching.test
+++ b/query_optimizer/tests/execution_generator/StringPatternMatching.test
@@ -144,7 +144,8 @@ WHERE name REGEXP '.[ace].'
 SELECT name, email, organization
 FROM foo, bar
 WHERE email LIKE pattern
-  AND name NOT LIKE 'd%';
+  AND name NOT LIKE 'd%'
+ORDER BY name ASC;
 --
 +------------------------+------------------------+------------------------+
 |name                    |email                   |organization            |


### PR DESCRIPTION
This small PR adds the `OrderBy` for a string matching test to avoid non-determination in the distributed execution engine observed in the CI.

https://travis-ci.org/pivotalsoftware/quickstep/jobs/120554158

```
[ RUN      ] DISTRIBUTED_EXECUTION_GENERATOR_TEST/TextBasedTest.CompareOutputs/8
SelectStatement
+-select_query=Select
  +-select_clause=SelectList
  | +-SelectListItem
  | | +-AttributeReference[attribute_name=name]
  | +-SelectListItem
  | | +-AttributeReference[attribute_name=email]
  | +-SelectListItem
  |   +-AttributeReference[attribute_name=organization]
  +-where_clause=And
  | +-kLike
  | | +-left_operand=AttributeReference[attribute_name=email]
  | | +-right_operand=AttributeReference[attribute_name=pattern]
  | +-kNotLike
  |   +-left_operand=AttributeReference[attribute_name=name]
  |   +-right_operand=Literal
  |     +-StringLiteral[value=d%]
  +-from_clause=
    +-TableReference[table=foo]
    +-TableReference[table=bar]
/home/travis/build/pivotalsoftware/quickstep/utility/textbased_test/TextBasedTest.cpp:28: Failure
Value of: test_case_->actual_output_text
  Actual: "+------------------------+------------------------+------------------------+\n|name                    |email                   |organization            |\n+------------------------+------------------------+------------------------+\n|                     aaa|           aaa@gmail.com|                  Google|\n|                     ccc|           ccc@gmail.com|                  Google|\n|                     bbb|         BBB@outlook.com|               Microsoft|\n|                     eee|            eee@wisc.edu|              UW Madison|\n|                     eef|         fff@cs.wisc.edu|           UW Madison CS|\n+------------------------+------------------------+------------------------+\n"
Expected: test_case_->expected_output_text
Which is: "+------------------------+------------------------+------------------------+\n|name                    |email                   |organization            |\n+------------------------+------------------------+------------------------+\n|                     aaa|           aaa@gmail.com|                  Google|\n|                     bbb|         BBB@outlook.com|               Microsoft|\n|                     ccc|           ccc@gmail.com|                  Google|\n|                     eee|            eee@wisc.edu|              UW Madison|\n|                     eef|         fff@cs.wisc.edu|           UW Madison CS|\n+------------------------+------------------------+------------------------+\n"
[  FAILED  ] DISTRIBUTED_EXECUTION_GENERATOR_TEST/TextBasedTest.CompareOutputs/8, where GetParam() = 0x4164140 (22 ms)
```