### PR TITLE
Revert "Use an explicit Agent (TMB Client) to send messages to Foreman."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015-2016 Pivotal Software, Inc.
+#   Copyright 2015 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -698,6 +698,7 @@ target_link_libraries(quickstep_cli_shell
                       quickstep_queryoptimizer_QueryPlan
                       quickstep_queryoptimizer_QueryProcessor
                       quickstep_storage_PreloaderThread
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
                       quickstep_utility_SqlError)

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -65,6 +65,7 @@ typedef quickstep::LineReaderDumb LineReaderImpl;
 #endif
 
 #include "storage/PreloaderThread.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "utility/Macros.hpp"
 #include "utility/PtrVector.hpp"
 #include "utility/SqlError.hpp"
@@ -176,6 +177,10 @@ int main(int argc, char* argv[]) {
               << quickstep::FLAGS_hdfs_num_replications << "\n";
   }
 #endif
+
+  // Initialize the thread ID based map here before the Foreman and workers are
+  // constructed because the initialization isn't thread safe.
+  quickstep::ClientIDMap::Instance();
 
   MessageBusImpl bus;
   bus.Initialize();

--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(quickstep_queryexecution_QueryExecutionState
                       glog
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryexecution_QueryExecutionTypedefs
+                      quickstep_threading_ThreadIDBasedMap
                       tmb)
 target_link_libraries(quickstep_queryexecution_QueryExecutionUtil
                       quickstep_queryexecution_QueryExecutionTypedefs
@@ -124,6 +125,7 @@ target_link_libraries(quickstep_queryexecution_Worker
                       quickstep_queryexecution_WorkerMessage
                       quickstep_relationaloperators_WorkOrder
                       quickstep_threading_Thread
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_threading_ThreadUtil
                       quickstep_utility_Macros
                       tmb)

--- a/query_execution/Foreman.cpp
+++ b/query_execution/Foreman.cpp
@@ -407,7 +407,6 @@ bool Foreman::fetchNormalWorkOrders(const dag_node_index index) {
                                                                    query_context_.get(),
                                                                    storage_manager_,
                                                                    foreman_client_id_,
-                                                                   agent_client_id_,
                                                                    bus_);
     if (done_generation) {
       query_exec_state_->setDoneGenerationWorkOrders(index);
@@ -524,7 +523,6 @@ void Foreman::getRebuildWorkOrders(const dag_node_index index, WorkOrdersContain
                             index,
                             op.getOutputRelationID(),
                             foreman_client_id_,
-                            agent_client_id_,
                             bus_),
         index);
   }

