### PR TITLE
Added worker_thread_id in TMB Messages Sent To Foreman.

### DIFF
--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -101,6 +101,7 @@ target_link_libraries(quickstep_queryexecution_QueryContext_proto
 target_link_libraries(quickstep_queryexecution_QueryExecutionMessages_proto
                       ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_queryexecution_QueryExecutionTypedefs
+                      quickstep_threading_ThreadIdBasedMap
                       tmb)
 target_link_libraries(quickstep_queryexecution_QueryExecutionUtil
                       quickstep_queryexecution_QueryExecutionTypedefs
@@ -119,6 +120,7 @@ target_link_libraries(quickstep_queryexecution_Worker
                       quickstep_queryexecution_WorkerMessage
                       quickstep_relationaloperators_WorkOrder
                       quickstep_threading_Thread
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_threading_ThreadUtil
                       quickstep_utility_Macros
                       tmb)

--- a/query_execution/Foreman.hpp
+++ b/query_execution/Foreman.hpp
@@ -246,21 +246,22 @@ class Foreman final : public ForemanLite {
    *
    * @param node_index The index of the specified operator node in the query DAG
    *        for the completed WorkOrder.
-   * @param worker_id The logical ID of the worker for the completed WorkOrder.
+   * @param worker_thread_id The logical ID of the worker for the completed
+   *        WorkOrder.
    **/
   void processWorkOrderCompleteMessage(const dag_node_index op_index,
-                                       const std::size_t worker_id);
+                                       const std::size_t worker_thread_id);
 
   /**
    * @brief Process the received RebuildWorkOrder complete message.
    *
    * @param node_index The index of the specified operator node in the query DAG
    *        for the completed RebuildWorkOrder.
-   * @param worker_id The logical ID of the worker for the completed
+   * @param worker_thread_id The logical ID of the worker for the completed
    *        RebuildWorkOrder.
    **/
   void processRebuildWorkOrderCompleteMessage(const dag_node_index op_index,
-                                              const std::size_t worker_id);
+                                              const std::size_t worker_thread_id);
 
   /**
    * @brief Process the received data pipeline message.
@@ -323,10 +324,10 @@ class Foreman final : public ForemanLite {
   /**
    * @brief Send the given message to the specified worker.
    *
-   * @param worker_id The logical ID of the recipient worker.
+   * @param worker_thread_id The logical ID of the recipient worker.
    * @param message The WorkerMessage to be sent.
    **/
-  void sendWorkerMessage(const std::size_t worker_id, const WorkerMessage &message);
+  void sendWorkerMessage(const std::size_t worker_thread_id, const WorkerMessage &message);
 
   /**
    * @brief Fetch all work orders currently available in relational operator and

--- a/query_execution/QueryExecutionMessages.proto
+++ b/query_execution/QueryExecutionMessages.proto
@@ -28,7 +28,7 @@ message WorkOrderCompletionMessage {
 message CatalogRelationNewBlockMessage {
   required int32 relation_id = 1;
   required fixed64 block_id = 2;
-  optional fixed64 worker_thread_id = 3;
+  required fixed64 worker_thread_id = 3;
 
   // Used by PartitionAwareInsertDestination.
   optional uint64 partition_id = 4;
@@ -38,7 +38,7 @@ message DataPipelineMessage {
   required uint64 operator_index = 1;
   required fixed64 block_id = 2;
   required int32 relation_id = 3;
-  optional fixed64 worker_thread_id = 4;
+  required fixed64 worker_thread_id = 4;
 }
 
 message WorkOrdersAvailableMessage {

--- a/query_execution/QueryExecutionMessages.proto
+++ b/query_execution/QueryExecutionMessages.proto
@@ -22,23 +22,26 @@ package quickstep.serialization;
 // WorkOrders.
 message WorkOrderCompletionMessage {
   required uint64 operator_index = 1;
-  required uint64 worker_id = 2;
+  required uint64 worker_thread_id = 2;
 }
 
 message CatalogRelationNewBlockMessage {
   required int32 relation_id = 1;
   required fixed64 block_id = 2;
+  optional fixed64 worker_thread_id = 3;
 
   // Used by PartitionAwareInsertDestination.
-  optional uint64 partition_id = 3;
+  optional uint64 partition_id = 4;
 }
 
 message DataPipelineMessage {
   required uint64 operator_index = 1;
   required fixed64 block_id = 2;
   required int32 relation_id = 3;
+  optional fixed64 worker_thread_id = 4;
 }
 
 message WorkOrdersAvailableMessage {
   required uint64 operator_index = 1;
+  required fixed64 worker_thread_id = 2;
 }

--- a/query_execution/QueryExecutionTypedefs.hpp
+++ b/query_execution/QueryExecutionTypedefs.hpp
@@ -18,6 +18,8 @@
 #ifndef QUICKSTEP_QUERY_EXECUTION_QUERY_EXECUTION_TYPEDEFS_HPP_
 #define QUICKSTEP_QUERY_EXECUTION_QUERY_EXECUTION_TYPEDEFS_HPP_
 
+#include <cstddef>
+
 #include "tmb/address.h"
 #include "tmb/id_typedefs.h"
 #include "tmb/message_style.h"
@@ -29,6 +31,8 @@ namespace quickstep {
 /** \addtogroup QueryExecution
  *  @{
  */
+
+constexpr std::size_t kInvalidWorkerThreadId = static_cast<std::size_t>(-1);
 
 typedef tmb::Address Address;
 typedef tmb::AnnotatedMessage AnnotatedMessage;

--- a/query_execution/QueryExecutionTypedefs.hpp
+++ b/query_execution/QueryExecutionTypedefs.hpp
@@ -20,6 +20,8 @@
 
 #include <cstddef>
 
+#include "threading/ThreadIdBasedMap.hpp"
+
 #include "tmb/address.h"
 #include "tmb/id_typedefs.h"
 #include "tmb/message_style.h"
@@ -43,6 +45,12 @@ typedef tmb::PureMemoryMessageBus<false> MessageBusImpl;
 typedef tmb::TaggedMessage TaggedMessage;
 typedef tmb::client_id client_id;
 typedef tmb::message_type_id message_type_id;
+
+using WorkerThreadIdMap = ThreadIdBasedMap<std::size_t,
+                                           'W', 'o', 'r', 'k', 'e', 'r',
+                                           'T', 'h', 'r', 'e', 'a', 'd',
+                                           'I', 'd',
+                                           'M', 'a', 'p'>;
 
 enum QueryExecutionMessageType : message_type_id {
   kWorkOrderMessage,  // From Foreman to Worker.

--- a/query_execution/Worker.cpp
+++ b/query_execution/Worker.cpp
@@ -74,7 +74,7 @@ void Worker::sendWorkOrderCompleteMessage(const tmb::client_id receiver,
                                           const bool is_rebuild_work_order) {
   serialization::WorkOrderCompletionMessage proto;
   proto.set_operator_index(op_index);
-  proto.set_worker_id(worker_id_);
+  proto.set_worker_thread_id(worker_thread_id_);
 
   // NOTE(zuyu): Using the heap memory to serialize proto as a c-like string.
   const size_t proto_length = proto.ByteSize();

--- a/query_execution/Worker.cpp
+++ b/query_execution/Worker.cpp
@@ -25,6 +25,7 @@
 #include "query_execution/QueryExecutionUtil.hpp"
 #include "query_execution/WorkerMessage.hpp"
 #include "relational_operators/WorkOrder.hpp"
+#include "threading/ThreadIdBasedMap.hpp"
 #include "threading/ThreadUtil.hpp"
 
 #include "glog/logging.h"
@@ -44,6 +45,11 @@ void Worker::run() {
   if (cpu_id_ >= 0) {
     ThreadUtil::BindToCPU(cpu_id_);
   }
+
+  // Refer to InsertDestination::sendBlockFilledMessage for the rationale
+  // behind using WorkerThreadIdMap.
+  WorkerThreadIdMap::Instance()->addValue(worker_thread_id_);
+
   for (;;) {
     // Receive() is a blocking call, causing this thread to sleep until next
     // message is received.
@@ -63,6 +69,7 @@ void Worker::run() {
         break;
       }
       case kPoisonMessage: {
+        WorkerThreadIdMap::Instance()->removeValue();
         return;
       }
     }

--- a/query_execution/Worker.hpp
+++ b/query_execution/Worker.hpp
@@ -41,17 +41,17 @@ class Worker : public Thread {
   /**
    * @brief Constructor
    *
-   * @param worker_id The unique ID of this worker thread.
+   * @param worker_thread_id The unique ID of this worker thread.
    * @param bus A pointer to the TMB.
    * @param cpu_id The ID of the CPU to which this worker thread can be pinned.
    *
    * @note If cpu_id is not specified, worker thread can be possibly moved
    *       around on different CPUs by the OS.
    **/
-  Worker(std::size_t worker_id,
+  Worker(std::size_t worker_thread_id,
          MessageBus *bus,
          int cpu_id = -1)
-      : worker_id_(worker_id),
+      : worker_thread_id_(worker_thread_id),
         bus_(bus),
         cpu_id_(cpu_id) {
     DEBUG_ASSERT(bus_ != nullptr);
@@ -100,7 +100,7 @@ class Worker : public Thread {
                                     const std::size_t op_index,
                                     const bool is_rebuild_work_order);
 
-  const std::size_t worker_id_;
+  const std::size_t worker_thread_id_;
   MessageBus *bus_;
 
   const int cpu_id_;

--- a/query_execution/Worker.hpp
+++ b/query_execution/Worker.hpp
@@ -24,6 +24,8 @@
 #include "threading/Thread.hpp"
 #include "utility/Macros.hpp"
 
+#include "glog/logging.h"
+
 #include "tmb/id_typedefs.h"
 #include "tmb/message_bus.h"
 
@@ -48,13 +50,15 @@ class Worker : public Thread {
    * @note If cpu_id is not specified, worker thread can be possibly moved
    *       around on different CPUs by the OS.
    **/
-  Worker(std::size_t worker_thread_id,
+  Worker(const std::size_t worker_thread_id,
          MessageBus *bus,
          int cpu_id = -1)
       : worker_thread_id_(worker_thread_id),
         bus_(bus),
         cpu_id_(cpu_id) {
+    DCHECK_NE(worker_thread_id_, kInvalidWorkerThreadId);
     DEBUG_ASSERT(bus_ != nullptr);
+
     worker_client_id_ = bus_->Connect();
 
     bus_->RegisterClientAsSender(worker_client_id_, kWorkOrderCompleteMessage);

--- a/query_optimizer/tests/CMakeLists.txt
+++ b/query_optimizer/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(quickstep_queryoptimizer_tests_TestDatabaseLoader
                       quickstep_storage_InsertDestination
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_CharType
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID

--- a/query_optimizer/tests/TestDatabaseLoader.hpp
+++ b/query_optimizer/tests/TestDatabaseLoader.hpp
@@ -23,6 +23,7 @@
 #include "catalog/CatalogDatabase.hpp"
 #include "query_execution/QueryExecutionTypedefs.hpp"
 #include "storage/StorageManager.hpp"
+#include "threading/ThreadIdBasedMap.hpp"
 #include "utility/Macros.hpp"
 
 #include "tmb/id_typedefs.h"
@@ -56,6 +57,10 @@ class TestDatabaseLoader {
                           0 /* id */),
         storage_manager_(storage_path),
         test_relation_(nullptr) {
+    // Refer to InsertDestination::sendBlockFilledMessage for the rationale
+    // behind using WorkerThreadIdMap.
+    WorkerThreadIdMap::Instance()->addValue(kInvalidWorkerThreadId);
+
     bus_.Initialize();
 
     foreman_client_id_ = bus_.Connect();
@@ -67,6 +72,7 @@ class TestDatabaseLoader {
 
   ~TestDatabaseLoader() {
     clear();
+    WorkerThreadIdMap::Instance()->removeValue();
   }
 
   /**

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -444,6 +444,7 @@ target_link_libraries(AggregationOperator_unittest
                       quickstep_storage_StorageBlockLayout
                       quickstep_storage_StorageManager
                       quickstep_storage_TupleStorageSubBlock
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType
@@ -494,6 +495,7 @@ target_link_libraries(HashJoinOperator_unittest
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_storage_StorageManager
                       quickstep_storage_TupleStorageSubBlock
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_CharType
                       quickstep_types_IntType
                       quickstep_types_LongType
@@ -546,6 +548,7 @@ target_link_libraries(SortMergeRunOperator_unittest
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_IntType
                       quickstep_types_Type
                       quickstep_types_TypeID
@@ -594,6 +597,7 @@ target_link_libraries(SortRunGenerationOperator_unittest
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_IntType
                       quickstep_types_Type
                       quickstep_types_TypeID
@@ -626,6 +630,7 @@ target_link_libraries(TextScanOperator_unittest
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_InsertDestination_proto
                       quickstep_storage_StorageManager
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID
                       quickstep_utility_MemStream

--- a/relational_operators/DeleteOperator.cpp
+++ b/relational_operators/DeleteOperator.cpp
@@ -95,6 +95,8 @@ void DeleteWorkOrder::execute() {
   proto.set_operator_index(delete_operator_index_);
   proto.set_block_id(input_block_id_);
   proto.set_relation_id(input_relation_.getID());
+  DCHECK_NE(worker_thread_id_, kInvalidWorkerThreadId);
+  proto.set_worker_thread_id(worker_thread_id_);
 
   // NOTE(zuyu): Using the heap memory to serialize proto as a c-like string.
   const std::size_t proto_length = proto.ByteSize();

--- a/relational_operators/RebuildWorkOrder.hpp
+++ b/relational_operators/RebuildWorkOrder.hpp
@@ -81,6 +81,8 @@ class RebuildWorkOrder : public WorkOrder {
     proto.set_operator_index(input_operator_index_);
     proto.set_block_id(block_ref_->getID());
     proto.set_relation_id(input_relation_id_);
+    DCHECK_NE(worker_thread_id_, kInvalidWorkerThreadId);
+    proto.set_worker_thread_id(worker_thread_id_);
 
     // NOTE(zuyu): Using the heap memory to serialize proto as a c-like string.
     const std::size_t proto_length = proto.ByteSize();

--- a/relational_operators/TextScanOperator.cpp
+++ b/relational_operators/TextScanOperator.cpp
@@ -664,6 +664,8 @@ void TextSplitWorkOrder::sendBlobInfoToOperator(const bool write_row_aligned) {
   // Notify Foreman for the avaiable work order on the blob.
   serialization::WorkOrdersAvailableMessage message_proto;
   message_proto.set_operator_index(operator_index_);
+  DCHECK_NE(worker_thread_id_, kInvalidWorkerThreadId);
+  message_proto.set_worker_thread_id(worker_thread_id_);
 
   // NOTE(zuyu): Using the heap memory to serialize proto as a c-like string.
   const size_t message_proto_length = message_proto.ByteSize();

--- a/relational_operators/UpdateOperator.cpp
+++ b/relational_operators/UpdateOperator.cpp
@@ -89,6 +89,8 @@ void UpdateWorkOrder::execute() {
   proto.set_operator_index(update_operator_index_);
   proto.set_block_id(input_block_id_);
   proto.set_relation_id(relation_.getID());
+  DCHECK_NE(worker_thread_id_, kInvalidWorkerThreadId);
+  proto.set_worker_thread_id(worker_thread_id_);
 
   // NOTE(zuyu): Using the heap memory to serialize proto as a c-like string.
   const std::size_t proto_length = proto.ByteSize();

--- a/relational_operators/WorkOrder.hpp
+++ b/relational_operators/WorkOrder.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ namespace quickstep {
 /** \addtogroup RelationalOperators
  *  @{
  */
-
 
 /**
  * @brief A single unit of work in a query plan, produced by a
@@ -285,8 +284,26 @@ class WorkOrder {
         " receiver thread with TMB client ID " << receiver_id;
   }
 
+  /**
+   * @brief Set the Worker thread index.
+   *
+   * @param worker_thread_id The Worker thread index in WorkerDirectory.
+   */
+  void setWorkerThreadId(const std::size_t worker_thread_id) {
+    worker_thread_id_ = worker_thread_id;
+  }
+
  protected:
-  WorkOrder() {}
+  /**
+   * @brief Constructor.
+   *
+   * @param worker_thread_id The Worker thread index in WorkerDirectory.
+   */
+  explicit WorkOrder(const std::size_t worker_thread_id = kInvalidWorkerThreadId)
+      : worker_thread_id_(worker_thread_id) {}
+
+  // The index of Worker thread in WorkerDirectory that executes this WorkOrder.
+  std::size_t worker_thread_id_;
 
   // A vector of preferred NUMA node IDs where this workorder should be executed.
   // These node IDs typically indicate the NUMA node IDs of the input(s) of the

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -53,6 +53,7 @@
 #include "storage/StorageBlockLayout.hpp"
 #include "storage/StorageManager.hpp"
 #include "storage/TupleStorageSubBlock.hpp"
+#include "threading/ThreadIdBasedMap.hpp"
 #include "types/DoubleType.hpp"
 #include "types/FloatType.hpp"
 #include "types/IntType.hpp"
@@ -106,6 +107,10 @@ class AggregationOperatorTest : public ::testing::Test {
   static const int kPlaceholder = 0xbeef;
 
   virtual void SetUp() {
+    // Usually the worker thread makes the following call. In this test setup,
+    // we don't have a worker thread hence we have to explicitly make the call.
+    WorkerThreadIdMap::Instance()->addValue(0 /* dummy_worker_thread_id */);
+
     bus_.Initialize();
 
     foreman_client_id_ = bus_.Connect();
@@ -159,6 +164,10 @@ class AggregationOperatorTest : public ::testing::Test {
       }
       storage_block->rebuild();
     }
+  }
+
+  virtual void TearDown() {
+    WorkerThreadIdMap::Instance()->removeValue();
   }
 
   Tuple* createTuple(const CatalogRelation &relation, const std::int64_t val) {

--- a/relational_operators/tests/SortMergeRunOperator_unittest.cpp
+++ b/relational_operators/tests/SortMergeRunOperator_unittest.cpp
@@ -58,6 +58,7 @@
 #include "storage/TupleStorageSubBlock.hpp"
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
+#include "threading/ThreadIdBasedMap.hpp"
 #include "types/IntType.hpp"
 #include "types/Type.hpp"
 #include "types/TypeID.hpp"
@@ -154,6 +155,10 @@ class RunTest : public ::testing::Test {
   static const char kStoragePath[];
 
   virtual void SetUp() {
+    // Usually the worker thread makes the following call. In this test setup,
+    // we don't have a worker thread hence we have to explicitly make the call.
+    WorkerThreadIdMap::Instance()->addValue(0 /* dummy_worker_thread_id */);
+
     // Initialize the TMB, register this thread as sender and receiver for
     // appropriate types of messages.
     bus_.Initialize();
@@ -184,6 +189,10 @@ class RunTest : public ::testing::Test {
                                        foreman_client_id_,
                                        agent_client_id_,
                                        &bus_));
+  }
+
+  virtual void TearDown() {
+    WorkerThreadIdMap::Instance()->removeValue();
   }
 
   // Helper method to insert test tuples.
@@ -361,6 +370,10 @@ class RunMergerTest : public ::testing::Test {
   static const char kStoragePath[];
 
   virtual void SetUp() {
+    // Usually the worker thread makes the following call. In this test setup,
+    // we don't have a worker thread hence we have to explicitly make the call.
+    WorkerThreadIdMap::Instance()->addValue(0 /* dummy_worker_thread_id */);
+
     // Initialize the TMB, register this thread as sender and receiver for
     // appropriate types of messages.
     bus_.Initialize();
@@ -402,6 +415,10 @@ class RunMergerTest : public ::testing::Test {
                                        foreman_client_id_,
                                        agent_client_id_,
                                        &bus_));
+  }
+
+  virtual void TearDown() {
+    WorkerThreadIdMap::Instance()->removeValue();
   }
 
   // Helper method to create test tuples.
@@ -1166,6 +1183,10 @@ class SortMergeRunOperatorTest : public ::testing::Test {
   static const char kDatabaseName[];
 
   virtual void SetUp() {
+    // Usually the worker thread makes the following call. In this test setup,
+    // we don't have a worker thread hence we have to explicitly make the call.
+    WorkerThreadIdMap::Instance()->addValue(0 /* dummy_worker_thread_id */);
+
     // Initialize the TMB, register this thread as sender and receiver for
     // appropriate types of messages.
     bus_.Initialize();
@@ -1243,6 +1264,10 @@ class SortMergeRunOperatorTest : public ::testing::Test {
                                           foreman_client_id_,
                                           agent_client_id_,
                                           &bus_));
+  }
+
+  virtual void TearDown() {
+    WorkerThreadIdMap::Instance()->removeValue();
   }
 
   CatalogRelation *createTable(const char *name, const relation_id rel_id) {

--- a/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
+++ b/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
@@ -54,6 +54,7 @@
 #include "storage/TupleStorageSubBlock.hpp"
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
+#include "threading/ThreadIdBasedMap.hpp"
 #include "types/IntType.hpp"
 #include "types/Type.hpp"
 #include "types/TypeID.hpp"
@@ -144,6 +145,10 @@ class SortRunGenerationOperatorTest : public ::testing::Test {
   static const char kStoragePath[];
 
   virtual void SetUp() {
+    // Usually the worker thread makes the following call. In this test setup,
+    // we don't have a worker thread hence we have to explicitly make the call.
+    WorkerThreadIdMap::Instance()->addValue(0 /* dummy_worker_thread_id */);
+
     // Initialize the TMB, register this thread as sender and receiver for
     // appropriate types of messages.
     bus_.Initialize();
@@ -181,6 +186,10 @@ class SortRunGenerationOperatorTest : public ::testing::Test {
     ASSERT_EQ(null_col2_, result_table_->getAttributeByName("null-col-2")->getID());
     ASSERT_EQ(null_col3_, result_table_->getAttributeByName("null-col-3")->getID());
     ASSERT_EQ(tid_col_, result_table_->getAttributeByName("tid")->getID());
+  }
+
+  virtual void TearDown() {
+    WorkerThreadIdMap::Instance()->removeValue();
   }
 
   // Helper method to create catalog relation.

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -583,6 +583,7 @@ target_link_libraries(quickstep_storage_InsertDestination
                       quickstep_storage_TupleIdSequence
                       quickstep_storage_ValueAccessorUtil
                       quickstep_threading_SpinMutex
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_types_TypedValue
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros

--- a/storage/InsertDestination.cpp
+++ b/storage/InsertDestination.cpp
@@ -39,6 +39,7 @@
 #include "storage/TupleIdSequence.hpp"
 #include "storage/ValueAccessorUtil.hpp"
 #include "threading/SpinMutex.hpp"
+#include "threading/ThreadIdBasedMap.hpp"
 #include "types/TypedValue.hpp"
 #include "types/containers/Tuple.hpp"
 
@@ -266,6 +267,7 @@ MutableBlockReference AlwaysCreateBlockInsertDestination::createNewBlock() {
   serialization::CatalogRelationNewBlockMessage proto;
   proto.set_relation_id(relation_.getID());
   proto.set_block_id(new_id);
+  proto.set_worker_thread_id(WorkerThreadIdMap::Instance()->getValue());
 
   const size_t proto_length = proto.ByteSize();
   char *proto_bytes = static_cast<char*>(malloc(proto_length));
@@ -313,6 +315,7 @@ MutableBlockReference BlockPoolInsertDestination::createNewBlock() {
   serialization::CatalogRelationNewBlockMessage proto;
   proto.set_relation_id(relation_.getID());
   proto.set_block_id(new_id);
+  proto.set_worker_thread_id(WorkerThreadIdMap::Instance()->getValue());
 
   const size_t proto_length = proto.ByteSize();
   char *proto_bytes = static_cast<char*>(malloc(proto_length));
@@ -420,6 +423,7 @@ MutableBlockReference PartitionAwareInsertDestination::createNewBlockInPartition
   serialization::CatalogRelationNewBlockMessage proto;
   proto.set_relation_id(relation_.getID());
   proto.set_block_id(new_id);
+  proto.set_worker_thread_id(WorkerThreadIdMap::Instance()->getValue());
   proto.set_partition_id(part_id);
 
   const size_t proto_length = proto.ByteSize();

--- a/threading/CMakeLists.txt
+++ b/threading/CMakeLists.txt
@@ -320,6 +320,7 @@ endif()
 
 add_library(quickstep_threading_SpinMutex ../empty_src.cpp SpinMutex.hpp)
 add_library(quickstep_threading_SpinSharedMutex ../empty_src.cpp SpinSharedMutex.hpp)
+add_library(quickstep_threading_ThreadIdBasedMap ../empty_src.cpp ThreadIdBasedMap.hpp)
 add_library(quickstep_threading_ThreadUtil ../empty_src.cpp ThreadUtil.hpp)
 
 # Link dependencies:
@@ -352,6 +353,12 @@ target_link_libraries(quickstep_threading_SpinSharedMutex
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_threading_Thread
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_threading_ThreadIdBasedMap
+                      glog
+                      quickstep_storage_StorageConstants
+                      quickstep_threading_Mutex
+                      quickstep_threading_SharedMutex
+                      quickstep_threading_SpinSharedMutex)
 target_link_libraries(quickstep_threading_ThreadUtil
                       quickstep_utility_Macros)
 
@@ -364,6 +371,7 @@ target_link_libraries(quickstep_threading
                       quickstep_threading_SpinMutex
                       quickstep_threading_SpinSharedMutex
                       quickstep_threading_Thread
+                      quickstep_threading_ThreadIdBasedMap
                       quickstep_threading_ThreadUtil)
 
 # Tests:

--- a/threading/ThreadIdBasedMap.hpp
+++ b/threading/ThreadIdBasedMap.hpp
@@ -1,0 +1,167 @@
+/**
+ *   Copyright 2015-2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_THREADING_THREAD_ID_BASED_MAP_HPP_
+#define QUICKSTEP_THREADING_THREAD_ID_BASED_MAP_HPP_
+
+#include <unordered_map>
+
+#include "threading/ThreadingConfig.h"
+
+#ifdef QUICKSTEP_HAVE_POSIX_THREADS
+#include <pthread.h>
+#endif
+
+#ifdef QUICKSTEP_HAVE_CPP11_THREADS
+#include <thread>  // NOLINT(build/c++11)
+#endif
+
+#ifdef QUICKSTEP_HAVE_WINDOWS_THREADS
+#include "threading/WinThreadsAPI.hpp"
+#endif
+
+#include "storage/StorageConstants.hpp"
+#include "threading/Mutex.hpp"
+#include "threading/SharedMutex.hpp"
+#include "threading/SpinSharedMutex.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+/** \addtogroup Threading
+ *  @{
+ */
+
+/**
+ * @brief A map which uses caller thread's ID as a key based on a singleton
+ *        pattern.
+ *
+ * @note This is in a way a simulation of thread-local object storage.
+ **/
+template <class V, char... name>
+class ThreadIDBasedMap {
+ public:
+#ifdef QUICKSTEP_HAVE_CPP11_THREADS
+  typedef std::thread::id thread_id_t;
+#endif
+
+#ifdef QUICKSTEP_HAVE_POSIX_THREADS
+  typedef pthread_t thread_id_t;
+#endif
+
+#ifdef QUICKSTEP_HAVE_WINDOWS_THREADS
+  typedef DWORD thread_id_t;
+#endif
+
+  /**
+   * @brief Get the instance of the map.
+   *
+   * @warning The initialization of the instance is not thread safe.
+   *
+   * @return A pointer to the instance.
+   **/
+  static ThreadIDBasedMap* Instance() {
+    static ThreadIDBasedMap instance;
+    return &instance;
+  }
+
+  /**
+   * @brief Add a value to the map.
+   *
+   * @param value The value to be added.
+   **/
+  void addValue(const V &value) {
+    const thread_id_t key = getKey();
+    {
+      SpinSharedMutexExclusiveLock<false> lock(map_mutex_);
+      DCHECK(map_.find(key) == map_.end());
+      map_.emplace(key, value);
+    }
+  }
+
+  /**
+   * @brief Remove the value for the caller thread.
+   **/
+  void removeValue() {
+    const thread_id_t key = getKey();
+    {
+      SpinSharedMutexExclusiveLock<false> lock(map_mutex_);
+      // Use the following way to avoid exception in erase() call.
+      const auto it = map_.find(key);
+      DCHECK(it != map_.end());
+      map_.erase(it);
+    }
+  }
+
+  /**
+   * @brief Get the value corresponding to the caller thread.
+   *
+   * @return The value for which the key is the caller thread's ID.
+   **/
+  const V& getValue() const {
+    const thread_id_t key = getKey();
+    {
+      SpinSharedMutexSharedLock<false> lock(map_mutex_);
+      const auto it = map_.find(key);
+      DCHECK(it != map_.end());
+      return it->second;
+    }
+  }
+
+ private:
+  /**
+   * @brief Constructor.
+   **/
+  ThreadIDBasedMap() {}
+
+  /**
+   * @brief Destructor.
+   *
+   * @note The destructor is private in order to prevent any caller that holds
+   *       a pointer to the map from accidentally deleting it.
+   **/
+  ~ThreadIDBasedMap() {}
+
+  /**
+   * @brief Return a unique key corresponding to the caller thread.
+   *
+   * @return A unique key.
+   **/
+  static thread_id_t getKey() {
+#ifdef QUICKSTEP_HAVE_CPP11_THREADS
+    return std::this_thread::get_id();
+#endif
+
+#ifdef QUICKSTEP_HAVE_POSIX_THREADS
+    return pthread_self();
+#endif
+
+#ifdef QUICKSTEP_HAVE_WINDOWS_THREADS
+    return GetCurrentThreadId();
+#endif
+  }
+
+  std::unordered_map<thread_id_t, V> map_;
+
+  alignas(kCacheLineBytes) mutable SpinSharedMutex<false> map_mutex_;
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_THREADING_THREAD_ID_BASED_MAP_HPP_

--- a/threading/ThreadIdBasedMap.hpp
+++ b/threading/ThreadIdBasedMap.hpp
@@ -53,7 +53,7 @@ namespace quickstep {
  * @note This is in a way a simulation of thread-local object storage.
  **/
 template <class V, char... name>
-class ThreadIDBasedMap {
+class ThreadIdBasedMap {
  public:
 #ifdef QUICKSTEP_HAVE_CPP11_THREADS
   typedef std::thread::id thread_id_t;
@@ -74,8 +74,8 @@ class ThreadIDBasedMap {
    *
    * @return A pointer to the instance.
    **/
-  static ThreadIDBasedMap* Instance() {
-    static ThreadIDBasedMap instance;
+  static ThreadIdBasedMap* Instance() {
+    static ThreadIdBasedMap instance;
     return &instance;
   }
 
@@ -89,6 +89,7 @@ class ThreadIDBasedMap {
     {
       SpinSharedMutexExclusiveLock<false> lock(map_mutex_);
       DCHECK(map_.find(key) == map_.end());
+
       map_.emplace(key, value);
     }
   }
@@ -103,6 +104,7 @@ class ThreadIDBasedMap {
       // Use the following way to avoid exception in erase() call.
       const auto it = map_.find(key);
       DCHECK(it != map_.end());
+
       map_.erase(it);
     }
   }
@@ -118,6 +120,7 @@ class ThreadIDBasedMap {
       SpinSharedMutexSharedLock<false> lock(map_mutex_);
       const auto it = map_.find(key);
       DCHECK(it != map_.end());
+
       return it->second;
     }
   }
@@ -126,7 +129,7 @@ class ThreadIDBasedMap {
   /**
    * @brief Constructor.
    **/
-  ThreadIDBasedMap() {}
+  ThreadIdBasedMap() {}
 
   /**
    * @brief Destructor.
@@ -134,7 +137,7 @@ class ThreadIDBasedMap {
    * @note The destructor is private in order to prevent any caller that holds
    *       a pointer to the map from accidentally deleting it.
    **/
-  ~ThreadIDBasedMap() {}
+  ~ThreadIdBasedMap() {}
 
   /**
    * @brief Return a unique key corresponding to the caller thread.


### PR DESCRIPTION
This PR adds `worker_thread_id` in all TMB messages sent to Foreman. The `thread id-based map` mechanism used here is the one for passing the TMB client id of a worker thread to some `WorkOrder`s and `InsertDestinations`, originally written by @hbdeshmukh.