### PR TITLE
Avoided update CatalogDatabaseCache on the fly.

### DIFF
--- a/catalog/CatalogDatabaseCache.hpp
+++ b/catalog/CatalogDatabaseCache.hpp
@@ -42,7 +42,14 @@ namespace serialization { class CatalogDatabase; }
  */
 
 /**
- * @brief A database cache used in the distributed version.
+ * @brief A database cache managed by Shiftboss in the distributed version.
+ *        During the runtime, it contains all the referenced relation schemas
+ *        to execute a query. For a SELECT query, the temporary query
+ *        result relation will be dropped after the CLI finishes processing the
+ *        result and notifies Shiftboss.
+ *
+ * @note A CatalogRelationSchema should be kept unless all associated blocks
+ *       have been deleted.
  **/
 class CatalogDatabaseCache : public CatalogDatabaseLite {
  public:
@@ -88,7 +95,7 @@ class CatalogDatabaseCache : public CatalogDatabaseLite {
 
   /**
    * @brief Update the cache from its serialized Protocol Buffer form. If the
-   *        relation schema exists, it will be overwritten.
+   *        relation schema exists, it will be ignored.
    *
    * @param proto The Protocol Buffer serialization of a catalog cache,
    *        previously produced in optimizer.

--- a/catalog/tests/Catalog_unittest.cpp
+++ b/catalog/tests/Catalog_unittest.cpp
@@ -606,6 +606,10 @@ TEST_F(CatalogTest, CatalogDatabaseCacheTest) {
   CatalogDatabaseCache cache(db_->getProto());
   compareCatalogDatabaseCache(cache);
 
+  // Test dropping relations in the cache.
+  cache.dropRelationById(rel->getID());
+  ASSERT_EQ(0u, cache.size());
+
   // CatalogRelactionSchema changes.
   const std::size_t str_type_length = 8;
   rel->addAttribute(
@@ -620,10 +624,6 @@ TEST_F(CatalogTest, CatalogDatabaseCacheTest) {
   // Update the cache after the schema changed.
   cache.update(db_->getProto());
   compareCatalogDatabaseCache(cache);
-
-  // Test dropping relations in the cache.
-  cache.dropRelationById(rel->getID());
-  ASSERT_EQ(0u, cache.size());
 }
 
 }  // namespace quickstep


### PR DESCRIPTION
In distributed version, it is not safe to update cached `CatalogRelationSchema` on the fly, while some storage blocks still have reference to the existing schema.

So, disable updates in the cache for now.