### PR TITLE
DO NOT MERGE: Explore faster GCC build times in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ env:
 
 install:
   - if [ "$VECTOR_COPY_ELISION_LEVEL" = "joinwithbinaryexpressions" ] && [ "$CC" = "gcc" ]; then
-      export MAKE_JOBS=2;
+      export MAKE_JOBS=1;
     else
-      export MAKE_JOBS=4;
+      export MAKE_JOBS=2;
     fi
   - export TEST_JOBS=2;
   - if [ "$CC" = "gcc" ]; then
-      export CC="gcc-4.9.3";
-      export CXX="g++-4.9.3";
+      export CC="gcc-5.3";
+      export CXX="g++-5.3";
     elif [ "$CC" = "clang" ]; then
       export CC="clang-3.7";
       export CXX="clang++-3.7";

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ env:
 
 install:
   - if [ "$VECTOR_COPY_ELISION_LEVEL" = "joinwithbinaryexpressions" ] && [ "$CC" = "gcc" ]; then
-      export MAKE_JOBS=1;
+      export MAKE_JOBS=2;
     else
       export MAKE_JOBS=2;
     fi
   - export TEST_JOBS=2;
   - if [ "$CC" = "gcc" ]; then
-      export CC="gcc-5.3";
-      export CXX="g++-5.3";
+      export CC="gcc-5";
+      export CXX="g++-5";
     elif [ "$CC" = "clang" ]; then
       export CC="clang-3.7";
       export CXX="clang++-3.7";
@@ -72,8 +72,8 @@ addons:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-precise-3.7
     packages:
-      - gcc-4.9
-      - g++-4.9
+      - gcc-5
+      - g++-5
       - clang-3.7
       - libprotobuf-dev
       - protobuf-compiler

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,21 @@ compiler:
   - gcc
 
 env:
-  - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none
-  - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none
-  - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
+#  - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none
+#  - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none
+#  - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
 
 install:
   - if [ "$VECTOR_COPY_ELISION_LEVEL" = "joinwithbinaryexpressions" ] && [ "$CC" = "gcc" ]; then
-      export MAKE_JOBS=1;
-    else
       export MAKE_JOBS=2;
+    else
+      export MAKE_JOBS=4;
     fi
   - export TEST_JOBS=2;
   - if [ "$CC" = "gcc" ]; then
-      export CC="gcc-4.9";
-      export CXX="g++-4.9";
+      export CC="gcc-4.9.3";
+      export CXX="g++-4.9.3";
     elif [ "$CC" = "clang" ]; then
       export CC="clang-3.7";
       export CXX="clang++-3.7";


### PR DESCRIPTION
GCC builds with `joinwithbinaryexpressions` turned on takes a very long time since the parallelism is set to 1. Explore if we can improve on this by moving up the gcc version that is more robust to template generation. 