--- a/query_execution/Foreman.hpp
+++ b/query_execution/Foreman.hpp
@@ -83,6 +83,8 @@ class Foreman final : public ForemanLite {
         num_numa_nodes_(num_numa_nodes) {
     bus_->RegisterClientAsSender(foreman_client_id_, kWorkOrderMessage);
     bus_->RegisterClientAsSender(foreman_client_id_, kRebuildWorkOrderMessage);
+    // NOTE(zuyu): For the single-node version, act as the sender on behalf of InsertDestinations.
+    bus_->RegisterClientAsSender(foreman_client_id_, kCatalogRelationNewBlockMessage);
     // NOTE : Right now, foreman thread doesn't send poison messages. In the
     // future if foreman needs to abort a worker thread, this registration
     // should be useful.
@@ -98,12 +100,6 @@ class Foreman final : public ForemanLite {
                                    kWorkOrdersAvailableMessage);
     bus_->RegisterClientAsReceiver(foreman_client_id_,
                                    kWorkOrderFeedbackMessage);
-
-    agent_client_id_ = bus_->Connect();
-    bus_->RegisterClientAsSender(agent_client_id_, kCatalogRelationNewBlockMessage);
-    bus_->RegisterClientAsSender(agent_client_id_, kDataPipelineMessage);
-    bus_->RegisterClientAsSender(agent_client_id_, kWorkOrderFeedbackMessage);
-    bus_->RegisterClientAsSender(agent_client_id_, kWorkOrdersAvailableMessage);
   }
 
   ~Foreman() override {}
@@ -124,7 +120,7 @@ class Foreman final : public ForemanLite {
    **/
   inline void reconstructQueryContextFromProto(const serialization::QueryContext &proto) {
     query_context_.reset(
-        new QueryContext(proto, *catalog_database_, storage_manager_, foreman_client_id_, agent_client_id_, bus_));
+        new QueryContext(proto, *catalog_database_, storage_manager_, foreman_client_id_, bus_));
   }
 
   /**
@@ -436,10 +432,6 @@ class Foreman final : public ForemanLite {
 
   CatalogDatabaseLite *catalog_database_;
   StorageManager *storage_manager_;
-
-  // The sender agent to send messages to Foreman on behalf of
-  // InsertDestinations and some WorkOrders.
-  tmb::client_id agent_client_id_;
 
   DAG<RelationalOperator, bool> *query_dag_;
 

--- a/query_execution/QueryContext.cpp
+++ b/query_execution/QueryContext.cpp
@@ -53,7 +53,6 @@ QueryContext::QueryContext(const serialization::QueryContext &proto,
                            const CatalogDatabaseLite &database,
                            StorageManager *storage_manager,
                            const tmb::client_id foreman_client_id,
-                           const tmb::client_id agent_client_id,
                            tmb::MessageBus *bus) {
   DCHECK(ProtoIsValid(proto, database))
       << "Attempted to create QueryContext from an invalid proto description:\n"
@@ -88,7 +87,6 @@ QueryContext::QueryContext(const serialization::QueryContext &proto,
                                                     insert_destination_proto.relation_id()),
                                                 storage_manager,
                                                 foreman_client_id,
-                                                agent_client_id,
                                                 bus));
   }
 

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -120,15 +120,12 @@ class QueryContext {
    *        in.
    * @param storage_manager The StorageManager to use.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    **/
   QueryContext(const serialization::QueryContext &proto,
                const CatalogDatabaseLite &database,
                StorageManager *storage_manager,
                const tmb::client_id foreman_client_id,
-               const tmb::client_id agent_client_id,
                tmb::MessageBus *bus);
 
   ~QueryContext() {}

--- a/query_execution/QueryExecutionTypedefs.hpp
+++ b/query_execution/QueryExecutionTypedefs.hpp
@@ -18,6 +18,8 @@
 #ifndef QUICKSTEP_QUERY_EXECUTION_QUERY_EXECUTION_TYPEDEFS_HPP_
 #define QUICKSTEP_QUERY_EXECUTION_QUERY_EXECUTION_TYPEDEFS_HPP_
 
+#include "threading/ThreadIDBasedMap.hpp"
+
 #include "tmb/address.h"
 #include "tmb/id_typedefs.h"
 #include "tmb/message_style.h"
@@ -39,6 +41,19 @@ typedef tmb::PureMemoryMessageBus<false> MessageBusImpl;
 typedef tmb::TaggedMessage TaggedMessage;
 typedef tmb::client_id client_id;
 typedef tmb::message_type_id message_type_id;
+
+using ClientIDMap = ThreadIDBasedMap<client_id,
+                                     'C',
+                                     'l',
+                                     'i',
+                                     'e',
+                                     'n',
+                                     't',
+                                     'I',
+                                     'D',
+                                     'M',
+                                     'a',
+                                     'p'>;
 
 enum QueryExecutionMessageType : message_type_id {
   kWorkOrderMessage,  // From Foreman to Worker.

--- a/query_execution/Worker.cpp
+++ b/query_execution/Worker.cpp
@@ -25,6 +25,7 @@
 #include "query_execution/QueryExecutionUtil.hpp"
 #include "query_execution/WorkerMessage.hpp"
 #include "relational_operators/WorkOrder.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "threading/ThreadUtil.hpp"
 
 #include "glog/logging.h"
@@ -44,6 +45,8 @@ void Worker::run() {
   if (cpu_id_ >= 0) {
     ThreadUtil::BindToCPU(cpu_id_);
   }
+  ClientIDMap *thread_id_map = ClientIDMap::Instance();
+  thread_id_map->addValue(worker_client_id_);
   for (;;) {
     // Receive() is a blocking call, causing this thread to sleep until next
     // message is received.
@@ -63,6 +66,8 @@ void Worker::run() {
         break;
       }
       case kPoisonMessage: {
+        // Remove the entry from the thread ID based map for this worker thread.
+        thread_id_map->removeValue();
         return;
       }
     }

--- a/query_execution/Worker.hpp
+++ b/query_execution/Worker.hpp
@@ -60,10 +60,12 @@ class Worker : public Thread {
     bus_->RegisterClientAsSender(worker_client_id_, kWorkOrderCompleteMessage);
     bus_->RegisterClientAsSender(worker_client_id_,
                                  kRebuildWorkOrderCompleteMessage);
+    bus_->RegisterClientAsSender(worker_client_id_, kDataPipelineMessage);
+    bus_->RegisterClientAsSender(worker_client_id_, kWorkOrdersAvailableMessage);
+    bus_->RegisterClientAsSender(worker_client_id_, kWorkOrderFeedbackMessage);
 
     bus_->RegisterClientAsReceiver(worker_client_id_, kWorkOrderMessage);
     bus_->RegisterClientAsReceiver(worker_client_id_, kRebuildWorkOrderMessage);
-
     bus_->RegisterClientAsReceiver(worker_client_id_, kPoisonMessage);
   }
 

--- a/query_execution/tests/Foreman_unittest.cpp
+++ b/query_execution/tests/Foreman_unittest.cpp
@@ -145,7 +145,6 @@ class MockOperator: public RelationalOperator {
       QueryContext *query_context,
       StorageManager *storage_manager,
       const tmb::client_id foreman_client_id,
-      const tmb::client_id agent_client_id,
       tmb::MessageBus *bus) override {
     ++num_calls_get_workorders_;
     if (produce_workorders_) {

--- a/query_optimizer/tests/CMakeLists.txt
+++ b/query_optimizer/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(quickstep_queryoptimizer_tests_ExecutionGeneratorTest
                       quickstep_queryoptimizer_QueryPlan
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_tests_TestDatabaseLoader
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       quickstep_utility_MemStream
                       quickstep_utility_SqlError

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.hpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.hpp
@@ -31,6 +31,7 @@
 #include "query_execution/WorkerDirectory.hpp"
 #include "query_execution/WorkerMessage.hpp"
 #include "query_optimizer/tests/TestDatabaseLoader.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "utility/Macros.hpp"
 #include "utility/textbased_test/TextBasedTestDriver.hpp"
 
@@ -53,7 +54,8 @@ class ExecutionGeneratorTestRunner : public TextBasedTestRunner {
    * @brief Constructor.
    */
   explicit ExecutionGeneratorTestRunner(const std::string &storage_path)
-      : test_database_loader_(storage_path) {
+      : test_database_loader_(storage_path),
+        thread_id_map_(ClientIDMap::Instance()) {
     test_database_loader_.createTestRelation(false /* allow_vchar */);
     test_database_loader_.loadTestRelation();
 
@@ -109,6 +111,11 @@ class ExecutionGeneratorTestRunner : public TextBasedTestRunner {
   std::unique_ptr<Worker> worker_;
 
   std::unique_ptr<WorkerDirectory> workers_;
+
+  // This map is needed for InsertDestination and some operators that send
+  // messages to Foreman directly. To know the reason behind the design of this
+  // map, see the note in InsertDestination.hpp.
+  ClientIDMap *thread_id_map_;
 
   DISALLOW_COPY_AND_ASSIGN(ExecutionGeneratorTestRunner);
 };

--- a/query_optimizer/tests/TestDatabaseLoader.cpp
+++ b/query_optimizer/tests/TestDatabaseLoader.cpp
@@ -93,7 +93,6 @@ void TestDatabaseLoader::loadTestRelation() {
                                          &storage_manager_,
                                          0 /* dummy op index */,
                                          foreman_client_id_,
-                                         agent_client_id_,
                                          &bus_);
   int sign = 1;
   for (int x = 0; x < 25; ++x) {

--- a/query_optimizer/tests/TestDatabaseLoader.hpp
+++ b/query_optimizer/tests/TestDatabaseLoader.hpp
@@ -59,10 +59,8 @@ class TestDatabaseLoader {
     bus_.Initialize();
 
     foreman_client_id_ = bus_.Connect();
+    bus_.RegisterClientAsSender(foreman_client_id_, kCatalogRelationNewBlockMessage);
     bus_.RegisterClientAsReceiver(foreman_client_id_, kCatalogRelationNewBlockMessage);
-
-    agent_client_id_ = bus_.Connect();
-    bus_.RegisterClientAsSender(agent_client_id_, kCatalogRelationNewBlockMessage);
   }
 
   ~TestDatabaseLoader() {
@@ -127,7 +125,7 @@ class TestDatabaseLoader {
   void processCatalogRelationNewBlockMessages();
 
   MessageBusImpl bus_;
-  tmb::client_id foreman_client_id_, agent_client_id_;
+  tmb::client_id foreman_client_id_;
 
   CatalogDatabase catalog_database_;
   StorageManager storage_manager_;

--- a/relational_operators/AggregationOperator.cpp
+++ b/relational_operators/AggregationOperator.cpp
@@ -33,7 +33,6 @@ bool AggregationOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (input_relation_is_stored_) {
     if (!started_) {

--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -75,7 +75,6 @@ class AggregationOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {

--- a/relational_operators/BuildHashOperator.cpp
+++ b/relational_operators/BuildHashOperator.cpp
@@ -61,7 +61,6 @@ bool BuildHashOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   DCHECK(query_context != nullptr);
 

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -90,7 +90,6 @@ class BuildHashOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id,

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -91,7 +91,7 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
 target_link_libraries(quickstep_relationaloperators_CreateIndexOperator
                       glog
                       quickstep_catalog_CatalogRelation
-                      quickstep_relationaloperators_RelationalOperator
+                      quickstep_relationaloperators_RelationalOperator                      
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_utility_Macros
                       tmb)
@@ -117,6 +117,7 @@ target_link_libraries(quickstep_relationaloperators_DeleteOperator
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_relationaloperators_DestroyHashOperator
@@ -213,6 +214,7 @@ target_link_libraries(quickstep_relationaloperators_RebuildWorkOrder
                       quickstep_queryexecution_QueryExecutionUtil
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_StorageBlock
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_relationaloperators_RelationalOperator
@@ -273,6 +275,7 @@ target_link_libraries(quickstep_relationaloperators_SortMergeRunOperator
                       quickstep_relationaloperators_SortMergeRunOperator_proto
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_StorageBlockInfo
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       quickstep_utility_SortConfiguration
                       tmb)
@@ -347,6 +350,7 @@ target_link_libraries(quickstep_relationaloperators_TextScanOperator
                       quickstep_storage_StorageBlob
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_types_Type
                       quickstep_types_TypedValue
                       quickstep_types_containers_Tuple
@@ -370,6 +374,7 @@ target_link_libraries(quickstep_relationaloperators_UpdateOperator
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_relationaloperators_WorkOrder
@@ -546,6 +551,7 @@ target_link_libraries(SortMergeRunOperator_unittest
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_types_IntType
                       quickstep_types_Type
                       quickstep_types_TypeID
@@ -594,6 +600,7 @@ target_link_libraries(SortRunGenerationOperator_unittest
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_types_IntType
                       quickstep_types_Type
                       quickstep_types_TypeID

--- a/relational_operators/CreateIndexOperator.cpp
+++ b/relational_operators/CreateIndexOperator.cpp
@@ -1,7 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *     University of Wisconsin—Madison.
- *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,7 +27,6 @@ bool CreateIndexOperator::getAllWorkOrders(WorkOrdersContainer *container,
                                            QueryContext *query_context,
                                            StorageManager *storage_manager,
                                            const tmb::client_id foreman_client_id,
-                                           const tmb::client_id agent_client_id,
                                            tmb::MessageBus *bus) {
   return true;
 }

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -1,7 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *     University of Wisconsin—Madison.
- *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -71,7 +70,6 @@ class CreateIndexOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void updateCatalogOnCompletion() override;

--- a/relational_operators/CreateTableOperator.cpp
+++ b/relational_operators/CreateTableOperator.cpp
@@ -30,7 +30,6 @@ bool CreateTableOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   return true;
 }

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -68,7 +68,6 @@ class CreateTableOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void updateCatalogOnCompletion() override;

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -79,7 +79,6 @@ class DeleteOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   const relation_id getOutputRelationID() const override {
@@ -128,8 +127,6 @@ class DeleteWorkOrder : public WorkOrder {
    * @param delete_operator_index The index of the Delete Operator in the query
    *        plan DAG.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    **/
   DeleteWorkOrder(const CatalogRelationSchema &input_relation,
@@ -138,7 +135,6 @@ class DeleteWorkOrder : public WorkOrder {
                   StorageManager *storage_manager,
                   const std::size_t delete_operator_index,
                   const tmb::client_id foreman_client_id,
-                  const tmb::client_id agent_client_id,
                   MessageBus *bus)
       : input_relation_(input_relation),
         input_block_id_(input_block_id),
@@ -146,7 +142,6 @@ class DeleteWorkOrder : public WorkOrder {
         storage_manager_(DCHECK_NOTNULL(storage_manager)),
         delete_operator_index_(delete_operator_index),
         foreman_client_id_(foreman_client_id),
-        agent_client_id_(agent_client_id),
         bus_(DCHECK_NOTNULL(bus)) {}
 
   ~DeleteWorkOrder() override {}
@@ -161,7 +156,7 @@ class DeleteWorkOrder : public WorkOrder {
   StorageManager *storage_manager_;
 
   const std::size_t delete_operator_index_;
-  const tmb::client_id foreman_client_id_, agent_client_id_;
+  const tmb::client_id foreman_client_id_;
   MessageBus *bus_;
 
   DISALLOW_COPY_AND_ASSIGN(DeleteWorkOrder);

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -29,7 +29,6 @@ bool DestroyHashOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -58,7 +58,6 @@ class DestroyHashOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
  private:

--- a/relational_operators/DropTableOperator.cpp
+++ b/relational_operators/DropTableOperator.cpp
@@ -36,7 +36,6 @@ bool DropTableOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -71,7 +71,6 @@ class DropTableOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void updateCatalogOnCompletion() override;

--- a/relational_operators/FinalizeAggregationOperator.cpp
+++ b/relational_operators/FinalizeAggregationOperator.cpp
@@ -32,7 +32,6 @@ bool FinalizeAggregationOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   DCHECK(query_context != nullptr);
 

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -72,7 +72,6 @@ class FinalizeAggregationOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {

--- a/relational_operators/HashJoinOperator.cpp
+++ b/relational_operators/HashJoinOperator.cpp
@@ -190,7 +190,6 @@ bool HashJoinOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   // We wait until the building of global hash table is complete.
   if (blocking_dependencies_met_) {

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -129,7 +129,6 @@ class HashJoinOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id,

--- a/relational_operators/InsertOperator.cpp
+++ b/relational_operators/InsertOperator.cpp
@@ -34,7 +34,6 @@ bool InsertOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     DCHECK(query_context != nullptr);

--- a/relational_operators/InsertOperator.hpp
+++ b/relational_operators/InsertOperator.hpp
@@ -71,7 +71,6 @@ class InsertOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {

--- a/relational_operators/NestedLoopsJoinOperator.cpp
+++ b/relational_operators/NestedLoopsJoinOperator.cpp
@@ -69,7 +69,6 @@ bool NestedLoopsJoinOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (left_relation_is_stored_ && right_relation_is_stored_) {
     // Make sure we generate workorders only once.

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -111,7 +111,6 @@ class NestedLoopsJoinOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void doneFeedingInputBlocks(const relation_id rel_id) override {

--- a/relational_operators/RebuildWorkOrder.hpp
+++ b/relational_operators/RebuildWorkOrder.hpp
@@ -29,6 +29,7 @@
 #include "query_execution/QueryExecutionUtil.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlock.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "utility/Macros.hpp"
 
 #include "tmb/message_bus.h"
@@ -59,13 +60,11 @@ class RebuildWorkOrder : public WorkOrder {
                    const std::size_t input_operator_index,
                    const relation_id input_relation_id,
                    const client_id foreman_client_id,
-                   const client_id agent_client_id,
                    MessageBus *bus)
       : block_ref_(std::move(block_ref)),
         input_operator_index_(input_operator_index),
         input_relation_id_(input_relation_id),
         foreman_client_id_(foreman_client_id),
-        agent_client_id_(agent_client_id),
         bus_(bus) {}
 
   ~RebuildWorkOrder() {}
@@ -92,21 +91,24 @@ class RebuildWorkOrder : public WorkOrder {
                                       kDataPipelineMessage);
     std::free(proto_bytes);
 
+    // Refer to InsertDestination::sendBlockFilledMessage for the rationale
+    // behind using the ClientIDMap map.
     const tmb::MessageBus::SendStatus send_status =
         QueryExecutionUtil::SendTMBMessage(bus_,
-                                           agent_client_id_,
+                                           ClientIDMap::Instance()->getValue(),
                                            foreman_client_id_,
                                            std::move(tagged_message));
-    CHECK(send_status == tmb::MessageBus::SendStatus::kOK)
-        << "Message could not be sent from the TMB client ID " << agent_client_id_
-        << " to Foreman with TMB client ID " << foreman_client_id_;
+    CHECK(send_status == tmb::MessageBus::SendStatus::kOK) << "Message could "
+        " not be sent from thread with TMB client ID " <<
+        ClientIDMap::Instance()->getValue() << " to Foreman with TMB client ID "
+        << foreman_client_id_;
   }
 
  private:
   MutableBlockReference block_ref_;
   const std::size_t input_operator_index_;
   const relation_id input_relation_id_;
-  const client_id foreman_client_id_, agent_client_id_;
+  const client_id foreman_client_id_;
 
   MessageBus *bus_;
 

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -69,8 +69,6 @@ class RelationalOperator {
    * @param query_context The QueryContext that stores query execution states.
    * @param storage_manager The StorageManager to use.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    *
    * @return Whether the operator has finished generating work orders. If \c
@@ -81,7 +79,6 @@ class RelationalOperator {
                                 QueryContext *query_context,
                                 StorageManager *storage_manager,
                                 const tmb::client_id foreman_client_id,
-                                const tmb::client_id agent_client_id,
                                 tmb::MessageBus *bus) = 0;
 
   /**

--- a/relational_operators/SampleOperator.cpp
+++ b/relational_operators/SampleOperator.cpp
@@ -1,7 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *     University of Wisconsin—Madison.
- *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,7 +38,6 @@ bool SampleOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   DCHECK(query_context != nullptr);
 

--- a/relational_operators/SampleOperator.hpp
+++ b/relational_operators/SampleOperator.hpp
@@ -1,7 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
  *     University of Wisconsin—Madison.
- *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -65,7 +64,7 @@ class SampleOperator : public RelationalOperator {
    *        workorders.
    * @param is_block_sample Flag indicating whether the sample type is block or tuple.
    * @param percentage The percentage of data to be sampled.
-   *
+   * 
    **/
   SampleOperator(const CatalogRelation &input_relation,
                  const CatalogRelationSchema &output_relation,
@@ -90,7 +89,6 @@ class SampleOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {

--- a/relational_operators/SaveBlocksOperator.cpp
+++ b/relational_operators/SaveBlocksOperator.cpp
@@ -32,7 +32,6 @@ bool SaveBlocksOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   while (num_workorders_generated_ < destination_block_ids_.size()) {
     container->addNormalWorkOrder(

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -63,7 +63,6 @@ class SaveBlocksOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override;

--- a/relational_operators/SelectOperator.cpp
+++ b/relational_operators/SelectOperator.cpp
@@ -40,7 +40,6 @@ bool SelectOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   DCHECK(query_context != nullptr);
 

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -132,7 +132,6 @@ class SelectOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {

--- a/relational_operators/SortMergeRunOperator.hpp
+++ b/relational_operators/SortMergeRunOperator.hpp
@@ -126,7 +126,6 @@ class SortMergeRunOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id,
@@ -170,7 +169,6 @@ class SortMergeRunOperator : public RelationalOperator {
                           QueryContext *query_context,
                           StorageManager *storage_manager,
                           const tmb::client_id foreman_client_id,
-                          const tmb::client_id agent_client_id,
                           tmb::MessageBus *bus);
 
   // Create a merge work order for the given merge job.
@@ -178,7 +176,6 @@ class SortMergeRunOperator : public RelationalOperator {
                              QueryContext *query_context,
                              StorageManager *storage_manager,
                              const tmb::client_id foreman_client_id,
-                             const tmb::client_id agent_client_id,
                              tmb::MessageBus *bus);
 
   const CatalogRelation &input_relation_;
@@ -229,8 +226,6 @@ class SortMergeRunWorkOrder : public WorkOrder {
    * @param operator_index Merge-run operator index to send feedback messages
    *                       to.
    * @param foreman_client_id Foreman's TMB client ID.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus TMB to send the feedback message on.
    **/
   SortMergeRunWorkOrder(
@@ -243,7 +238,6 @@ class SortMergeRunWorkOrder : public WorkOrder {
       StorageManager *storage_manager,
       const std::size_t operator_index,
       const tmb::client_id foreman_client_id,
-      const tmb::client_id agent_client_id,
       MessageBus *bus)
       : sort_config_(sort_config),
         run_relation_(run_relation),
@@ -254,7 +248,6 @@ class SortMergeRunWorkOrder : public WorkOrder {
         storage_manager_(DCHECK_NOTNULL(storage_manager)),
         operator_index_(operator_index),
         foreman_client_id_(foreman_client_id),
-        agent_client_id_(agent_client_id),
         bus_(DCHECK_NOTNULL(bus)) {
     DCHECK(sort_config_.isValid());
   }
@@ -269,7 +262,7 @@ class SortMergeRunWorkOrder : public WorkOrder {
   StorageManager *storage_manager_;
 
   const std::size_t operator_index_;
-  const tmb::client_id foreman_client_id_, agent_client_id_;
+  const tmb::client_id foreman_client_id_;
   MessageBus *bus_;
 
   friend class SortMergeRunOperator;

--- a/relational_operators/SortRunGenerationOperator.cpp
+++ b/relational_operators/SortRunGenerationOperator.cpp
@@ -39,7 +39,6 @@ bool SortRunGenerationOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   DCHECK(query_context != nullptr);
 

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -105,7 +105,6 @@ class SortRunGenerationOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {

--- a/relational_operators/TableGeneratorOperator.cpp
+++ b/relational_operators/TableGeneratorOperator.cpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
- *     University of Wisconsin—Madison.
+ *   University of Wisconsin—Madison.
  *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,6 @@ bool TableGeneratorOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (!started_) {
     DCHECK(query_context != nullptr);

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
- *     University of Wisconsin—Madison.
+ *   University of Wisconsin—Madison.
  *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,7 +77,6 @@ class TableGeneratorOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {

--- a/relational_operators/TextScanOperator.cpp
+++ b/relational_operators/TextScanOperator.cpp
@@ -39,6 +39,7 @@
 #include "storage/StorageBlob.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageManager.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "types/Type.hpp"
 #include "types/TypedValue.hpp"
 #include "types/containers/Tuple.hpp"
@@ -142,7 +143,6 @@ bool TextScanOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   DCHECK(query_context != nullptr);
 
@@ -166,7 +166,6 @@ bool TextScanOperator::getAllWorkOrders(
                                      storage_manager,
                                      op_index_,
                                      foreman_client_id,
-                                     agent_client_id,
                                      bus),
               op_index_);
           ++num_split_work_orders_;
@@ -600,7 +599,7 @@ void TextSplitWorkOrder::execute() {
                       nullptr /* payload */,
                       0 /* payload_size */,
                       false /* ownership */);
-  SendFeedbackMessage(bus_, agent_client_id_, foreman_client_id_, msg);
+  SendFeedbackMessage(bus_, ClientIDMap::Instance()->getValue(), foreman_client_id_, msg);
 }
 
 // Allocate new blob.
@@ -659,7 +658,7 @@ void TextSplitWorkOrder::sendBlobInfoToOperator(const bool write_row_aligned) {
                                operator_index_,
                                payload,
                                payload_size);
-  SendFeedbackMessage(bus_, agent_client_id_, foreman_client_id_, feedback_msg);
+  SendFeedbackMessage(bus_, ClientIDMap::Instance()->getValue(), foreman_client_id_, feedback_msg);
 
   // Notify Foreman for the avaiable work order on the blob.
   serialization::WorkOrdersAvailableMessage message_proto;
@@ -679,12 +678,13 @@ void TextSplitWorkOrder::sendBlobInfoToOperator(const bool write_row_aligned) {
   const tmb::MessageBus::SendStatus send_status =
       QueryExecutionUtil::SendTMBMessage(
           bus_,
-          agent_client_id_,
+          ClientIDMap::Instance()->getValue(),
           foreman_client_id_,
           std::move(tagged_message));
-  CHECK(send_status == tmb::MessageBus::SendStatus::kOK)
-      << "Message could not be sent from the TMB client ID " << agent_client_id_
-      << " to Foreman with TMB client ID " << foreman_client_id_;
+  CHECK(send_status == tmb::MessageBus::SendStatus::kOK) << "Message could not "
+      "be sent from thread with TMB client ID "
+      << ClientIDMap::Instance()->getValue() << " to Foreman with TMB client "
+      "ID " << foreman_client_id_;
 
   if (residue.size()) {
     // Allocate new blob, and copy residual bytes from last blob.

--- a/relational_operators/TextScanOperator.hpp
+++ b/relational_operators/TextScanOperator.hpp
@@ -157,7 +157,6 @@ class TextScanOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {
@@ -323,8 +322,6 @@ class TextSplitWorkOrder : public WorkOrder {
    * @param operator_index Operator index of the current operator. This is used
    *                       to send new-work available message to Foreman.
    * @param foreman_client_id The TMB client ID of the foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    */
   TextSplitWorkOrder(const std::string filename,
@@ -332,14 +329,12 @@ class TextSplitWorkOrder : public WorkOrder {
                      StorageManager *storage_manager,
                      const std::size_t operator_index,
                      const tmb::client_id foreman_client_id,
-                     const tmb::client_id agent_client_id,
                      MessageBus *bus)
       : filename_(filename),
         process_escape_sequences_(process_escape_sequences),
         storage_manager_(DCHECK_NOTNULL(storage_manager)),
         operator_index_(operator_index),
         foreman_client_id_(foreman_client_id),
-        agent_client_id_(agent_client_id),
         bus_(DCHECK_NOTNULL(bus)) {}
 
   /**
@@ -374,7 +369,7 @@ class TextSplitWorkOrder : public WorkOrder {
   StorageManager *storage_manager_;
 
   const std::size_t operator_index_;  // Opeartor index.
-  const tmb::client_id foreman_client_id_, agent_client_id_;
+  const tmb::client_id foreman_client_id_;  // Foreman TMB client ID.
   MessageBus *bus_;
 
   MutableBlobReference text_blob_;  // Mutable reference to current blob.

--- a/relational_operators/UpdateOperator.cpp
+++ b/relational_operators/UpdateOperator.cpp
@@ -31,6 +31,7 @@
 #include "storage/StorageBlock.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageManager.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "utility/Macros.hpp"
 
 #include "glog/logging.h"
@@ -46,7 +47,6 @@ bool UpdateOperator::getAllWorkOrders(
     QueryContext *query_context,
     StorageManager *storage_manager,
     const tmb::client_id foreman_client_id,
-    const tmb::client_id agent_client_id,
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !started_) {
     DCHECK(query_context != nullptr);
@@ -61,7 +61,6 @@ bool UpdateOperator::getAllWorkOrders(
                               storage_manager,
                               op_index_,
                               foreman_client_id,
-                              agent_client_id,
                               bus),
           op_index_);
     }
@@ -103,12 +102,13 @@ void UpdateWorkOrder::execute() {
   const tmb::MessageBus::SendStatus send_status =
       QueryExecutionUtil::SendTMBMessage(
           bus_,
-          agent_client_id_,
+          ClientIDMap::Instance()->getValue(),
           foreman_client_id_,
           std::move(tagged_message));
-  CHECK(send_status == tmb::MessageBus::SendStatus::kOK)
-      << "Message could not be sent from thread with TMB client ID " << agent_client_id_
-      << " to Foreman with TMB client ID " << foreman_client_id_;
+  CHECK(send_status == tmb::MessageBus::SendStatus::kOK) << "Message could not"
+      " be sent from thread with TMB client ID " <<
+      ClientIDMap::Instance()->getValue() << " to Foreman with TMB client ID "
+      << foreman_client_id_;
 }
 
 }  // namespace quickstep

--- a/relational_operators/UpdateOperator.hpp
+++ b/relational_operators/UpdateOperator.hpp
@@ -93,7 +93,6 @@ class UpdateOperator : public RelationalOperator {
                         QueryContext *query_context,
                         StorageManager *storage_manager,
                         const tmb::client_id foreman_client_id,
-                        const tmb::client_id agent_client_id,
                         tmb::MessageBus *bus) override;
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {
@@ -137,9 +136,7 @@ class UpdateWorkOrder : public WorkOrder {
    * @param storage_manager The StorageManager to use.
    * @param update_operator_index The index of the Update Operator in the query
    *        plan DAG.
-   * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
+   * @param foreman_input_queue The input queue in Foreman.
    * @param bus A pointer to the TMB.
    **/
   UpdateWorkOrder(const CatalogRelationSchema &relation,
@@ -150,7 +147,6 @@ class UpdateWorkOrder : public WorkOrder {
                   StorageManager *storage_manager,
                   const std::size_t update_operator_index,
                   const tmb::client_id foreman_client_id,
-                  const tmb::client_id agent_client_id,
                   MessageBus *bus)
       : relation_(relation),
         input_block_id_(input_block_id),
@@ -160,7 +156,6 @@ class UpdateWorkOrder : public WorkOrder {
         storage_manager_(DCHECK_NOTNULL(storage_manager)),
         update_operator_index_(update_operator_index),
         foreman_client_id_(foreman_client_id),
-        agent_client_id_(agent_client_id),
         bus_(DCHECK_NOTNULL(bus)) {}
 
   ~UpdateWorkOrder() override {}
@@ -177,7 +172,7 @@ class UpdateWorkOrder : public WorkOrder {
   StorageManager *storage_manager_;
 
   const std::size_t update_operator_index_;
-  const tmb::client_id foreman_client_id_, agent_client_id_;
+  const tmb::client_id foreman_client_id_;
   MessageBus *bus_;
 
   DISALLOW_COPY_AND_ASSIGN(UpdateWorkOrder);

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -109,10 +109,8 @@ class AggregationOperatorTest : public ::testing::Test {
     bus_.Initialize();
 
     foreman_client_id_ = bus_.Connect();
+    bus_.RegisterClientAsSender(foreman_client_id_, kCatalogRelationNewBlockMessage);
     bus_.RegisterClientAsReceiver(foreman_client_id_, kCatalogRelationNewBlockMessage);
-
-    agent_client_id_ = bus_.Connect();
-    bus_.RegisterClientAsSender(agent_client_id_, kCatalogRelationNewBlockMessage);
 
     storage_manager_.reset(new StorageManager(kStoragePath));
 
@@ -267,7 +265,6 @@ class AggregationOperatorTest : public ::testing::Test {
                                           *db_,
                                           storage_manager_.get(),
                                           foreman_client_id_,
-                                          agent_client_id_,
                                           &bus_));
 
     // Note: We treat these two operators as different query plan DAGs. The
@@ -350,7 +347,6 @@ class AggregationOperatorTest : public ::testing::Test {
                                           *db_,
                                           storage_manager_.get(),
                                           foreman_client_id_,
-                                          agent_client_id_,
                                           &bus_));
 
     // Note: We treat these two operators as different query plan DAGs. The
@@ -367,7 +363,6 @@ class AggregationOperatorTest : public ::testing::Test {
                           query_context_.get(),
                           storage_manager_.get(),
                           foreman_client_id_,
-                          agent_client_id_,
                           &bus_);
 
     while (op_container.hasNormalWorkOrder(op_index)) {
@@ -384,7 +379,6 @@ class AggregationOperatorTest : public ::testing::Test {
                                    query_context_.get(),
                                    storage_manager_.get(),
                                    foreman_client_id_,
-                                   agent_client_id_,
                                    &bus_);
 
     while (finalize_op_container.hasNormalWorkOrder(finalize_op_index)) {
@@ -473,7 +467,7 @@ class AggregationOperatorTest : public ::testing::Test {
   }
 
   MessageBusImpl bus_;
-  tmb::client_id foreman_client_id_, agent_client_id_;
+  tmb::client_id foreman_client_id_;
 
   std::unique_ptr<QueryContext> query_context_;
   std::unique_ptr<StorageManager> storage_manager_;

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -101,10 +101,8 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
     bus_.Initialize();
 
     foreman_client_id_ = bus_.Connect();
+    bus_.RegisterClientAsSender(foreman_client_id_, kCatalogRelationNewBlockMessage);
     bus_.RegisterClientAsReceiver(foreman_client_id_, kCatalogRelationNewBlockMessage);
-
-    agent_client_id_ = bus_.Connect();
-    bus_.RegisterClientAsSender(agent_client_id_, kCatalogRelationNewBlockMessage);
 
     storage_manager_.reset(new StorageManager("./test_data/"));
 
@@ -242,7 +240,6 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
                          query_context_.get(),
                          storage_manager_.get(),
                          foreman_client_id_,
-                         agent_client_id_,
                          &bus_);
 
     while (container.hasNormalWorkOrder(op_index)) {
@@ -253,7 +250,7 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
   }
 
   MessageBusImpl bus_;
-  tmb::client_id foreman_client_id_, agent_client_id_;
+  tmb::client_id foreman_client_id_;
 
   unique_ptr<QueryContext> query_context_;
   std::unique_ptr<StorageManager> storage_manager_;
@@ -348,7 +345,6 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   // Execute the operators.
@@ -491,7 +487,6 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   // Execute the operators.
@@ -642,7 +637,6 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   // Execute the operators.
@@ -778,7 +772,6 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   // Execute the operators.
@@ -948,7 +941,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   // Execute the operators.
@@ -1129,7 +1121,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   // Execute the operators.

--- a/relational_operators/tests/TextScanOperator_unittest.cpp
+++ b/relational_operators/tests/TextScanOperator_unittest.cpp
@@ -63,10 +63,8 @@ class TextScanOperatorTest : public ::testing::Test {
     bus_.Initialize();
 
     foreman_client_id_ = bus_.Connect();
+    bus_.RegisterClientAsSender(foreman_client_id_, kCatalogRelationNewBlockMessage);
     bus_.RegisterClientAsReceiver(foreman_client_id_, kCatalogRelationNewBlockMessage);
-
-    agent_client_id_ = bus_.Connect();
-    bus_.RegisterClientAsSender(agent_client_id_, kCatalogRelationNewBlockMessage);
 
     db_.reset(new CatalogDatabase(nullptr, "database"));
 
@@ -100,7 +98,6 @@ class TextScanOperatorTest : public ::testing::Test {
                          query_context_.get(),
                          storage_manager_.get(),
                          foreman_client_id_,
-                         agent_client_id_,
                          &bus_);
 
     while (container.hasNormalWorkOrder(op_index)) {
@@ -151,7 +148,7 @@ class TextScanOperatorTest : public ::testing::Test {
   }
 
   MessageBusImpl bus_;
-  tmb::client_id foreman_client_id_, agent_client_id_;
+  tmb::client_id foreman_client_id_;
 
   std::unique_ptr<CatalogDatabase> db_;
   CatalogRelation *relation_;
@@ -185,7 +182,6 @@ TEST_F(TextScanOperatorTest, ScanTest) {
                                         *db_,
                                         storage_manager_.get(),
                                         foreman_client_id_,
-                                        agent_client_id_,
                                         &bus_));
 
   fetchAndExecuteWorkOrders(text_scan_op.get());

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -583,6 +583,7 @@ target_link_libraries(quickstep_storage_InsertDestination
                       quickstep_storage_TupleIdSequence
                       quickstep_storage_ValueAccessorUtil
                       quickstep_threading_SpinMutex
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_types_TypedValue
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros

--- a/storage/InsertDestination.hpp
+++ b/storage/InsertDestination.hpp
@@ -35,6 +35,7 @@
 #include "storage/StorageBlockInfo.hpp"
 #include "storage/StorageBlockLayout.hpp"
 #include "threading/SpinMutex.hpp"
+#include "threading/ThreadIDBasedMap.hpp"
 #include "types/containers/Tuple.hpp"
 #include "utility/Macros.hpp"
 
@@ -85,7 +86,6 @@ class InsertDestination : public InsertDestinationInterface {
                     StorageManager *storage_manager,
                     const std::size_t relational_op_index,
                     const tmb::client_id foreman_client_id,
-                    const tmb::client_id agent_client_id,
                     tmb::MessageBus *bus);
 
   /**
@@ -103,8 +103,6 @@ class InsertDestination : public InsertDestinationInterface {
    * @param relation The relation to insert tuples into.
    * @param storage_manager The StorageManager to use.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    *
    * @return The constructed InsertDestination.
@@ -113,7 +111,6 @@ class InsertDestination : public InsertDestinationInterface {
                                                  const CatalogRelationSchema &relation,
                                                  StorageManager *storage_manager,
                                                  const tmb::client_id foreman_client_id,
-                                                 const tmb::client_id agent_client_id,
                                                  tmb::MessageBus *bus);
 
   /**
@@ -224,14 +221,35 @@ class InsertDestination : public InsertDestinationInterface {
                                       kDataPipelineMessage);
     std::free(proto_bytes);
 
+    // The reason we use the ClientIDMap is as follows:
+    // InsertDestination needs to send data pipeline messages to Foreman. To
+    // send a TMB message, we need to know the sender and receiver's TMB client
+    // ID. In this case, the sender thread is the worker thread that executes
+    // this function. To figure out the TMB client ID of the executing thread,
+    // there are multiple ways :
+    // 1. Trickle down the worker's client ID all the way from Worker::run()
+    // method until here.
+    // 2. Use thread-local storage - Each worker saves its TMB client ID in the
+    // local storage.
+    // 3. Use a globally accessible map whose key is the caller thread's
+    // process level ID and value is the TMB client ID.
+    //
+    // Option 1 involves modifying the signature of several functions across
+    // different modules. Option 2 was difficult to implement given that Apple's
+    // Clang doesn't allow C++11's thread_local keyword. Therefore we chose
+    // option 3.
+    ClientIDMap *thread_id_map = ClientIDMap::Instance();
+
+    DCHECK(bus_ != nullptr);
     const tmb::MessageBus::SendStatus send_status =
         QueryExecutionUtil::SendTMBMessage(bus_,
-                                           agent_client_id_,
+                                           thread_id_map->getValue(),
                                            foreman_client_id_,
                                            std::move(tagged_message));
-    CHECK(send_status == tmb::MessageBus::SendStatus::kOK)
-        << "Message could not be sent from thread with TMB client ID " << agent_client_id_
-        << " to Foreman with TMB client ID " << foreman_client_id_;
+    CHECK(send_status == tmb::MessageBus::SendStatus::kOK) <<
+        "Message could not be sent from thread with TMB client ID "
+        << ClientIDMap::Instance()->getValue() << " to Foreman with TMB client"
+        " ID " << foreman_client_id_;
   }
 
   StorageManager *storage_manager_;
@@ -240,7 +258,7 @@ class InsertDestination : public InsertDestinationInterface {
   std::unique_ptr<const StorageBlockLayout> layout_;
   const std::size_t relational_op_index_;
 
-  const tmb::client_id foreman_client_id_, agent_client_id_;
+  tmb::client_id foreman_client_id_;
   tmb::MessageBus *bus_;
 
   // TODO(chasseur): If contention is high, finer-grained locking of internal
@@ -263,29 +281,13 @@ class InsertDestination : public InsertDestinationInterface {
  **/
 class AlwaysCreateBlockInsertDestination : public InsertDestination {
  public:
-  /**
-   * @brief Constructor.
-   *
-   * @param relation The relation to insert tuples into.
-   * @param layout The layout to use for any newly-created blocks. If NULL,
-   *        defaults to relation's default layout.
-   * @param storage_manager The StorageManager to use.
-   * @param relational_op_index The index of the relational operator in the
-   *        QueryPlan DAG that has outputs.
-   * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
-   * @param bus A pointer to the TMB.
-   **/
   AlwaysCreateBlockInsertDestination(const CatalogRelationSchema &relation,
                                      const StorageBlockLayout *layout,
                                      StorageManager *storage_manager,
                                      const std::size_t relational_op_index,
                                      const tmb::client_id foreman_client_id,
-                                     const tmb::client_id agent_client_id,
                                      tmb::MessageBus *bus)
-      : InsertDestination(relation, layout, storage_manager, relational_op_index,
-                          foreman_client_id, agent_client_id, bus) {
+      : InsertDestination(relation, layout, storage_manager, relational_op_index, foreman_client_id, bus) {
   }
 
   ~AlwaysCreateBlockInsertDestination() override {
@@ -329,8 +331,6 @@ class BlockPoolInsertDestination : public InsertDestination {
    * @param relational_op_index The index of the relational operator in the
    *        QueryPlan DAG that has outputs.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    **/
   BlockPoolInsertDestination(const CatalogRelationSchema &relation,
@@ -338,10 +338,8 @@ class BlockPoolInsertDestination : public InsertDestination {
                              StorageManager *storage_manager,
                              const std::size_t relational_op_index,
                              const tmb::client_id foreman_client_id,
-                             const tmb::client_id agent_client_id,
                              tmb::MessageBus *bus)
-      : InsertDestination(relation, layout, storage_manager, relational_op_index,
-                          foreman_client_id, agent_client_id, bus) {
+      : InsertDestination(relation, layout, storage_manager, relational_op_index, foreman_client_id, bus) {
   }
 
   /**
@@ -355,8 +353,6 @@ class BlockPoolInsertDestination : public InsertDestination {
    * @param relational_op_index The index of the relational operator in the
    *        QueryPlan DAG that has outputs.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    **/
   BlockPoolInsertDestination(const CatalogRelationSchema &relation,
@@ -365,10 +361,8 @@ class BlockPoolInsertDestination : public InsertDestination {
                              std::vector<block_id> &&blocks,
                              const std::size_t relational_op_index,
                              const tmb::client_id foreman_client_id,
-                             const tmb::client_id agent_client_id,
                              tmb::MessageBus *bus)
-      : InsertDestination(relation, layout, storage_manager, relational_op_index,
-                          foreman_client_id, agent_client_id, bus),
+      : InsertDestination(relation, layout, storage_manager, relational_op_index, foreman_client_id, bus),
         available_block_ids_(std::move(blocks)) {
     // TODO(chasseur): Once block fill statistics are available, replace this
     // with something smarter.
@@ -419,8 +413,6 @@ class PartitionAwareInsertDestination : public InsertDestination {
    * @param relational_op_index The index of the relational operator in the
    *        QueryPlan DAG that has outputs.
    * @param foreman_client_id The TMB client ID of the Foreman thread.
-   * @param agent_client_id The TMB client ID of the agent that sends messages
-   *        to Foreman.
    * @param bus A pointer to the TMB.
    **/
   PartitionAwareInsertDestination(PartitionSchemeHeader *partition_scheme_header,
@@ -430,7 +422,6 @@ class PartitionAwareInsertDestination : public InsertDestination {
                                   std::vector<std::vector<block_id>> &&partitions,
                                   const std::size_t relational_op_index,
                                   const tmb::client_id foreman_client_id,
-                                  const tmb::client_id agent_client_id,
                                   tmb::MessageBus *bus);
 
   ~PartitionAwareInsertDestination() override {

--- a/threading/CMakeLists.txt
+++ b/threading/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015-2016 Pivotal Software, Inc.
+#   Copyright 2015 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -320,6 +320,7 @@ endif()
 
 add_library(quickstep_threading_SpinMutex ../empty_src.cpp SpinMutex.hpp)
 add_library(quickstep_threading_SpinSharedMutex ../empty_src.cpp SpinSharedMutex.hpp)
+add_library(quickstep_threading_ThreadIDBasedMap ../empty_src.cpp ThreadIDBasedMap.hpp)
 add_library(quickstep_threading_ThreadUtil ../empty_src.cpp ThreadUtil.hpp)
 
 # Link dependencies:
@@ -352,6 +353,11 @@ target_link_libraries(quickstep_threading_SpinSharedMutex
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_threading_Thread
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_threading_ThreadIDBasedMap
+                      glog
+                      quickstep_threading_Mutex
+                      quickstep_threading_SharedMutex
+                      quickstep_threading_SpinSharedMutex)
 target_link_libraries(quickstep_threading_ThreadUtil
                       quickstep_utility_Macros)
 
@@ -364,6 +370,7 @@ target_link_libraries(quickstep_threading
                       quickstep_threading_SpinMutex
                       quickstep_threading_SpinSharedMutex
                       quickstep_threading_Thread
+                      quickstep_threading_ThreadIDBasedMap
                       quickstep_threading_ThreadUtil)
 
 # Tests:

--- a/threading/ThreadIDBasedMap.hpp
+++ b/threading/ThreadIDBasedMap.hpp
@@ -1,0 +1,159 @@
+/**
+ *   Copyright 2015 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_THREADING_THREAD_ID_BASED_MAP_HPP_
+#define QUICKSTEP_THREADING_THREAD_ID_BASED_MAP_HPP_
+
+#include <unordered_map>
+
+#include "threading/ThreadingConfig.h"
+
+#ifdef QUICKSTEP_HAVE_POSIX_THREADS
+#include <pthread.h>
+#endif
+
+#ifdef QUICKSTEP_HAVE_CPP11_THREADS
+#include <thread>  // NOLINT(build/c++11)
+#endif
+
+#ifdef QUICKSTEP_HAVE_WINDOWS_THREADS
+#include "threading/WinThreadsAPI.hpp"
+#endif
+
+#include "threading/Mutex.hpp"
+#include "threading/SharedMutex.hpp"
+#include "threading/SpinSharedMutex.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+/** \addtogroup QueryExecution
+ *  @{
+ */
+/**
+ * @brief A map which uses caller thread's ID as a key based on a singleton
+ *        pattern.
+ *
+ * @note This is in a way a simulation of thread-local object storage.
+ **/
+template <class V, char... name>
+class ThreadIDBasedMap {
+ public:
+#ifdef QUICKSTEP_HAVE_CPP11_THREADS
+  typedef std::thread::id thread_id_t;
+#endif
+#ifdef QUICKSTEP_HAVE_POSIX_THREADS
+  typedef pthread_t thread_id_t;
+#endif
+#ifdef QUICKSTEP_HAVE_WINDOWS_THREADS
+  typedef DWORD thread_id_t;
+#endif
+  /**
+   * @brief Get the instance of the map.
+   *
+   * @warning The initialization of the instance is not thread safe.
+   *
+   * @return A pointer to the instance.
+   **/
+  static ThreadIDBasedMap* Instance() {
+    static ThreadIDBasedMap instance;
+    return &instance;
+  }
+
+  /**
+   * @brief Add a value to the map.
+   *
+   * @param value The value to be added.
+   **/
+  void addValue(const V &value) {
+    const thread_id_t key = getKey();
+    {
+      SpinSharedMutexExclusiveLock<false> lock(map_mutex_);
+      DCHECK(map_.find(key) == map_.end());
+      map_[key] = value;
+    }
+  }
+
+  /**
+   * @brief Remove the value for the caller thread.
+   **/
+  void removeValue() {
+    const thread_id_t key = getKey();
+    {
+      SpinSharedMutexExclusiveLock<false> lock(map_mutex_);
+      // Use the following way to avoid exception in erase() call.
+      auto remove_iter = map_.find(key);
+      DCHECK(remove_iter != map_.end());
+      map_.erase(remove_iter);
+    }
+  }
+
+  /**
+   * @brief Get the value corresponding to the caller thread.
+   *
+   * @return The value for which the key is the caller thread's ID.
+   **/
+  const V& getValue() {
+    const thread_id_t key = getKey();
+    {
+      SpinSharedMutexSharedLock<false> lock(map_mutex_);
+      DCHECK(map_.find(key) != map_.end());
+      return map_[key];
+    }
+  }
+
+ private:
+  /**
+   * @brief Constructor.
+   **/
+  ThreadIDBasedMap() {}
+
+  /**
+   * @brief Destructor.
+   *
+   * @note The destructor is private in order to prevent any caller that holds
+   *       a pointer to the map from accidentally deleting it.
+   **/
+  ~ThreadIDBasedMap() {}
+
+  /**
+   * @brief Return a unique key corresponding to the caller thread.
+   *
+   * @return A unique key.
+   **/
+  static thread_id_t getKey() {
+#ifdef QUICKSTEP_HAVE_CPP11_THREADS
+    return std::this_thread::get_id();
+#endif
+#ifdef QUICKSTEP_HAVE_POSIX_THREADS
+    return pthread_self();
+#endif
+#ifdef QUICKSTEP_HAVE_WINDOWS_THREADS
+    return GetCurrentThreadId();
+#endif
+  }
+
+  std::unordered_map<thread_id_t, V> map_;
+
+  SpinSharedMutex<false> map_mutex_;
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_THREADING_THREAD_ID_BASED_MAP_HPP_


### PR DESCRIPTION
This reverts commit be14790b0ced59cb7c6f802464ba7337eb7fbe77.

Instead, will use an explicit scheduler client id for receiving TMB messages.