### PR TITLE
Transaction Part 3: LockTable, TransactionTable, LockRequest

### DIFF
--- a/transaction/AccessMode.cpp
+++ b/transaction/AccessMode.cpp
@@ -1,0 +1,34 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "AccessMode.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+const bool AccessMode::kLockCompatibilityMatrix[kNumberLocks][kNumberLocks] = {
+/*           NL     IS     IX      S     SIX     X    */
+/*  NL  */ {true , true , true , true , true , true },
+/*  IS  */ {true , true , true , true , true , false},
+/*  IX  */ {true , true , true , false, false, false},
+/*  S   */ {true , true , false, true , false, false},
+/*  SIX */ {true , true , false, false, false, false},
+/*  X   */ {true , false, false, false, false, false}
+};
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/AccessMode.hpp
+++ b/transaction/AccessMode.hpp
@@ -144,26 +144,13 @@ class AccessMode {
 
   // Compatibility matrix for checking access modes.
   // True means they are compatible.
-  static constexpr bool kLockCompatibilityMatrix[kNumberLocks][kNumberLocks] = {
-/*           NL     IS     IX      S     SIX     X    */
-/*  NL  */ {true , true , true , true , true , true },
-/*  IS  */ {true , true , true , true , true , false},
-/*  IX  */ {true , true , true , false, false, false},
-/*  S   */ {true , true , false, true , false, false},
-/*  SIX */ {true , true , false, false, false, false},
-/*  X   */ {true , false, false, false, false, false}
-  };
-
+  static const bool kLockCompatibilityMatrix[kNumberLocks][kNumberLocks];
   // Type of access, the possible values are
   // NoLock, IsLock, IxLock, SLock, SixLock, XLock
   AccessModeType access_mode_;
 };
 
 /** @} */
-
-// static constexpr fields must be declared here, otherwise gcc
-// gives linkage errors.
-constexpr bool AccessMode::kLockCompatibilityMatrix[][kNumberLocks];
 
 }  // namespace transaction
 }  // namespace quickstep

