### PR TITLE
DO NOT MERGE: Try to debug the ref count problem on Travis CI.

### DIFF
--- a/query_execution/Worker.cpp
+++ b/query_execution/Worker.cpp
@@ -59,10 +59,10 @@ void Worker::run() {
         DCHECK(message.getWorkOrder() != nullptr);
         message.getWorkOrder()->execute();
 
+        delete message.getWorkOrder();
         sendWorkOrderCompleteMessage(annotated_msg.sender,
                                      message.getRelationalOpIndex(),
                                      tagged_message.message_type() == kRebuildWorkOrderMessage);
-        delete message.getWorkOrder();
         break;
       }
       case kPoisonMessage: {

--- a/query_optimizer/tests/CMakeLists.txt
+++ b/query_optimizer/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(quickstep_queryoptimizer_tests_ExecutionGeneratorTest
                       quickstep_queryoptimizer_QueryPlan
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_tests_TestDatabaseLoader
+                      quickstep_storage_CountedReference
                       quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       quickstep_utility_MemStream

--- a/query_optimizer/tests/ExecutionGeneratorTest.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTest.cpp
@@ -21,6 +21,7 @@
 
 #include "query_optimizer/tests/ExecutionGeneratorTestRunner.hpp"
 #include "utility/textbased_test/TextBasedTestDriver.hpp"
+#include "storage/CountedReference.hpp"
 
 #include "glog/logging.h"
 
@@ -35,6 +36,8 @@ int main(int argc, char** argv) {
     LOG(ERROR) << "Must have at least 3 arguments, but " << argc - 1
                << " are provided";
   }
+
+  quickstep::countedreference_print_stacktrace = true;
 
   std::ifstream input_file(argv[1]);
   CHECK(input_file.is_open()) << argv[1];

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -155,7 +155,7 @@ add_library(quickstep_storage_CompressedStoreUtil CompressedStoreUtil.cpp Compre
 add_library(quickstep_storage_CompressedTupleStorageSubBlock
             CompressedTupleStorageSubBlock.cpp
             CompressedTupleStorageSubBlock.hpp)
-add_library(quickstep_storage_CountedReference ../empty_src.cpp CountedReference.hpp)
+add_library(quickstep_storage_CountedReference CountedReference.cpp CountedReference.hpp)
 add_library(quickstep_storage_CSBTreeIndexSubBlock CSBTreeIndexSubBlock.cpp CSBTreeIndexSubBlock.hpp)
 add_library(quickstep_storage_EvictionPolicy EvictionPolicy.cpp EvictionPolicy.hpp)
 add_library(quickstep_storage_FileManager ../empty_src.cpp FileManager.hpp)
@@ -439,6 +439,7 @@ target_link_libraries(quickstep_storage_CompressedTupleStorageSubBlock
 target_link_libraries(quickstep_storage_CountedReference
                       quickstep_storage_EvictionPolicy
                       quickstep_storage_StorageBlockBase
+                      quickstep_threading_SpinSharedMutex
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_CSBTreeIndexSubBlock
                       quickstep_catalog_CatalogAttribute

--- a/storage/CountedReference.cpp
+++ b/storage/CountedReference.cpp
@@ -1,0 +1,15 @@
+/**
+ *   Temporary file for debugging.
+ **/
+
+#include "storage/CountedReference.hpp"
+
+#include "threading/SpinSharedMutex.hpp"
+
+namespace quickstep {
+
+
+SpinSharedMutex<false> countedreference_print_mutex;
+bool countedreference_print_stacktrace = false;
+
+}  // namespace quickstep

--- a/storage/CountedReference.cpp
+++ b/storage/CountedReference.cpp
@@ -1,13 +1,26 @@
 /**
- *   Temporary file for debugging.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  **/
+
 
 #include "storage/CountedReference.hpp"
 
 #include "threading/SpinSharedMutex.hpp"
 
 namespace quickstep {
-
 
 SpinSharedMutex<false> countedreference_print_mutex;
 bool countedreference_print_stacktrace = false;

--- a/storage/CountedReference.hpp
+++ b/storage/CountedReference.hpp
@@ -19,10 +19,10 @@
 #define QUICKSTEP_STORAGE_COUNTED_REFERENCE_HPP_
 
 #include <execinfo.h>
-#include <cstdio>
-#include <cstdlib>
 #include <unistd.h>
 
+#include <cstdio>
+#include <cstdlib>
 #include <type_traits>
 
 #include "storage/EvictionPolicy.hpp"


### PR DESCRIPTION
Print stacktrace information when `StorageBlockBase::ref()` and `StorageBlockBase::unref()` are called.