### PR TITLE
Refactor AggregationHandle to avoid cyclic library dependency when using HashTable

### DIFF
--- a/expressions/aggregation/AggregationConcreteHandle.hpp
+++ b/expressions/aggregation/AggregationConcreteHandle.hpp
@@ -1,0 +1,276 @@
+/**
+ *   Copyright 2011-2015 Quickstep Technologies LLC.
+ *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_EXPRESSIONS_AGGREGATION_AGGREGATION_CONCRETE_HANDLE_HPP_
+#define QUICKSTEP_EXPRESSIONS_AGGREGATION_AGGREGATION_CONCRETE_HANDLE_HPP_
+
+#include <cstddef>
+#include <vector>
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationHandle.hpp"
+#include "storage/HashTableBase.hpp"
+#include "types/TypedValue.hpp"
+#include "types/containers/ColumnVector.hpp"
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+class Type;
+class ValueAccessor;
+
+/** \addtogroup Expressions
+ *  @{
+ */
+
+
+/**
+ * @brief The helper intermediate subclass of AggregationHandle that provides
+ *        virtual method implementations as well as helper methods that are
+ *        shared among all its subclasses.
+ *
+ * @note The reason that we have this intermediate class instead of putting
+ *       everything inside AggregationHandle is to avoid cyclic dependency, e.g.
+ *       when HashTable has to be used.
+ **/
+class AggregationConcreteHandle : public AggregationHandle {
+ public:
+  AggregationState* accumulateNullary(
+      const std::size_t num_tuples) const override {
+    LOG(FATAL) << "Called accumulateNullary on an AggregationHandle that "
+               << "takes at least one argument.";
+  }
+
+ protected:
+  AggregationConcreteHandle() {
+  }
+
+  template <typename HandleT,
+            typename StateT,
+            typename HashTableT>
+  void aggregateValueAccessorIntoHashTableNullaryHelper(
+      ValueAccessor *accessor,
+      const std::vector<attribute_id> &group_by_key_ids,
+      const StateT &default_state,
+      AggregationStateHashTableBase *hash_table) const;
+
+  template <typename HandleT,
+            typename StateT,
+            typename HashTableT>
+  void aggregateValueAccessorIntoHashTableUnaryHelper(
+      ValueAccessor *accessor,
+      const attribute_id argument_id,
+      const std::vector<attribute_id> &group_by_key_ids,
+      const StateT &default_state,
+      AggregationStateHashTableBase *hash_table) const;
+
+  template <typename HandleT,
+            typename HashTableT>
+  ColumnVector* finalizeHashTableHelper(
+      const Type &result_type,
+      const AggregationStateHashTableBase &hash_table,
+      std::vector<std::vector<TypedValue>> *group_by_keys) const;
+
+  template <typename HandleT, typename HashTableT>
+  inline TypedValue finalizeGroupInHashTable(
+      const AggregationStateHashTableBase &hash_table,
+      const std::vector<TypedValue> &group_key) const {
+    const AggregationState *group_state
+        = static_cast<const HashTableT&>(hash_table).getSingleCompositeKey(group_key);
+    DCHECK(group_state != nullptr)
+        << "Could not find entry for specified group_key in HashTable";
+    return static_cast<const HandleT*>(this)->finalizeHashTableEntry(*group_state);
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(AggregationConcreteHandle);
+};
+
+/**
+ * @brief Templated class to implement value-accessor-based upserter for each
+ *        aggregation state payload type. This version is for nullary
+ *        aggregates (those that take no arguments).
+ **/
+template <typename HandleT, typename StateT>
+class NullaryAggregationStateValueAccessorUpserter {
+ public:
+  explicit NullaryAggregationStateValueAccessorUpserter(const HandleT &handle)
+      : handle_(handle) {
+  }
+
+  template <typename ValueAccessorT>
+  inline void operator()(const ValueAccessorT &accessor, StateT *state) {
+    handle_.iterateNullaryInl(state);
+  }
+
+ private:
+  const HandleT &handle_;
+};
+
+/**
+ * @brief Templated class to implement value-accessor-based upserter for each
+ *        aggregation state payload type. This version is for unary aggregates
+ *        (those that take a single argument).
+ **/
+template <typename HandleT, typename StateT>
+class UnaryAggregationStateValueAccessorUpserter {
+ public:
+  UnaryAggregationStateValueAccessorUpserter(const HandleT &handle,
+                                             attribute_id value_id)
+    : handle_(handle),
+      value_id_(value_id) {
+  }
+
+  template <typename ValueAccessorT>
+  inline void operator()(const ValueAccessorT &accessor, StateT *state) {
+    handle_.iterateUnaryInl(state, accessor.getTypedValue(value_id_));
+  }
+
+ private:
+  const HandleT &handle_;
+  const attribute_id value_id_;
+};
+
+/**
+ * @brief Templated helper class used to implement
+ *        AggregationHandle::finalizeHashTable() by visiting each entry (i.e.
+ *        GROUP) in a HashTable, finalizing the aggregation for the GROUP, and
+ *        collecting the GROUP BY key values and the final aggregate values in
+ *        a ColumnVector.
+ **/
+template <typename HandleT, typename ColumnVectorT>
+class HashTableAggregateFinalizer {
+ public:
+  HashTableAggregateFinalizer(const HandleT &handle,
+                              std::vector<std::vector<TypedValue>> *group_by_keys,
+                              ColumnVectorT *output_column_vector)
+      : handle_(handle),
+        group_by_keys_(group_by_keys),
+        output_column_vector_(output_column_vector) {
+  }
+
+  inline void operator()(const std::vector<TypedValue> &group_by_key,
+                         const AggregationState &group_state) {
+    group_by_keys_->emplace_back(group_by_key);
+    output_column_vector_->appendTypedValue(handle_.finalizeHashTableEntry(group_state));
+  }
+
+ private:
+  const HandleT &handle_;
+  std::vector<std::vector<TypedValue>> *group_by_keys_;
+  ColumnVectorT *output_column_vector_;
+};
+
+/** @} */
+
+// ----------------------------------------------------------------------------
+// Implementations of templated methods follow:
+
+template <typename HandleT,
+          typename StateT,
+          typename HashTableT>
+void AggregationConcreteHandle::aggregateValueAccessorIntoHashTableNullaryHelper(
+    ValueAccessor *accessor,
+    const std::vector<attribute_id> &group_by_key_ids,
+    const StateT &default_state,
+    AggregationStateHashTableBase *hash_table) const {
+  NullaryAggregationStateValueAccessorUpserter<HandleT, StateT>
+      upserter(static_cast<const HandleT&>(*this));
+  static_cast<HashTableT*>(hash_table)->upsertValueAccessorCompositeKey(
+      accessor,
+      group_by_key_ids,
+      true,
+      default_state,
+      &upserter);
+}
+
+template <typename HandleT,
+          typename StateT,
+          typename HashTableT>
+void AggregationConcreteHandle::aggregateValueAccessorIntoHashTableUnaryHelper(
+    ValueAccessor *accessor,
+    const attribute_id argument_id,
+    const std::vector<attribute_id> &group_by_key_ids,
+    const StateT &default_state,
+    AggregationStateHashTableBase *hash_table) const {
+  UnaryAggregationStateValueAccessorUpserter<HandleT, StateT>
+      upserter(static_cast<const HandleT&>(*this), argument_id);
+  static_cast<HashTableT*>(hash_table)->upsertValueAccessorCompositeKey(
+      accessor,
+      group_by_key_ids,
+      true,
+      default_state,
+      &upserter);
+}
+
+template <typename HandleT,
+          typename HashTableT>
+ColumnVector* AggregationConcreteHandle::finalizeHashTableHelper(
+    const Type &result_type,
+    const AggregationStateHashTableBase &hash_table,
+    std::vector<std::vector<TypedValue>> *group_by_keys) const {
+  const HandleT &handle = static_cast<const HandleT&>(*this);
+  const HashTableT &hash_table_concrete = static_cast<const HashTableT&>(hash_table);
+
+  if (group_by_keys->empty()) {
+    if (NativeColumnVector::UsableForType(result_type)) {
+      NativeColumnVector *result = new NativeColumnVector(result_type,
+                                                          hash_table_concrete.numEntries());
+      HashTableAggregateFinalizer<HandleT, NativeColumnVector> finalizer(
+          handle,
+          group_by_keys,
+          result);
+      hash_table_concrete.forEachCompositeKey(&finalizer);
+      return result;
+    } else {
+      IndirectColumnVector *result = new IndirectColumnVector(result_type,
+                                                              hash_table_concrete.numEntries());
+      HashTableAggregateFinalizer<HandleT, IndirectColumnVector> finalizer(
+          handle,
+          group_by_keys,
+          result);
+      hash_table_concrete.forEachCompositeKey(&finalizer);
+      return result;
+    }
+  } else {
+    if (NativeColumnVector::UsableForType(result_type)) {
+      NativeColumnVector *result = new NativeColumnVector(result_type,
+                                                          group_by_keys->size());
+      for (const std::vector<TypedValue> &group_by_key : *group_by_keys) {
+        result->appendTypedValue(finalizeGroupInHashTable<HandleT, HashTableT>(hash_table,
+                                                                               group_by_key));
+      }
+      return result;
+    } else {
+      IndirectColumnVector *result = new IndirectColumnVector(result_type,
+                                                              hash_table_concrete.numEntries());
+      for (const std::vector<TypedValue> &group_by_key : *group_by_keys) {
+        result->appendTypedValue(finalizeGroupInHashTable<HandleT, HashTableT>(hash_table,
+                                                                               group_by_key));
+      }
+      return result;
+    }
+  }
+}
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_EXPRESSIONS_AGGREGATION_AGGREGATION_CONCRETE_HANDLE_HPP_

--- a/expressions/aggregation/AggregationHandle.hpp
+++ b/expressions/aggregation/AggregationHandle.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,13 +27,11 @@
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/HashTableBase.hpp"
 #include "types/TypedValue.hpp"
-#include "types/containers/ColumnVector.hpp"
 #include "utility/Macros.hpp"
-
-#include "glog/logging.h"
 
 namespace quickstep {
 
+class ColumnVector;
 class StorageManager;
 class Type;
 class ValueAccessor;
@@ -152,10 +152,7 @@ class AggregationHandle {
    *         tuples.
    **/
   virtual AggregationState* accumulateNullary(
-      const std::size_t num_tuples) const {
-    LOG(FATAL) << "Called accumulateNullary on an AggregationHandle that "
-               << "takes at least one argument.";
-  }
+      const std::size_t num_tuples) const = 0;
 
   /**
    * @brief Accumulate (iterate over) all values in one or more ColumnVectors
@@ -274,213 +271,9 @@ class AggregationHandle {
   AggregationHandle() {
   }
 
-  template <typename HandleT,
-            typename StateT,
-            typename HashTableT>
-  void aggregateValueAccessorIntoHashTableNullaryHelper(
-      ValueAccessor *accessor,
-      const std::vector<attribute_id> &group_by_key_ids,
-      const StateT &default_state,
-      AggregationStateHashTableBase *hash_table) const;
-
-  template <typename HandleT,
-            typename StateT,
-            typename HashTableT>
-  void aggregateValueAccessorIntoHashTableUnaryHelper(
-      ValueAccessor *accessor,
-      const attribute_id argument_id,
-      const std::vector<attribute_id> &group_by_key_ids,
-      const StateT &default_state,
-      AggregationStateHashTableBase *hash_table) const;
-
-  template <typename HandleT,
-            typename HashTableT>
-  ColumnVector* finalizeHashTableHelper(
-      const Type &result_type,
-      const AggregationStateHashTableBase &hash_table,
-      std::vector<std::vector<TypedValue>> *group_by_keys) const;
-
-  template <typename HandleT, typename HashTableT>
-  inline TypedValue finalizeGroupInHashTable(
-      const AggregationStateHashTableBase &hash_table,
-      const std::vector<TypedValue> &group_key) const {
-    const AggregationState *group_state
-        = static_cast<const HashTableT&>(hash_table).getSingleCompositeKey(group_key);
-    DCHECK(group_state != nullptr)
-        << "Could not find entry for specified group_key in HashTable";
-    return static_cast<const HandleT*>(this)->finalizeHashTableEntry(*group_state);
-  }
-
  private:
   DISALLOW_COPY_AND_ASSIGN(AggregationHandle);
 };
-
-/**
- * @brief Templated class to implement value-accessor-based upserter for each
- *        aggregation state payload type. This version is for nullary
- *        aggregates (those that take no arguments).
- **/
-template <typename HandleT, typename StateT>
-class NullaryAggregationStateValueAccessorUpserter {
- public:
-  explicit NullaryAggregationStateValueAccessorUpserter(const HandleT &handle)
-      : handle_(handle) {
-  }
-
-  template <typename ValueAccessorT>
-  inline void operator()(const ValueAccessorT &accessor, StateT *state) {
-    handle_.iterateNullaryInl(state);
-  }
-
- private:
-  const HandleT &handle_;
-};
-
-/**
- * @brief Templated class to implement value-accessor-based upserter for each
- *        aggregation state payload type. This version is for unary aggregates
- *        (those that take a single argument).
- **/
-template <typename HandleT, typename StateT>
-class UnaryAggregationStateValueAccessorUpserter {
- public:
-  UnaryAggregationStateValueAccessorUpserter(const HandleT &handle,
-                                             attribute_id value_id)
-    : handle_(handle),
-      value_id_(value_id) {
-  }
-
-  template <typename ValueAccessorT>
-  inline void operator()(const ValueAccessorT &accessor, StateT *state) {
-    handle_.iterateUnaryInl(state, accessor.getTypedValue(value_id_));
-  }
-
- private:
-  const HandleT &handle_;
-  const attribute_id value_id_;
-};
-
-/**
- * @brief Templated helper class used to implement
- *        AggregationHandle::finalizeHashTable() by visiting each entry (i.e.
- *        GROUP) in a HashTable, finalizing the aggregation for the GROUP, and
- *        collecting the GROUP BY key values and the final aggregate values in
- *        a ColumnVector.
- **/
-template <typename HandleT, typename ColumnVectorT>
-class HashTableAggregateFinalizer {
- public:
-  HashTableAggregateFinalizer(const HandleT &handle,
-                              std::vector<std::vector<TypedValue>> *group_by_keys,
-                              ColumnVectorT *output_column_vector)
-      : handle_(handle),
-        group_by_keys_(group_by_keys),
-        output_column_vector_(output_column_vector) {
-  }
-
-  inline void operator()(const std::vector<TypedValue> &group_by_key,
-                         const AggregationState &group_state) {
-    group_by_keys_->emplace_back(group_by_key);
-    output_column_vector_->appendTypedValue(handle_.finalizeHashTableEntry(group_state));
-  }
-
- private:
-  const HandleT &handle_;
-  std::vector<std::vector<TypedValue>> *group_by_keys_;
-  ColumnVectorT *output_column_vector_;
-};
-
-/** @} */
-
-// ----------------------------------------------------------------------------
-// Implementations of templated methods follow:
-
-template <typename HandleT,
-          typename StateT,
-          typename HashTableT>
-void AggregationHandle::aggregateValueAccessorIntoHashTableNullaryHelper(
-    ValueAccessor *accessor,
-    const std::vector<attribute_id> &group_by_key_ids,
-    const StateT &default_state,
-    AggregationStateHashTableBase *hash_table) const {
-  NullaryAggregationStateValueAccessorUpserter<HandleT, StateT>
-      upserter(static_cast<const HandleT&>(*this));
-  static_cast<HashTableT*>(hash_table)->upsertValueAccessorCompositeKey(
-      accessor,
-      group_by_key_ids,
-      true,
-      default_state,
-      &upserter);
-}
-
-template <typename HandleT,
-          typename StateT,
-          typename HashTableT>
-void AggregationHandle::aggregateValueAccessorIntoHashTableUnaryHelper(
-    ValueAccessor *accessor,
-    const attribute_id argument_id,
-    const std::vector<attribute_id> &group_by_key_ids,
-    const StateT &default_state,
-    AggregationStateHashTableBase *hash_table) const {
-  UnaryAggregationStateValueAccessorUpserter<HandleT, StateT>
-      upserter(static_cast<const HandleT&>(*this), argument_id);
-  static_cast<HashTableT*>(hash_table)->upsertValueAccessorCompositeKey(
-      accessor,
-      group_by_key_ids,
-      true,
-      default_state,
-      &upserter);
-}
-
-template <typename HandleT,
-          typename HashTableT>
-ColumnVector* AggregationHandle::finalizeHashTableHelper(
-    const Type &result_type,
-    const AggregationStateHashTableBase &hash_table,
-    std::vector<std::vector<TypedValue>> *group_by_keys) const {
-  const HandleT &handle = static_cast<const HandleT&>(*this);
-  const HashTableT &hash_table_concrete = static_cast<const HashTableT&>(hash_table);
-
-  if (group_by_keys->empty()) {
-    if (NativeColumnVector::UsableForType(result_type)) {
-      NativeColumnVector *result = new NativeColumnVector(result_type,
-                                                          hash_table_concrete.numEntries());
-      HashTableAggregateFinalizer<HandleT, NativeColumnVector> finalizer(
-          handle,
-          group_by_keys,
-          result);
-      hash_table_concrete.forEachCompositeKey(&finalizer);
-      return result;
-    } else {
-      IndirectColumnVector *result = new IndirectColumnVector(result_type,
-                                                              hash_table_concrete.numEntries());
-      HashTableAggregateFinalizer<HandleT, IndirectColumnVector> finalizer(
-          handle,
-          group_by_keys,
-          result);
-      hash_table_concrete.forEachCompositeKey(&finalizer);
-      return result;
-    }
-  } else {
-    if (NativeColumnVector::UsableForType(result_type)) {
-      NativeColumnVector *result = new NativeColumnVector(result_type,
-                                                          group_by_keys->size());
-      for (const std::vector<TypedValue> &group_by_key : *group_by_keys) {
-        result->appendTypedValue(finalizeGroupInHashTable<HandleT, HashTableT>(hash_table,
-                                                                               group_by_key));
-      }
-      return result;
-    } else {
-      IndirectColumnVector *result = new IndirectColumnVector(result_type,
-                                                              hash_table_concrete.numEntries());
-      for (const std::vector<TypedValue> &group_by_key : *group_by_keys) {
-        result->appendTypedValue(finalizeGroupInHashTable<HandleT, HashTableT>(hash_table,
-                                                                               group_by_key));
-      }
-      return result;
-    }
-  }
-}
 
 }  // namespace quickstep
 

--- a/expressions/aggregation/AggregationHandleAvg.hpp
+++ b/expressions/aggregation/AggregationHandleAvg.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationConcreteHandle.hpp"
 #include "expressions/aggregation/AggregationHandle.hpp"
 #include "storage/HashTableBase.hpp"
 #include "threading/SpinMutex.hpp"
@@ -79,7 +82,7 @@ class AggregationStateAvg : public AggregationState {
 /**
  * @brief An aggregationhandle for avg.
  **/
-class AggregationHandleAvg : public AggregationHandle {
+class AggregationHandleAvg : public AggregationConcreteHandle {
  public:
   ~AggregationHandleAvg() override {
   }

--- a/expressions/aggregation/AggregationHandleCount.hpp
+++ b/expressions/aggregation/AggregationHandleCount.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,6 +27,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationConcreteHandle.hpp"
 #include "expressions/aggregation/AggregationHandle.hpp"
 #include "storage/HashTableBase.hpp"
 #include "types/TypedValue.hpp"
@@ -86,7 +89,7 @@ class AggregationStateCount : public AggregationState {
  *        not nullable and NULL-checks can safely be skipped.
  **/
 template <bool count_star, bool nullable_type>
-class AggregationHandleCount : public AggregationHandle {
+class AggregationHandleCount : public AggregationConcreteHandle {
  public:
   ~AggregationHandleCount() override {
   }

--- a/expressions/aggregation/AggregationHandleDistinct.cpp
+++ b/expressions/aggregation/AggregationHandleDistinct.cpp
@@ -28,6 +28,8 @@
 
 #include "types/TypedValue.hpp"
 
+#include "glog/logging.h"
+
 namespace quickstep {
 
 class ColumnVector;

--- a/expressions/aggregation/AggregationHandleDistinct.hpp
+++ b/expressions/aggregation/AggregationHandleDistinct.hpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
-#include "expressions/aggregation/AggregationHandle.hpp"
+#include "expressions/aggregation/AggregationConcreteHandle.hpp"
 #include "storage/HashTableBase.hpp"
 #include "types/TypedValue.hpp"
 #include "utility/Macros.hpp"
@@ -32,6 +32,7 @@
 
 namespace quickstep {
 
+class AggregationState;
 class ColumnVector;
 class StorageManager;
 class Type;
@@ -41,7 +42,7 @@ class ValueAccessor;
  *  @{
  */
 
-class AggregationHandleDistinct : public AggregationHandle{
+class AggregationHandleDistinct : public AggregationConcreteHandle {
  public:
   /**
    * @brief Constructor.

--- a/expressions/aggregation/AggregationHandleMax.hpp
+++ b/expressions/aggregation/AggregationHandleMax.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationConcreteHandle.hpp"
 #include "expressions/aggregation/AggregationHandle.hpp"
 #include "storage/HashTableBase.hpp"
 #include "threading/SpinMutex.hpp"
@@ -79,7 +82,7 @@ class AggregationStateMax : public AggregationState {
 /**
  * @brief An aggregationhandle for max.
  **/
-class AggregationHandleMax : public AggregationHandle {
+class AggregationHandleMax : public AggregationConcreteHandle {
  public:
   ~AggregationHandleMax() override {
   }

--- a/expressions/aggregation/AggregationHandleMin.hpp
+++ b/expressions/aggregation/AggregationHandleMin.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationConcreteHandle.hpp"
 #include "expressions/aggregation/AggregationHandle.hpp"
 #include "storage/HashTableBase.hpp"
 #include "threading/SpinMutex.hpp"
@@ -78,7 +81,7 @@ class AggregationStateMin : public AggregationState {
 /**
  * @brief An aggregationhandle for min.
  **/
-class AggregationHandleMin : public AggregationHandle {
+class AggregationHandleMin : public AggregationConcreteHandle {
  public:
   ~AggregationHandleMin() override {
   }

--- a/expressions/aggregation/AggregationHandleSum.hpp
+++ b/expressions/aggregation/AggregationHandleSum.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
+#include "expressions/aggregation/AggregationConcreteHandle.hpp"
 #include "expressions/aggregation/AggregationHandle.hpp"
 #include "storage/HashTableBase.hpp"
 #include "threading/SpinMutex.hpp"
@@ -78,7 +81,7 @@ class AggregationStateSum : public AggregationState {
 /**
  * @brief An aggregationhandle for sum.
  **/
-class AggregationHandleSum : public AggregationHandle {
+class AggregationHandleSum : public AggregationConcreteHandle {
  public:
   ~AggregationHandleSum() override {
   }

--- a/expressions/aggregation/CMakeLists.txt
+++ b/expressions/aggregation/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -41,6 +41,9 @@ add_library(quickstep_expressions_aggregation_AggregateFunctionMin
 add_library(quickstep_expressions_aggregation_AggregateFunctionSum
             AggregateFunctionSum.cpp
             AggregateFunctionSum.hpp)
+add_library(quickstep_expressions_aggregation_AggregationConcreteHandle
+            ../../empty_src.cpp
+            AggregationConcreteHandle.hpp)
 add_library(quickstep_expressions_aggregation_AggregationHandle
             ../../empty_src.cpp
             AggregationHandle.hpp)
@@ -137,16 +140,24 @@ target_link_libraries(quickstep_expressions_aggregation_AggregateFunctionSum
                       quickstep_types_operations_binaryoperations_BinaryOperationFactory
                       quickstep_types_operations_binaryoperations_BinaryOperationID
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_expressions_aggregation_AggregationConcreteHandle
+                      glog
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationHandle
+                      quickstep_storage_HashTableBase
+                      quickstep_types_TypedValue
+                      quickstep_types_containers_ColumnVector
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandle
                       glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_HashTableBase
                       quickstep_types_TypedValue
-                      quickstep_types_containers_ColumnVector
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleAvg
                       glog
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
@@ -163,6 +174,7 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleAvg
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleCount
                       glog
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
@@ -178,7 +190,7 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleCount
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleDistinct
                       glog
                       quickstep_catalog_CatalogTypedefs
-                      quickstep_expressions_aggregation_AggregationHandle
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
                       quickstep_storage_HashTableFactory
@@ -187,6 +199,7 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleDistinc
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleMax
                       glog
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
@@ -202,6 +215,7 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleMax
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleMin
                       glog
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
@@ -217,6 +231,7 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleMin
 target_link_libraries(quickstep_expressions_aggregation_AggregationHandleSum
                       glog
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase
@@ -242,6 +257,7 @@ target_link_libraries(quickstep_expressions_aggregation
                       quickstep_expressions_aggregation_AggregateFunctionMax
                       quickstep_expressions_aggregation_AggregateFunctionMin
                       quickstep_expressions_aggregation_AggregateFunctionSum
+                      quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_expressions_aggregation_AggregationHandleAvg
                       quickstep_expressions_aggregation_AggregationHandleCount


### PR DESCRIPTION
This PR refactors `AggregationHandle` into two classes: class  `AggregationHandle` to contain only pure virtual methods, and its helper subclass `AggregationConcreteHandle` to contain method implementations as well as helper methods that are shared by all the aggregation handle subclasses (e.g. `AggregationHandleSum`).

The reason for doing this is to avoid cyclic library dependency that occurs in a later DISTINCT aggregation PR. That is, we hope to add some methods in the base class `AggregationHandle` that are shared by all its subclasses. However, the methods use `HashTable` and `HashTableFactory`, which forms the following dependency cycle:
```
AggregationHandle -> HashTable -> StorageManager -> StorageBlock -> AggregationHandle
```