### PR TITLE
Likely the fix to ref_count() bug: Worker delete WorkOrder before sendWorkOrderCompleteMessage

### DIFF
--- a/query_execution/Worker.cpp
+++ b/query_execution/Worker.cpp
@@ -58,11 +58,11 @@ void Worker::run() {
         WorkerMessage message(*static_cast<const WorkerMessage*>(tagged_message.message()));
         DCHECK(message.getWorkOrder() != nullptr);
         message.getWorkOrder()->execute();
+        delete message.getWorkOrder();
 
         sendWorkOrderCompleteMessage(annotated_msg.sender,
                                      message.getRelationalOpIndex(),
                                      tagged_message.message_type() == kRebuildWorkOrderMessage);
-        delete message.getWorkOrder();
         break;
       }
       case kPoisonMessage: {


### PR DESCRIPTION
This PR is likely the fix for the `Check failed: 0 == getRefCount()` bug.

If we print out the stacktrace of each `StorageBlockBase::ref()` and `StorageBlockBase::undef()` called by `CountedReference`, as #144's  [build log](https://travis-ci.org/pivotalsoftware/quickstep/jobs/121513496) shows, an example output when the bug occurs is:
```
SelectStatement
+-select_query=Select
  +-select_clause=SelectStar
  +-from_clause=
    +-TableGenerator
      +-FunctionCall[name=generate_series]
        +-Literal
        | +-NumericLiteral[numeric_string=1,float_like=false]
        +-Literal
          +-NumericLiteral[numeric_string=10,float_like=false]

Ref: (1, 2)
_ZN9quickstep16CountedReferenceINS_12StorageBlockEEC2EPS1_PNS_14EvictionPolicyE+0x191[0x14ab4f1]
_ZN9quickstep14StorageManager16getBlockInternalEmRKNS_21CatalogRelationSchemaEi+0x26c[0x14a9a0c]
_ZN9quickstep14StorageManager15getBlockMutableEmRKNS_21CatalogRelationSchemaEi+0x34[0x1241154]
_ZN9quickstep26BlockPoolInsertDestination14createNewBlockEv+0x3a5[0x1487785]
_ZN9quickstep26BlockPoolInsertDestination20getBlockForInsertionEv+0x83[0x1487953]
[0x148bab1]
[0x148a117]
[0x1486b3d]
_ZN9quickstep17InsertDestination16bulkInsertTuplesEPNS_13ValueAccessorEb+0x37[0x1486ab7]
_ZN9quickstep23TableGeneratorWorkOrder7executeEv+0x9f[0x12bc98f]
_ZN9quickstep6Worker3runEv+0x260[0x117e8e0]
_ZN9quickstep18threading_internal38executeRunMethodForThreadReturnNothingEPv+0x24[0x12265b4]
_ZNSt12_Bind_simpleIFPFvPvEPN9quickstep15ThreadImplCPP11EEE9_M_invokeIJLm0EEEEvSt12_Index_tupleIJXspT_EEE+0x45[0x10b11e5]
_ZNSt12_Bind_simpleIFPFvPvEPN9quickstep15ThreadImplCPP11EEEclEv+0x15[0x10b1195]
_ZNSt6thread5_ImplISt12_Bind_simpleIFPFvPvEPN9quickstep15ThreadImplCPP11EEEE6_M_runEv+0x19[0x10b0e39]
/usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0x8da30)[0x7ff3e6262a30]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x7e9a)[0x7ff3e69e4e9a]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7ff3e59f738d]

Ref: (1, 2)
_ZN9quickstep16CountedReferenceINS_12StorageBlockEEC2EPS1_PNS_14EvictionPolicyE+0x191[0x14ab4f1]
_ZN9quickstep14StorageManager16getBlockInternalEmRKNS_21CatalogRelationSchemaEi+0x26c[0x14a9a0c]
_ZN9quickstep14StorageManager8getBlockEmRKNS_21CatalogRelationSchemaEi+0x3f[0x111ad8f]
_ZN9quickstep13PrintToScreen13PrintRelationERKNS_15CatalogRelationEPNS_14StorageManagerEP8_IO_FILE+0x49d[0x111a15d]
_ZN9quickstep9optimizer28ExecutionGeneratorTestRunner11runTestCaseERKSsRKSt3setISsSt4lessISsESaISsEEPSs+0x653[0x10c01c3]
_ZN9quickstep33TextBasedTest_CompareOutputs_Test8TestBodyEv+0x45[0x10ca145]
_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x7a[0x110cbaa]
_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x71[0x10fd0c1]
_ZN7testing4Test3RunEv+0xcb[0x10e5c8b]
_ZN7testing8TestInfo3RunEv+0xdb[0x10e68cb]
_ZN7testing8TestCase3RunEv+0xe7[0x10e6f77]
_ZN7testing8internal12UnitTestImpl11RunAllTestsEv+0x2e4[0x10ee4c4]
_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+0x7a[0x110f92a]
_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+0x71[0x10ff421]
_ZN7testing8UnitTest3RunEv+0xd3[0x10ee193]
_Z13RUN_ALL_TESTSv+0x11[0x10a9301]
main+0x398[0x10a8718]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xed)[0x7ff3e592576d]
[0x10a8245]

Unref: (1, 2)
_ZN9quickstep16CountedReferenceIKNS_12StorageBlockEED2Ev+0x154[0x111b274]
_ZN9quickstep13PrintToScreen13PrintRelationERKNS_15CatalogRelationEPNS_14StorageManagerEP8_IO_FILE+0x745[0x111a405]
_ZN9quickstep9optimizer28ExecutionGeneratorTestRunner11runTestCaseERKSsRKSt3setISsSt4lessISsESaISsEEPSs+0x653[0x10c01c3]
_ZN9quickstep33TextBasedTest_CompareOutputs_Test8TestBodyEv+0x45[0x10ca145]
_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x7a[0x110cbaa]
_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x71[0x10fd0c1]
_ZN7testing4Test3RunEv+0xcb[0x10e5c8b]
_ZN7testing8TestInfo3RunEv+0xdb[0x10e68cb]
_ZN7testing8TestCase3RunEv+0xe7[0x10e6f77]
_ZN7testing8internal12UnitTestImpl11RunAllTestsEv+0x2e4[0x10ee4c4]
_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+0x7a[0x110f92a]
_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+0x71[0x10ff421]
_ZN7testing8UnitTest3RunEv+0xd3[0x10ee193]
_Z13RUN_ALL_TESTSv+0x11[0x10a9301]
main+0x398[0x10a8718]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xed)[0x7ff3e592576d]
[0x10a8245]
F0407 20:05:10.534940 18559 StorageBlockBase.hpp:42] Check failed: 0 == getRefCount() (0 vs. 1) Nonzero ref_count_ when deleting block (1, 2)
*** Check failure stack trace: ***
    @          0x10cdd0b  (unknown)
    @          0x10cd157  (unknown)
    @          0x10cd9da  (unknown)
    @          0x10d0d98  (unknown)
    @          0x14ac3d6  (unknown)
    @          0x1530b36  (unknown)
    @          0x1530b59  (unknown)
    @          0x14a912b  (unknown)
    @          0x14a922b  (unknown)
    @          0x111948c  (unknown)
    @          0x10c022e  (unknown)
    @          0x10ca145  (unknown)
    @          0x110cbaa  (unknown)
    @          0x10fd0c1  (unknown)
    @          0x10e5c8b  (unknown)
    @          0x10e68cb  (unknown)
    @          0x10e6f77  (unknown)
    @          0x10ee4c4  (unknown)
    @          0x110f92a  (unknown)
    @          0x10ff421  (unknown)
    @          0x10ee193  (unknown)
    @          0x10a9301  (unknown)
    @          0x10a8718  (unknown)
    @     0x7ff3e592576d  (unknown)
    @          0x10a8245  (unknown)
```

So there are two `ref()` calls and only one `unref()` call, i.e. an `unref()` is missing.

If we test it on local machines, we can find that the missing `unref()` is
```
Unref: (1, 2)
0   _ZN9quickstep16CountedReferenceINS_12StorageBlockEED2Ev + 358
1   _ZN9quickstep16CountedReferenceINS_12StorageBlockEED1Ev + 21
2   _ZN9quickstep16RebuildWorkOrderD2Ev + 49
3   _ZN9quickstep16RebuildWorkOrderD1Ev + 21
4   _ZN9quickstep16RebuildWorkOrderD0Ev + 25
5   _ZN9quickstep6Worker3runEv + 797
6   _ZN9quickstep18threading_internal38executeRunMethodForThreadReturnNothingEPv + 36
7   _ZNSt3__114__thread_proxyINS_5tupleIJPFvPvEPN9quickstep15ThreadImplCPP11EEEEEES2_S2_ + 429
8   libsystem_pthread.dylib             0x00007fff912d5c13 _pthread_body + 131
9   libsystem_pthread.dylib             0x00007fff912d5b90 _pthread_body + 0
10  libsystem_pthread.dylib             0x00007fff912d3375 thread_start + 13
```
So `RebuildWorkOrder` owns the problematic `CountedReference`, and `unref()` will be called on `RebuildWorkOrder`'s destruction, but the destruction may be delayed and the following event flow can happen:
1. In Thread 1, `Worker::run()` called  `sendWorkOrderCompleteMessage()`, but the next statement `delete message.getWorkOrder()` was delayed.
2. In Thread 2, `Foreman::join()` finished, then called `PrintToScreen::PrintRelation`, then started calling `DropRelation::Drop`.
3. Thread 1's `delete message.getWorkOrder()` was not started yet, but Thread 2's `DropRelation::Drop` was going to delete the output block, which was referenced by the Thread 1's not-yet deleted `message.getWorkOrder()`.