--- a/transaction/CMakeLists.txt
+++ b/transaction/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(quickstep_transaction_Lock
                       quickstep_transaction_AccessMode
                       quickstep_transaction_ResourceId)
 target_link_libraries(quickstep_transaction_LockRequest
-                      quickstep_transaction_AcessMode
+                      quickstep_transaction_AccessMode
                       quickstep_transaction_ResourceId
                       quickstep_transaction_Transaction)
 target_link_libraries(quickstep_transaction_LockTable
@@ -82,9 +82,12 @@ target_link_libraries(quickstep_transaction
                       quickstep_transaction_AccessMode
                       quickstep_transaction_DirectedGraph
                       quickstep_transaction_Lock
+                      quickstep_transaction_LockRequest
+                      quickstep_transaction_LockTable
                       quickstep_transaction_ResourceId
                       quickstep_transaction_StronglyConnectedComponents
-                      quickstep_transaction_Transaction)
+                      quickstep_transaction_Transaction
+                      quickstep_transaction_TransactionTable)
 
 add_executable(AccessMode_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/AccessMode_unittest.cpp")
@@ -106,12 +109,22 @@ add_test(DirectedGraph_unittest DirectedGraph_unittest)
 add_executable(Lock_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/Lock_unittest.cpp")
 target_link_libraries(Lock_unittest
-               gtest
-               gtest_main
-               quickstep_transaction_AccessMode
-               quickstep_transaction_Lock
-               quickstep_transaction_ResourceId)
+                      gtest
+                      gtest_main
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_Lock
+                      quickstep_transaction_ResourceId)
 add_test(Lock_unittest Lock_unittest)
+
+add_executable(LockRequest_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/LockRequest_unittest.cpp")
+target_link_libraries(LockRequest_unittest
+                      gtest
+                      gtest_main
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_ResourceId
+                      quickstep_transaction_Transaction)
+add_test(LockRequest_unittest LockRequest_unittest)
 
 add_executable(LockTable_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/LockTable_unittest.cpp")

--- a/transaction/CMakeLists.txt
+++ b/transaction/CMakeLists.txt
@@ -14,7 +14,7 @@
 #   limitations under the License.
 
 add_library(quickstep_transaction_AccessMode
-            ../empty_src.cpp
+            AccessMode.cpp
             AccessMode.hpp)
 add_library(quickstep_transaction_DirectedGraph
             ../empty_src.cpp
@@ -22,6 +22,12 @@ add_library(quickstep_transaction_DirectedGraph
 add_library(quickstep_transaction_Lock
             ../empty_src.cpp
             Lock.hpp)
+add_library(quickstep_transaction_LockRequest
+            ../empty_src.cpp
+            LockRequest.hpp)
+add_library(quickstep_transaction_LockTable
+            LockTable.cpp
+            LockTable.hpp)
 add_library(quickstep_transaction_ResourceId
             ResourceId.cpp
             ResourceId.hpp)
@@ -39,6 +45,17 @@ target_link_libraries(quickstep_transaction_DirectedGraph
 target_link_libraries(quickstep_transaction_Lock
                       quickstep_transaction_AccessMode
                       quickstep_transaction_ResourceId)
+target_link_libraries(quickstep_transaction_LockRequest
+                      quickstep_transaction_AcessMode
+                      quickstep_transaction_ResourceId
+                      quickstep_transaction_Transaction)
+target_link_libraries(quickstep_transaction_LockTable
+                      quickstep_threading_SharedMutex
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_Lock
+                      quickstep_transaction_ResourceId
+                      quickstep_transaction_Transaction
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_transaction_ResourceId
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_StorageBlockInfo
@@ -86,6 +103,17 @@ target_link_libraries(Lock_unittest
                quickstep_transaction_Lock
                quickstep_transaction_ResourceId)
 add_test(Lock_unittest Lock_unittest)
+
+add_executable(LockTable_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/LockTable_unittest.cpp")
+target_link_libraries(LockTable_unittest
+                      gtest
+                      gtest_main
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_LockTable
+                      quickstep_transaction_ResourceId
+                      quickstep_transaction_Transaction)
+add_test(LockTable_unittest LockTable_unittest)
 
 add_executable(ResourceId_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/ResourceId_unittest.cpp")

--- a/transaction/CMakeLists.txt
+++ b/transaction/CMakeLists.txt
@@ -37,7 +37,10 @@ add_library(quickstep_transaction_StronglyConnectedComponents
 add_library(quickstep_transaction_Transaction
             ../empty_src.cpp
             Transaction.hpp)
-
+add_library(quickstep_transaction_TransactionTable
+            TransactionTable.cpp
+            TransactionTable.hpp)
+          
 target_link_libraries(quickstep_transaction_DirectedGraph
                       glog
                       quickstep_transaction_Transaction
@@ -64,6 +67,12 @@ target_link_libraries(quickstep_transaction_ResourceId
                       glog)
 target_link_libraries(quickstep_transaction_StronglyConnectedComponents
                       quickstep_transaction_DirectedGraph
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_transaction_TransactionTable
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_Lock
+                      quickstep_transaction_ResourceId
+                      quickstep_transaction_Transaction
                       quickstep_utility_Macros)
 
 add_library(quickstep_transaction
@@ -131,3 +140,14 @@ target_link_libraries(StronglyConnectedComponents_unittest
                       quickstep_transaction_DirectedGraph
                       quickstep_transaction_StronglyConnectedComponents)
 add_test(StronglyConnectedComponents_unittest StronglyConnectedComponents_unittest)
+
+add_executable(TransactionTable_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/TransactionTable_unittest.cpp")
+target_link_libraries(TransactionTable_unittest
+                      gtest
+                      gtest_main
+                      quickstep_transaction_AccessMode
+                      quickstep_transaction_ResourceId
+                      quickstep_transaction_Transaction
+                      quickstep_transaction_TransactionTable)
+add_test(TransactionTable_unittest TransactionTable_unittest)

--- a/transaction/LockRequest.hpp
+++ b/transaction/LockRequest.hpp
@@ -33,8 +33,8 @@ namespace transaction {
  * @brief Enum class for representing request types.
  **/
 enum class RequestType {
-  kACQUIRE_LOCK = 0,
-  kRELEASE_LOCKS
+  kAcquireLock = 0,
+  kReleaseLocks,
 };
 
 /**
@@ -51,14 +51,14 @@ class LockRequest {
    * @param access_mode Access mode of the request.
    * @param type Type of the request.
    */
-  LockRequest(TransactionId tid,
+  LockRequest(const transaction_id tid,
               const ResourceId &rid,
-              AccessMode access_mode,
-              RequestType request_type)
+              const AccessMode access_mode,
+              const RequestType request_type)
       : tid_(tid),
         rid_(rid),
         access_mode_(access_mode),
-        request_type_(type) {
+        request_type_(request_type) {
   }
 
   /**
@@ -66,7 +66,7 @@ class LockRequest {
    *
    * @return Transaction id of the request.
    **/
-  inline TransactionId getTransactionId() const {
+  inline transaction_id getTransactionId() const {
     return tid_;
   }
 
@@ -98,7 +98,7 @@ class LockRequest {
   }
 
  private:
-  TransactionId tid_;
+  transaction_id tid_;
   ResourceId rid_;
   AccessMode access_mode_;
   RequestType request_type_;

--- a/transaction/LockRequest.hpp
+++ b/transaction/LockRequest.hpp
@@ -1,0 +1,112 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TRANSACTION_LOCK_REQUEST_HPP_
+#define QUICKSTEP_TRANSACTION_LOCK_REQUEST_HPP_
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+/** \addtogroup Transaction
+ *  @{
+ */
+
+/**
+ * @brief Enum class for representing request types.
+ **/
+enum class RequestType {
+  kACQUIRE_LOCK = 0,
+  kRELEASE_LOCKS
+};
+
+/**
+ * @brief Class for encapsulate lock request put into
+ *        the buffers.
+ **/
+class LockRequest {
+ public:
+  /**
+   * @brief Constructor for LockRequest.
+   *
+   * @param tid Id of the transaction that requests the lock.
+   * @param rid Id of the resource that is requested.
+   * @param access_mode Access mode of the request.
+   * @param type Type of the request.
+   */
+  LockRequest(TransactionId tid,
+              const ResourceId &rid,
+              AccessMode access_mode,
+              RequestType request_type)
+      : tid_(tid),
+        rid_(rid),
+        access_mode_(access_mode),
+        request_type_(type) {
+  }
+
+  /**
+   * @brief Getter for transaction id.
+   *
+   * @return Transaction id of the request.
+   **/
+  inline TransactionId getTransactionId() const {
+    return tid_;
+  }
+
+  /**
+   * @brief Getter for resource id.
+   *
+   * @return Resource id of the request.
+   **/
+  inline const ResourceId& getResourceId() const {
+    return rid_;
+  }
+
+  /**
+   * @brief Getter for access mode.
+   *
+   * @return Access mode of the request.
+   **/
+  inline AccessMode getAccessMode() const {
+    return access_mode_;
+  }
+
+  /**
+   * @brief Getter for request type.
+   *
+   * @return Type of the request.
+   **/
+  inline RequestType getRequestType() const {
+    return request_type_;
+  }
+
+ private:
+  TransactionId tid_;
+  ResourceId rid_;
+  AccessMode access_mode_;
+  RequestType request_type_;
+};
+
+/** @} */
+
+}  // namespace transaction
+}  // namespace quickstep
+
+#endif

--- a/transaction/LockTable.cpp
+++ b/transaction/LockTable.cpp
@@ -35,7 +35,7 @@ LockTableResult
 LockTable::putLock(const transaction_id tid,
                    const ResourceId &rid,
                    const AccessMode access_mode) {
-  //TODO(hakan): Lock upgrade is not supported.
+  // TODO(hakan): Lock upgrade is not supported.
   lock_list_pair &lock_list_pair = internal_map_[rid];
 
   // Each resource id entry has own list and pending list.

--- a/transaction/LockTable.cpp
+++ b/transaction/LockTable.cpp
@@ -1,0 +1,206 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/LockTable.hpp"
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+#include "threading/SharedMutex.hpp"
+#include "transaction/AccessMode.hpp"
+#include "transaction/Lock.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+LockTableResult
+LockTable::putLock(const transaction_id tid,
+                   const ResourceId &rid,
+                   const AccessMode access_mode) {
+  //TODO(hakan): Lock upgrade is not supported.
+  lock_list_pair &lock_list_pair = internal_map_[rid];
+
+  // Each resource id entry has own list and pending list.
+  lock_own_list &lock_own_list = lock_list_pair.first;
+  lock_pending_list &lock_pending_list = lock_list_pair.second;
+
+  // Check this resource id already has the same lock request from
+  // the same transaction in the own list.
+  for (lock_own_list::const_iterator it = lock_own_list.cbegin();
+       it != lock_own_list.cend(); ++it) {
+    if (it->first == tid && it->second.getAccessMode() == access_mode) {
+      return LockTableResult::kALREADY_IN_OWNED;
+    }
+  }
+
+  // Check this resource id already has the same lock request from
+  // the same transaction in the pending list.
+  for (lock_pending_list::const_iterator it = lock_pending_list.cbegin();
+       it != lock_pending_list.cend(); ++it) {
+    if (it->first == tid && it->second.getAccessMode() == access_mode) {
+      return LockTableResult::kALREADY_IN_PENDING;
+    }
+  }
+
+  // If the execution can reach this point, it means the resource id
+  // does not have duplicate lock record (for both in owned and pending).
+  if (lock_pending_list.empty()) {
+    for (lock_own_list::const_iterator it = lock_own_list.cbegin();
+         it != lock_own_list.cend(); ++it) {
+      if (!access_mode.isCompatible(it->second.getAccessMode())) {
+        lock_pending_list.push_back(std::make_pair(tid,
+                                                   Lock(rid, access_mode)));
+        return LockTableResult::kPLACED_IN_PENDING;
+      }
+    }
+
+    lock_own_list.push_back(std::make_pair(tid, Lock(rid, access_mode)));
+    return LockTableResult::kPLACED_IN_OWNED;
+  } else {
+    // If the pending list is not empty, even if the lock request is compatible
+    // with other owned lock entries, we put the new request into the pending
+    // list to eliminate starvation.
+    lock_pending_list.push_back(std::make_pair(tid, Lock(rid, access_mode)));
+    return LockTableResult::kPLACED_IN_PENDING;
+  }
+}
+
+LockTableResult
+LockTable::deleteLock(const transaction_id tid,
+                      const ResourceId &rid) {
+  lock_list_pair &lock_list_pair = internal_map_[rid];
+
+  // Each resource id has its own and pending locks list.
+  lock_own_list &lock_own_list = lock_list_pair.first;
+  lock_pending_list &lock_pending_list = lock_list_pair.second;
+
+  // Iterate over owned locks list to see the lock entry of the transaction
+  // on the resource id exists.
+  for (lock_own_list::const_iterator it = lock_own_list.begin();
+       it != lock_own_list.cend(); ++it) {
+    if (it->first == tid) {
+      // If it exists, erase it from the owned list.
+      lock_own_list.erase(it);
+
+      // Since we erased a lock entry from owned list, the first entries
+      // in the pending list can be pushed to owned list if they are
+      // compatible with the remaining owned entries.
+      movePendingToOwned(rid);
+
+      return LockTableResult::kDEL_FROM_OWNED;
+    }
+  }
+
+  // Iterate over pending locks list to check the lock entry of the transaction
+  // on this resource id exists.
+  for (lock_pending_list::const_iterator it = lock_pending_list.begin();
+         it != lock_pending_list.cend(); ++it) {
+    if (it->first == tid) {
+      // If it exists, erase it from pending list.
+      lock_pending_list.erase(it);
+      return LockTableResult::kDEL_FROM_PENDING;
+    }
+  }
+
+  // Execution reaches here, if we cannot find the corresponding lock entry
+  // in the both list.
+  return LockTableResult::kDEL_ERROR;
+}
+
+void LockTable::movePendingToOwned(const ResourceId &rid) {
+  lock_list_pair &lock_list_pair = internal_map_[rid];
+  lock_own_list &lock_own_list = lock_list_pair.first;
+  lock_pending_list &lock_pending_list = lock_list_pair.second;
+
+  // Iterate over pending list to pending requests compatible with the
+  // all entries in the resource ids owned lock list.
+  for (lock_pending_list::const_iterator pending_it = lock_pending_list.cbegin();
+         pending_it != lock_pending_list.cend(); ++pending_it) {
+    transaction_id pending_tid = pending_it->first;
+    AccessMode pending_mode = pending_it->second.getAccessMode();
+    bool is_compatible_with_own_list = true;
+
+    // Now compare against the all entries in the owned lock list.
+    for (lock_own_list::const_iterator owned_it = lock_own_list.cbegin();
+           owned_it != lock_pending_list.cend(); ++owned_it) {
+      AccessMode owned_mode = owned_it->second.getAccessMode();
+      if (!pending_mode.isCompatible(owned_mode)) {
+        // If it is not compatible, we will not move this entry.
+        is_compatible_with_own_list = false;
+        break;
+      }
+    }
+
+    // If this pending lock entry is compatible with the all entries in the
+    // owned lock list, we should move it from pending list to owned list.
+    if (is_compatible_with_own_list) {
+      // Erase the entry from the list. Get the new iterator.
+      pending_it = lock_pending_list.erase(pending_it);
+
+      // Put the corresponding entry to the own list.
+      lock_own_list.emplace_back(pending_tid, Lock(rid, pending_mode));
+
+      // Move iterator one step backward because erasing an element moves the
+      // iterator to the next element.
+      --pending_it;
+    } else {
+      // There is no need to iterate pending list anymore since
+      // we found first incompatible one. Checking, and accepting other pending
+      // entries may cause starvation.
+      break;
+    }
+  }
+}
+
+LockTable::iterator LockTable::begin() {
+  return internal_map_.begin();
+}
+
+LockTable::iterator LockTable::end() {
+  return internal_map_.end();
+}
+
+LockTable::const_iterator LockTable::begin() const {
+  return internal_map_.begin();
+}
+
+LockTable::const_iterator LockTable::end() const {
+  return internal_map_.end();
+}
+
+void LockTable::latchShared() {
+  mutex_.lockShared();
+}
+
+void LockTable::unlatchShared() {
+  mutex_.unlockShared();
+}
+
+void LockTable::latchExclusive() {
+  mutex_.lock();
+}
+
+void LockTable::unlatchExclusive() {
+  mutex_.unlock();
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/LockTable.hpp
+++ b/transaction/LockTable.hpp
@@ -1,0 +1,179 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TRANSACTION_LOCK_TABLE_HPP_
+#define QUICKSTEP_TRANSACTION_LOCK_TABLE_HPP_
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+#include "threading/SharedMutex.hpp"
+#include "transaction/AccessMode.hpp"
+#include "transaction/Lock.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+/** \addtogroup Transaction
+ * @{
+ */
+
+/**
+ * @brief Represents different results for LockTable's methods.
+ **/
+enum class LockTableResult {
+  kPLACED_IN_OWNED = 0,
+  kPLACED_IN_PENDING,
+  kALREADY_IN_OWNED,
+  kALREADY_IN_PENDING,
+  kDEL_FROM_OWNED,
+  kDEL_FROM_PENDING,
+  kDEL_ERROR,
+  kPUT_ERROR,
+};
+
+/**
+ * @brief LockTable class represents the hash map for RID and
+ *        list of locks on RID.
+ **/
+class LockTable {
+ public:
+  typedef std::pair<transaction_id, Lock> lock_entry;
+  typedef std::list<lock_entry> lock_own_list;
+  typedef std::list<lock_entry> lock_pending_list;
+  typedef std::pair<lock_own_list, lock_pending_list> lock_list_pair;
+  typedef std::unordered_map<ResourceId,
+                             lock_list_pair,
+                             ResourceId::ResourceIdHasher> internal_map_type;
+  typedef internal_map_type::iterator iterator;
+  typedef internal_map_type::const_iterator const_iterator;
+
+  /**
+   * @brief Constructor for LockTable.
+   **/
+  LockTable() {
+  }
+
+  /**
+   * @brief Puts the lock entry into the lock table for corresponding resource.
+   *
+   * @param tid Id of the transaction that requests the lock.
+   * @param rid Id of the resource to be locked.
+   * @param access_mode Access mode of the lock.
+   *
+   * @return LockTableResult::kPLACED_IN_OWNED if lock is granted,
+   *         LockTableResult::kPLACED_IN_PENDING if lock is not granted,
+   *         LockTableResult::kALREADY_IN_OWNED if lock has been
+   *         already granted,
+   *         LockTableResult::kALREADY_IN_PENDING if lock has been
+   *         already pending.
+   **/
+  LockTableResult putLock(const transaction_id tid,
+                          const ResourceId &rid,
+                          const AccessMode access_mode);
+  /**
+   * @brief Deletes the lock entry.
+   *
+   * @param tid Id of the transaction that owns or awaits.
+   * @param rid Id of resource that the lock covers.
+   *
+   * @return LockTableResult::kDEL_FROM_OWNED if the lock is deleted from
+   *         owned list,
+   *         LockTableResult::kDEL_FROM_PENDING if the lock is deleted from
+   *         pending list,
+   *         LockTableResult::kDEL_ERROR if the lock cannot be found
+   **/
+  LockTableResult deleteLock(const transaction_id tid,
+                             const ResourceId &rid);
+
+
+  /**
+   * @brief Iterator for begin position.
+   *
+   * @return Non-const Iterator which points to begin point
+   *         of the lock table.
+   **/
+  iterator begin();
+
+  /**
+   * @brief Iterator for end position.
+   *
+   * @return Non-const iterator which points to end point
+   *         of the lock table.
+   **/
+  iterator end();
+
+  /**
+   * @brief Iterator for begin position.
+   *
+   * @return Const iterator which points to the begin
+   *         point of the lock table.
+   **/
+  const_iterator begin() const;
+
+  /**
+   * @brief Iterator for end position.
+   *
+   * @return Const iterator which points to the end
+   *         point of the lock table.
+   **/
+  const_iterator end() const;
+
+  /**
+   * @brief Latch mutex in shared mode. Multiple shared mode
+   *        latch acquisition is compatible.
+   **/
+  void latchShared();
+
+  /**
+   * @brief Unlatch mutex in shared mode.
+   **/
+  void unlatchShared();
+
+  /**
+   * @brief Latch mutex in exclusive mode.
+   */
+  void latchExclusive();
+
+  /**
+   * @brief Unlatch mutex in exclusive mode.
+   */
+  void unlatchExclusive();
+
+ private:
+  // This method will be called after deletion of locks.
+  // After delete, some pending locks might be acquired.
+  void movePendingToOwned(const ResourceId &rid);
+
+  internal_map_type internal_map_;
+
+  // Mutex protects whole lock table.
+  SharedMutex mutex_;
+
+  DISALLOW_COPY_AND_ASSIGN(LockTable);
+};
+
+/** @} */
+
+}  // namespace transaction
+}  // namespace quickstep
+
+#endif

--- a/transaction/Transaction.cpp
+++ b/transaction/Transaction.cpp
@@ -1,0 +1,48 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/Transaction.hpp"
+
+#include <functional>
+
+namespace quickstep {
+
+namespace transaction {
+
+TransactionId Transaction::getTransactionId() const {
+  return tid_;
+}
+
+void Transaction::setStatus(TransactionStatus status) {
+  status_ = status;
+}
+
+TransactionStatus Transaction::getStatus() const {
+  return status_;
+}
+
+bool Transaction::operator==(const Transaction &other) const {
+  return tid_ == other.tid_;
+}
+
+std::size_t Transaction::TransactionHasher::operator()(const Transaction &transaction) const {
+  return std::hash<TransactionId>()(transaction.tid_);
+}
+
+}  // namespace transaction
+
+}  // namespace quickstep

--- a/transaction/TransactionTable.cpp
+++ b/transaction/TransactionTable.cpp
@@ -1,0 +1,140 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/TransactionTable.hpp"
+
+#include <cstddef>
+#include <list>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+TransactionTableResult
+TransactionTable::putOwnEntry(const transaction_id tid,
+                              const ResourceId &rid,
+                              const AccessMode access_mode) {
+  transaction_list_pair &transaction_list_pair = internal_map_[tid];
+  transaction_own_list &transaction_own_list = transaction_list_pair.first;
+
+  transaction_own_list.push_back(std::make_pair(rid, Lock(rid, access_mode)));
+
+  return TransactionTableResult::kPLACED_IN_OWNED;
+}
+
+TransactionTableResult
+TransactionTable::putPendingEntry(const transaction_id tid,
+                                  const ResourceId &rid,
+                                  const AccessMode access_mode) {
+  transaction_list_pair &transaction_list_pair = internal_map_[tid];
+  transaction_pending_list &transaction_pending_list
+      = transaction_list_pair.second;
+
+  transaction_pending_list.push_back(std::make_pair(rid,
+                                                    Lock(rid, access_mode)));
+
+  return TransactionTableResult::kPLACED_IN_PENDING;
+}
+
+TransactionTableResult
+TransactionTable::deleteOwnEntry(const transaction_id tid,
+                                 const ResourceId &rid,
+                                 const AccessMode access_mode) {
+  transaction_list_pair &transaction_list_pair = internal_map_[tid];
+  transaction_own_list &transaction_own_list = transaction_list_pair.first;
+
+  std::size_t original_size = transaction_own_list.size();
+  transaction_own_list.remove_if(
+      [&rid, &access_mode](TransactionEntry &entry) {
+        return entry.second.getResourceId() == rid
+        && entry.second.getAccessMode() == access_mode;
+      });
+  if (transaction_own_list.size() == original_size) {
+    return TransactionTableResult::kDEL_ERROR;
+  } else {
+    return TransactionTableResult::kDEL_FROM_OWNED;
+  }
+}
+
+TransactionTableResult
+TransactionTable::deletePendingEntry(const transaction_id tid,
+                                     const ResourceId &rid,
+                                     const AccessMode access_mode) {
+  transaction_list_pair &transaction_list_pair = internal_map_[tid];
+  transaction_pending_list &transaction_pending_list
+      = transaction_list_pair.second;
+
+  std::size_t original_size = transaction_pending_list.size();
+  transaction_pending_list.remove_if(
+     [&rid, &access_mode] (TransactionEntry &entry) {
+       return entry.second.getResourceId() == rid
+         && entry.second.getAccessMode() == access_mode;
+     });
+
+  if (transaction_pending_list.size() == original_size) {
+    return TransactionTableResult::kDEL_ERROR;
+  } else {
+    return TransactionTableResult::kDEL_FROM_PENDING;
+  }
+}
+
+std::vector<ResourceId>
+TransactionTable::getResourceIdList(transaction_id tid) {
+  std::vector<ResourceId> result;
+  const transaction_list_pair &transaction_list_pair = internal_map_[tid];
+  const transaction_own_list &transaction_own_list =
+      transaction_list_pair.second;
+  const transaction_pending_list
+      &transaction_pending_list = transaction_list_pair.first;
+
+  for (transaction_own_list::const_iterator it = transaction_own_list.begin();
+       it != transaction_own_list.end();
+       ++it) {
+    result.push_back(it->first);
+  }
+
+  for (transaction_pending_list::const_iterator
+           it = transaction_pending_list.begin();
+       it != transaction_pending_list.end();
+       ++it) {
+    result.push_back(it->first);
+  }
+
+  return result;
+}
+
+TransactionTableResult
+TransactionTable::deleteTransaction(const transaction_id tid) {
+  std::size_t original_size = internal_map_.size();
+  internal_map_.erase(id);
+  std::size_t size_after_delete = internal_map_.size();
+
+  if (original_size == size_after_delete) {
+    return  TransactionTableResult::kTRANSACTION_DELETE_ERROR;
+  }
+
+  return TransactionTableResult::kTRANSACTION_DELETE_OK;
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/TransactionTable.cpp
+++ b/transaction/TransactionTable.cpp
@@ -39,7 +39,7 @@ TransactionTable::putOwnEntry(const transaction_id tid,
 
   transaction_own_list.push_back(std::make_pair(rid, Lock(rid, access_mode)));
 
-  return TransactionTableResult::kPLACED_IN_OWNED;
+  return TransactionTableResult::kPlacedInOwned;
 }
 
 TransactionTableResult
@@ -53,7 +53,7 @@ TransactionTable::putPendingEntry(const transaction_id tid,
   transaction_pending_list.push_back(std::make_pair(rid,
                                                     Lock(rid, access_mode)));
 
-  return TransactionTableResult::kPLACED_IN_PENDING;
+  return TransactionTableResult::kPlacedInPending;
 }
 
 TransactionTableResult
@@ -65,14 +65,14 @@ TransactionTable::deleteOwnEntry(const transaction_id tid,
 
   std::size_t original_size = transaction_own_list.size();
   transaction_own_list.remove_if(
-      [&rid, &access_mode](TransactionEntry &entry) {
+      [&rid, &access_mode](transaction_entry &entry) {
         return entry.second.getResourceId() == rid
         && entry.second.getAccessMode() == access_mode;
       });
   if (transaction_own_list.size() == original_size) {
-    return TransactionTableResult::kDEL_ERROR;
+    return TransactionTableResult::kDelError;
   } else {
-    return TransactionTableResult::kDEL_FROM_OWNED;
+    return TransactionTableResult::kDelFromOwned;
   }
 }
 
@@ -86,20 +86,20 @@ TransactionTable::deletePendingEntry(const transaction_id tid,
 
   std::size_t original_size = transaction_pending_list.size();
   transaction_pending_list.remove_if(
-     [&rid, &access_mode] (TransactionEntry &entry) {
+     [&rid, &access_mode] (transaction_entry &entry) {
        return entry.second.getResourceId() == rid
          && entry.second.getAccessMode() == access_mode;
      });
 
   if (transaction_pending_list.size() == original_size) {
-    return TransactionTableResult::kDEL_ERROR;
+    return TransactionTableResult::kDelError;
   } else {
-    return TransactionTableResult::kDEL_FROM_PENDING;
+    return TransactionTableResult::kDelFromPending;
   }
 }
 
 std::vector<ResourceId>
-TransactionTable::getResourceIdList(transaction_id tid) {
+TransactionTable::getResourceIdList(const transaction_id tid) {
   std::vector<ResourceId> result;
   const transaction_list_pair &transaction_list_pair = internal_map_[tid];
   const transaction_own_list &transaction_own_list =
@@ -126,14 +126,14 @@ TransactionTable::getResourceIdList(transaction_id tid) {
 TransactionTableResult
 TransactionTable::deleteTransaction(const transaction_id tid) {
   std::size_t original_size = internal_map_.size();
-  internal_map_.erase(id);
+  internal_map_.erase(tid);
   std::size_t size_after_delete = internal_map_.size();
 
   if (original_size == size_after_delete) {
-    return  TransactionTableResult::kTRANSACTION_DELETE_ERROR;
+    return  TransactionTableResult::kTransactionDeleteError;
   }
 
-  return TransactionTableResult::kTRANSACTION_DELETE_OK;
+  return TransactionTableResult::kTransactionDeleteOk;
 }
 
 }  // namespace transaction

--- a/transaction/TransactionTable.hpp
+++ b/transaction/TransactionTable.hpp
@@ -1,0 +1,161 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TRANSACTION_TRANSACTION_TABLE_HPP_
+#define QUICKSTEP_TRANSACTION_TRANSACTION_TABLE_HPP_
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "transaction/Lock.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace transaction {
+
+/** \addtogroup Transaction
+ *  @{
+ */
+
+/**
+ * @brief Represents different result for TransactionTable's methods.
+ **/
+enum class TransactionTableResult {
+  kPLACED_IN_OWNED = 0,
+  kPLACED_IN_PENDING,
+  kALREADY_IN_OWNED,
+  kALREADY_IN_PENDING,
+  kDEL_FROM_OWNED,
+  kDEL_FROM_PENDING,
+  kDEL_ERROR,
+  kPUT_ERROR,
+  kTRANSACTION_DELETE_OK,
+  kTRANSACTION_DELETE_ERROR
+};
+
+/**
+ * @brief Class for keeping track of the owner and pending list of transactions.
+ **/
+class TransactionTable {
+ public:
+  typedef std::pair<ResourceId, Lock> transaction_entry;
+  typedef transaction_own_list std::list<transaction_entry>;
+  typedef transaction_pending_list = std::list<transaction_entry>;
+  typedef transaction_list_pair = std::pair<transaction_own_list,
+                                            transaction_pending_list>;
+
+  /**
+   * @brief Contructor for TransactionTable.
+   **/
+  TransactionTable() {
+  }
+
+  /**
+   * @brief Puts a owned entry of the given resource id in the given
+   *        transaction's owned list.
+   *
+   * @param tid Transaction id of the requestor.
+   * @param rid Resource id of the corresponding lock.
+   * @param access_mode Access mode of the lock.
+   *
+   * @return TransactionTableResult::kPLACED_IN_OWNED since it is
+   *         always a successful operation on owned list.
+   **/
+  TransactionTableResult putOwnEntry(TransactionId tid,
+                                     const ResourceId &rid,
+                                     AccessMode access_mode);
+
+  /**
+   * @brief Puts a pending entry of the given resource id in the given
+   *        transaction's pending list.
+   *
+   * @param tid Transaction id of the requestor.
+   * @param rid Resource id of the corresponding lock.
+   * @param access_mode Access mode of the lock.
+   *
+   * @return TransactionTableResult::kPLACED_IN_PENDING
+   **/
+  TransactionTableResult putPendingEntry(TransactionId tid,
+                                         const ResourceId &rid,
+                                         AccessMode access_mode);
+
+  /**
+   * @brief Deletes the owned entry corresponding to the resource id
+   *        in the transaction's owned list.
+   *
+   * @param tid Transaction id of the owner.
+   * @param rid Resource id of the corresponding lock.
+   * @param access_mode Access mode of the lock.
+   *
+   * @return TransactionTableResult::kDEL_FROM_OWNED if the entry is deleted,
+   *         otherwise TransactionTable::kDEL_ERROR.
+   **/
+  TransactionTableResult deleteOwnEntry(TransactionId tid,
+                                        const ResourceId &rid,
+                                        AccessMode access_mode);
+
+  /**
+   * @brief Deletes the pending entry corresponding to the resource id
+   *        in the transaction's pending list.
+   * @param tid Transaction id of the owner.
+   * @param rid Resource id of the corresponding lock.
+   * @param access_mode Access mode of the lock.
+   *
+   * @return TransactionTableResult::kDEL_FROM_PENDING if the entry is
+   *         successfuly deleted, otherwise TransactionTableResult::k_DEL_ERROR.
+   **/
+  TransactionTableResult deletePendingEntry(TransactionId tid,
+                                            const ResourceId &rid,
+                                            AccessMode access_mode);
+
+  /**
+   * @brief Returns a vector of resource ids which the corresponding transaction
+   *        owns or pends.
+   *
+   * @param tid Transaction id of the corresponding transaction
+   *
+   * @return Vector of resource id that the transaction owns or pends.
+   **/
+  std::vector<ResourceId> getResourceIdList(TransactionId tid);
+
+  /**
+   * @brief Deletes the transaction entry from transaction table.
+   *
+   * @param tid Transaction id of the corresponding transaction.
+   *
+   * @return TransactionTableResult::kTRANSACTION_DELETE_ERROR if there is no
+   *         entry for the transaction, otherwise
+   *         TransactionTableResult::kTRANSACTION_DELETE_OK.
+   **/
+  TransactionTableResult deleteTransaction(TransactionId tid);
+
+ private:
+  std::unordered_map<TransactionId, TransactionListPair> internal_map_;
+
+  DISALLOW_COPY_AND_ASSIGN(TransactionTable);
+};
+
+/** @} */
+
+}  // namespace transaction
+}  // namespace quickstep
+
+#endif

--- a/transaction/TransactionTable.hpp
+++ b/transaction/TransactionTable.hpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "transaction/AccessMode.hpp"
 #include "transaction/Lock.hpp"
 #include "transaction/ResourceId.hpp"
 #include "transaction/Transaction.hpp"
@@ -39,16 +40,15 @@ namespace transaction {
  * @brief Represents different result for TransactionTable's methods.
  **/
 enum class TransactionTableResult {
-  kPLACED_IN_OWNED = 0,
-  kPLACED_IN_PENDING,
-  kALREADY_IN_OWNED,
-  kALREADY_IN_PENDING,
-  kDEL_FROM_OWNED,
-  kDEL_FROM_PENDING,
-  kDEL_ERROR,
-  kPUT_ERROR,
-  kTRANSACTION_DELETE_OK,
-  kTRANSACTION_DELETE_ERROR
+  kPlacedInOwned = 0,
+  kPlacedInPending,
+  kAlreadyInOwned,
+  kAlreadyInPending,
+  kDelFromOwned,
+  kDelFromPending,
+  kDelError,
+  kTransactionDeleteOk,
+  kTransactionDeleteError,
 };
 
 /**
@@ -57,10 +57,10 @@ enum class TransactionTableResult {
 class TransactionTable {
  public:
   typedef std::pair<ResourceId, Lock> transaction_entry;
-  typedef transaction_own_list std::list<transaction_entry>;
-  typedef transaction_pending_list = std::list<transaction_entry>;
-  typedef transaction_list_pair = std::pair<transaction_own_list,
-                                            transaction_pending_list>;
+  typedef std::list<transaction_entry> transaction_own_list;
+  typedef std::list<transaction_entry> transaction_pending_list;
+  typedef std::pair<transaction_own_list, transaction_pending_list>
+      transaction_list_pair;
 
   /**
    * @brief Contructor for TransactionTable.
@@ -79,9 +79,9 @@ class TransactionTable {
    * @return TransactionTableResult::kPLACED_IN_OWNED since it is
    *         always a successful operation on owned list.
    **/
-  TransactionTableResult putOwnEntry(TransactionId tid,
+  TransactionTableResult putOwnEntry(const transaction_id tid,
                                      const ResourceId &rid,
-                                     AccessMode access_mode);
+                                     const AccessMode access_mode);
 
   /**
    * @brief Puts a pending entry of the given resource id in the given
@@ -93,9 +93,9 @@ class TransactionTable {
    *
    * @return TransactionTableResult::kPLACED_IN_PENDING
    **/
-  TransactionTableResult putPendingEntry(TransactionId tid,
+  TransactionTableResult putPendingEntry(const transaction_id tid,
                                          const ResourceId &rid,
-                                         AccessMode access_mode);
+                                         const AccessMode access_mode);
 
   /**
    * @brief Deletes the owned entry corresponding to the resource id
@@ -108,9 +108,9 @@ class TransactionTable {
    * @return TransactionTableResult::kDEL_FROM_OWNED if the entry is deleted,
    *         otherwise TransactionTable::kDEL_ERROR.
    **/
-  TransactionTableResult deleteOwnEntry(TransactionId tid,
+  TransactionTableResult deleteOwnEntry(const transaction_id tid,
                                         const ResourceId &rid,
-                                        AccessMode access_mode);
+                                        const AccessMode access_mode);
 
   /**
    * @brief Deletes the pending entry corresponding to the resource id
@@ -122,9 +122,9 @@ class TransactionTable {
    * @return TransactionTableResult::kDEL_FROM_PENDING if the entry is
    *         successfuly deleted, otherwise TransactionTableResult::k_DEL_ERROR.
    **/
-  TransactionTableResult deletePendingEntry(TransactionId tid,
+  TransactionTableResult deletePendingEntry(const transaction_id tid,
                                             const ResourceId &rid,
-                                            AccessMode access_mode);
+                                            const AccessMode access_mode);
 
   /**
    * @brief Returns a vector of resource ids which the corresponding transaction
@@ -134,7 +134,7 @@ class TransactionTable {
    *
    * @return Vector of resource id that the transaction owns or pends.
    **/
-  std::vector<ResourceId> getResourceIdList(TransactionId tid);
+  std::vector<ResourceId> getResourceIdList(const transaction_id tid);
 
   /**
    * @brief Deletes the transaction entry from transaction table.
@@ -145,10 +145,10 @@ class TransactionTable {
    *         entry for the transaction, otherwise
    *         TransactionTableResult::kTRANSACTION_DELETE_OK.
    **/
-  TransactionTableResult deleteTransaction(TransactionId tid);
+  TransactionTableResult deleteTransaction(const transaction_id tid);
 
  private:
-  std::unordered_map<TransactionId, TransactionListPair> internal_map_;
+  std::unordered_map<transaction_id, transaction_list_pair> internal_map_;
 
   DISALLOW_COPY_AND_ASSIGN(TransactionTable);
 };

--- a/transaction/tests/LockRequest_unittest.cpp
+++ b/transaction/tests/LockRequest_unittest.cpp
@@ -1,0 +1,49 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/LockRequest.hpp"
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+namespace transaction {
+
+class LockRequestTest : public ::testing::Test {
+ protected:
+  LockRequestTest()
+      : lock_request_(transaction_id(3),
+                      ResourceId(5),
+                      AccessMode(AccessModeType::kSLock),
+                      RequestType::kAcquireLock) {
+  }
+
+  const LockRequest lock_request_;
+};
+
+TEST_F(LockRequestTest, CheckGetters) {
+  EXPECT_EQ(transaction_id(3), lock_request_.getTransactionId());
+  EXPECT_EQ(ResourceId(5), lock_request_.getResourceId());
+  EXPECT_EQ(AccessMode(AccessModeType::kSLock), lock_request_.getAccessMode());
+  EXPECT_EQ(RequestType::kAcquireLock, lock_request_.getRequestType());
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/tests/LockTable_unittest.cpp
+++ b/transaction/tests/LockTable_unittest.cpp
@@ -1,0 +1,105 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "transaction/LockTable.hpp"
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+namespace transaction {
+
+class LockTableTest : public ::testing::Test {
+ protected:
+  LockTableTest()
+      : tid_1_(1),
+        tid_2_(2),
+        tid_3_(3) {
+  }
+
+  LockTable lock_table_;
+  const transaction_id tid_1_;
+  const transaction_id tid_2_;
+  const transaction_id tid_3_;
+};
+
+TEST_F(LockTableTest, CompatibleRequestsFromDifferentTransactions) {
+  EXPECT_EQ(lock_table_.putLock(tid_1_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kIsLock)),
+            LockTableResult::kPLACED_IN_OWNED);
+
+  // Acquire the same lock mode on same resource.
+  EXPECT_EQ(lock_table_.putLock(tid_1_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kIsLock)),
+            LockTableResult::kALREADY_IN_OWNED);
+
+  // Another transaction acquires compatible lock on the same resource.
+  EXPECT_EQ(lock_table_.putLock(tid_2_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kSLock)),
+            LockTableResult::kPLACED_IN_OWNED);
+}
+
+TEST_F(LockTableTest, IncompatibleRequestsFromDifferentTransactions) {
+  EXPECT_EQ(lock_table_.putLock(tid_1_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kIsLock)),
+            LockTableResult::kPLACED_IN_OWNED);
+
+  // Acquire the same lock mode on same resource.
+  EXPECT_EQ(lock_table_.putLock(tid_1_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kIsLock)),
+            LockTableResult::kALREADY_IN_OWNED);
+
+  // Another transaction acquires incompatible lock on the same resource.
+  EXPECT_EQ(lock_table_.putLock(tid_2_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kXLock)),
+            LockTableResult::kPLACED_IN_PENDING);
+}
+
+TEST_F(LockTableTest, StarvationProtection) {
+  EXPECT_EQ(lock_table_.putLock(tid_1_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kIsLock)),
+            LockTableResult::kPLACED_IN_OWNED);
+
+  // Another transaction requests incompatible lock on the same resource.
+  // It should wait for the previous transaction.
+  EXPECT_EQ(lock_table_.putLock(tid_2_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kXLock)),
+            LockTableResult::kPLACED_IN_PENDING);
+
+  // Another third transaction requests a compatible lock on the same resource.
+  // Normally, it should acquire the lock, however, there is a pending
+  // transaction waiting on the same resource. To prevent starvation, we should
+  // put in the pending list.
+  EXPECT_EQ(lock_table_.putLock(tid_3_,
+                                ResourceId(2),
+                                AccessMode(AccessModeType::kIsLock)),
+            LockTableResult::kPLACED_IN_PENDING);
+}
+
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/tests/TransactionTable_unittest.cpp
+++ b/transaction/tests/TransactionTable_unittest.cpp
@@ -1,3 +1,20 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
 #include "transaction/TransactionTable.hpp"
 
 #include "transaction/AccessMode.hpp"
@@ -111,5 +128,5 @@ TEST_F(TransactionTableTest, TransactionEntries) {
             TransactionTableResult::kDelError);
 }
 
-}
-}
+}  // namespace transaction
+}  // namespace quickstep

--- a/transaction/tests/TransactionTable_unittest.cpp
+++ b/transaction/tests/TransactionTable_unittest.cpp
@@ -1,0 +1,115 @@
+#include "transaction/TransactionTable.hpp"
+
+#include "transaction/AccessMode.hpp"
+#include "transaction/ResourceId.hpp"
+#include "transaction/Transaction.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+namespace transaction {
+
+class TransactionTableTest : public ::testing::Test {
+ protected:
+  TransactionTableTest()
+      : tid_1_(1),
+        tid_2_(2),
+        tid_3_(3) {
+    }
+
+  TransactionTable transaction_table_;
+  const transaction_id tid_1_;
+  const transaction_id tid_2_;
+  const transaction_id tid_3_;
+};
+
+TEST_F(TransactionTableTest, NormalOperations) {
+  EXPECT_EQ(transaction_table_.putOwnEntry(tid_1_,
+                                           ResourceId(3),
+                                           AccessMode(AccessModeType::kIsLock)),
+            TransactionTableResult::kPlacedInOwned);
+
+  EXPECT_EQ(transaction_table_.putPendingEntry(tid_1_,
+                                               ResourceId(5),
+                                               AccessMode(AccessModeType::kXLock)),
+            TransactionTableResult::kPlacedInPending);
+}
+
+TEST_F(TransactionTableTest, DeleteEntryOperations) {
+  EXPECT_EQ(transaction_table_.deleteOwnEntry(tid_2_,
+                                              ResourceId(5),
+                                              AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelError);
+
+  EXPECT_EQ(transaction_table_.putOwnEntry(tid_2_,
+                                           ResourceId(5),
+                                           AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kPlacedInOwned);
+
+  // Tring to delete a lock with different acces mode on same resource id
+  // will result in an error.
+  EXPECT_EQ(transaction_table_.deleteOwnEntry(tid_2_,
+                                              ResourceId(5),
+                                              AccessMode(AccessModeType::kXLock)),
+            TransactionTableResult::kDelError);
+
+  // Transaction 3 does not have a lock on this resource id.
+  EXPECT_EQ(transaction_table_.deleteOwnEntry(tid_3_,
+                                              ResourceId(5),
+                                              AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelError);
+
+  // This will result in success since transaction 2 have acquired the lock on
+  // this resource with the corresponding mode.
+  EXPECT_EQ(transaction_table_.deleteOwnEntry(tid_2_,
+                                              ResourceId(5),
+                                              AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelFromOwned);
+
+  // Repeat the previous sequence, with pending list.
+  EXPECT_EQ(transaction_table_.deletePendingEntry(tid_2_,
+                                                  ResourceId(5),
+                                                  AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelError);
+
+  EXPECT_EQ(transaction_table_.putPendingEntry(tid_2_,
+                                               ResourceId(5),
+                                               AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kPlacedInPending);
+
+  EXPECT_EQ(transaction_table_.deletePendingEntry(tid_2_,
+                                                  ResourceId(5),
+                                                  AccessMode(AccessModeType::kXLock)),
+            TransactionTableResult::kDelError);
+
+  EXPECT_EQ(transaction_table_.deletePendingEntry(tid_3_,
+                                                  ResourceId(5),
+                                                  AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelError);
+
+  EXPECT_EQ(transaction_table_.deletePendingEntry(tid_2_,
+                                                  ResourceId(5),
+                                                  AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelFromPending);
+}
+
+TEST_F(TransactionTableTest, TransactionEntries) {
+  EXPECT_EQ(transaction_table_.deleteTransaction(tid_1_),
+            TransactionTableResult::kTransactionDeleteError);
+
+  EXPECT_EQ(transaction_table_.putOwnEntry(tid_1_,
+                                           ResourceId(4),
+                                           AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kPlacedInOwned);
+
+  EXPECT_EQ(transaction_table_.deleteTransaction(tid_1_),
+            TransactionTableResult::kTransactionDeleteOk);
+
+  EXPECT_EQ(transaction_table_.deleteOwnEntry(tid_1_,
+                                              ResourceId(4),
+                                              AccessMode(AccessModeType::kSLock)),
+            TransactionTableResult::kDelError);
+}
+
+}
+}


### PR DESCRIPTION
This PR includes 3 new classes:

- LockTable: Maps each resource to the transaction that have a lock on that resource.

- TransactionTable: Inverted version of LockTable.

- LockRequest: Input for LockManager which will be added later. 