### PR TITLE
Resolver support for the EXISTS subquery

### DIFF
--- a/query_optimizer/OptimizerContext.hpp
+++ b/query_optimizer/OptimizerContext.hpp
@@ -61,6 +61,7 @@ class OptimizerContext {
         current_expr_id_(-1),
         catalog_database_(catalog_database),
         storage_manager_(storage_manager),
+        has_nested_queries_(false),
         is_catalog_changed_(false) {}
 
   /**
@@ -107,6 +108,20 @@ class OptimizerContext {
   }
 
   /**
+   * @brief Indicate that the query has a nested subquery.
+   */
+  void set_has_nested_queries() {
+    has_nested_queries_ = true;
+  }
+
+  /**
+   * @return True if the query has a nested subquery.
+   */
+  bool has_nested_queries() const {
+    return has_nested_queries_;
+  }
+
+  /**
    * @brief Sets <is_catalog_changed_> to be true to indicate the query will
    *        modify the catalog permanently.
    */
@@ -124,6 +139,8 @@ class OptimizerContext {
 
   CatalogDatabase *catalog_database_;
   StorageManager *storage_manager_;
+
+  bool has_nested_queries_;
 
   bool is_catalog_changed_;
 

--- a/query_optimizer/expressions/CMakeLists.txt
+++ b/query_optimizer/expressions/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -21,6 +23,7 @@ add_library(quickstep_queryoptimizer_expressions_BinaryExpression BinaryExpressi
 add_library(quickstep_queryoptimizer_expressions_Cast Cast.cpp Cast.hpp)
 add_library(quickstep_queryoptimizer_expressions_ComparisonExpression ComparisonExpression.cpp
             ComparisonExpression.hpp)
+add_library(quickstep_queryoptimizer_expressions_Exists Exists.cpp Exists.hpp)
 add_library(quickstep_queryoptimizer_expressions_Expression ../../empty_src.cpp Expression.hpp)
 add_library(quickstep_queryoptimizer_expressions_ExpressionType ../../empty_src.cpp ExpressionType.hpp)
 add_library(quickstep_queryoptimizer_expressions_ExprId ../../empty_src.cpp ExprId.hpp)
@@ -36,6 +39,7 @@ add_library(quickstep_queryoptimizer_expressions_Scalar ../../empty_src.cpp Scal
 add_library(quickstep_queryoptimizer_expressions_ScalarLiteral ScalarLiteral.cpp ScalarLiteral.hpp)
 add_library(quickstep_queryoptimizer_expressions_SearchedCase SearchedCase.cpp SearchedCase.hpp)
 add_library(quickstep_queryoptimizer_expressions_SimpleCase SimpleCase.cpp SimpleCase.hpp)
+add_library(quickstep_queryoptimizer_expressions_SubqueryExpression SubqueryExpression.cpp SubqueryExpression.hpp)
 add_library(quickstep_queryoptimizer_expressions_UnaryExpression UnaryExpression.cpp UnaryExpression.hpp)
 
 # Link dependencies:
@@ -113,6 +117,15 @@ target_link_libraries(quickstep_queryoptimizer_expressions_ComparisonExpression
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_queryoptimizer_expressions_Exists
+                      quickstep_queryoptimizer_OptimizerTree
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
+                      quickstep_queryoptimizer_expressions_ExpressionType
+                      quickstep_queryoptimizer_expressions_Predicate
+                      quickstep_queryoptimizer_expressions_SubqueryExpression
+                      quickstep_utility_Macros
+                      glog)
 target_link_libraries(quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_ExpressionType
@@ -237,6 +250,15 @@ target_link_libraries(quickstep_queryoptimizer_expressions_SimpleCase
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_queryoptimizer_expressions_SubqueryExpression
+                      glog
+                      quickstep_queryoptimizer_OptimizerTree
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
+                      quickstep_queryoptimizer_expressions_ExpressionType
+                      quickstep_queryoptimizer_expressions_Scalar
+                      quickstep_queryoptimizer_logical_Logical
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_UnaryExpression
                       glog
                       quickstep_expressions_scalar_ScalarUnaryExpression
@@ -260,6 +282,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions
                       quickstep_queryoptimizer_expressions_BinaryExpression
                       quickstep_queryoptimizer_expressions_Cast
                       quickstep_queryoptimizer_expressions_ComparisonExpression
+                      quickstep_queryoptimizer_expressions_Exists
                       quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_ExpressionType
                       quickstep_queryoptimizer_expressions_ExprId
@@ -275,4 +298,5 @@ target_link_libraries(quickstep_queryoptimizer_expressions
                       quickstep_queryoptimizer_expressions_ScalarLiteral
                       quickstep_queryoptimizer_expressions_SearchedCase
                       quickstep_queryoptimizer_expressions_SimpleCase
+                      quickstep_queryoptimizer_expressions_SubqueryExpression
                       quickstep_queryoptimizer_expressions_UnaryExpression)

--- a/query_optimizer/expressions/Exists.cpp
+++ b/query_optimizer/expressions/Exists.cpp
@@ -1,0 +1,52 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "query_optimizer/expressions/Exists.hpp"
+
+#include <vector>
+#include <string>
+
+#include "query_optimizer/OptimizerTree.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+namespace optimizer {
+namespace expressions {
+
+::quickstep::Predicate* Exists::concretize(
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+  LOG(FATAL) << "Exists predicate should not be concretized";
+  return nullptr;
+}
+
+
+void Exists::getFieldStringItems(
+    std::vector<std::string> *inline_field_names,
+    std::vector<std::string> *inline_field_values,
+    std::vector<std::string> *non_container_child_field_names,
+    std::vector<OptimizerTreeBaseNodePtr> *non_container_child_fields,
+    std::vector<std::string> *container_child_field_names,
+    std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const {
+  non_container_child_field_names->push_back("exists_subquery");
+  non_container_child_fields->push_back(exists_subquery_);
+}
+
+
+}  // namespace expressions
+}  // namespace optimizer
+}  // namespace quickstep

--- a/query_optimizer/expressions/Exists.hpp
+++ b/query_optimizer/expressions/Exists.hpp
@@ -1,0 +1,118 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_OPTIMIZER_EXPRESSIONS_EXISTS_HPP_
+#define QUICKSTEP_QUERY_OPTIMIZER_EXPRESSIONS_EXISTS_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "query_optimizer/OptimizerTree.hpp"
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
+#include "query_optimizer/expressions/ExpressionType.hpp"
+#include "query_optimizer/expressions/Predicate.hpp"
+#include "query_optimizer/expressions/SubqueryExpression.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace optimizer {
+namespace expressions {
+
+/** \addtogroup OptimizerExpressions
+ *  @{
+ */
+
+class Exists;
+typedef std::shared_ptr<const Exists> ExistsPtr;
+
+/**
+ * @brief EXISTS predicate expression.
+ */
+class Exists : public Predicate {
+ public:
+  ExpressionType getExpressionType() const override {
+    return ExpressionType::kExists;
+  }
+
+  std::string getName() const override {
+    return "Exists";
+  }
+
+  bool isConstant() const override {
+    return false;
+  }
+
+  /**
+   * @return The subquery expression for this EXISTS predicate.
+   */
+  const SubqueryExpressionPtr& exists_subquery() const {
+    return exists_subquery_;
+  }
+
+  ExpressionPtr copyWithNewChildren(
+      const std::vector<ExpressionPtr> &new_children) const override {
+    DCHECK_EQ(new_children.size(), 1u);
+    return Create(std::static_pointer_cast<const SubqueryExpression>(new_children[0]));
+  }
+
+  std::vector<AttributeReferencePtr> getReferencedAttributes() const override {
+    return {};
+  }
+
+  ::quickstep::Predicate* concretize(
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+
+  /**
+   * @brief Create an Exists predicate expression.
+   *
+   * @param exists_subquery The subquery expression for this EXISTS predicate.
+   * @return An immutable Exists expression node.
+   */
+  static ExistsPtr Create(const SubqueryExpressionPtr &exists_subquery) {
+    return ExistsPtr(new Exists(exists_subquery));
+  }
+
+ protected:
+  void getFieldStringItems(
+      std::vector<std::string> *inline_field_names,
+      std::vector<std::string> *inline_field_values,
+      std::vector<std::string> *non_container_child_field_names,
+      std::vector<OptimizerTreeBaseNodePtr> *non_container_child_fields,
+      std::vector<std::string> *container_child_field_names,
+      std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const override;
+
+ private:
+  explicit Exists(const SubqueryExpressionPtr &exists_subquery)
+      : exists_subquery_(exists_subquery) {
+    addChild(exists_subquery_);
+  }
+
+  SubqueryExpressionPtr exists_subquery_;
+
+  DISALLOW_COPY_AND_ASSIGN(Exists);
+};
+
+/** @} */
+
+}  // namespace expressions
+}  // namespace optimizer
+}  // namespace quickstep
+
+
+#endif /* QUICKSTEP_QUERY_OPTIMIZER_EXPRESSIONS_EXISTS_HPP_ */

--- a/query_optimizer/expressions/ExpressionType.hpp
+++ b/query_optimizer/expressions/ExpressionType.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -36,6 +38,7 @@ enum class ExpressionType {
   kBinaryExpression,
   kCast,
   kComparisonExpression,
+  kExists,
   kLogicalAnd,
   kLogicalOr,
   kLogicalNot,
@@ -43,6 +46,7 @@ enum class ExpressionType {
   kScalarLiteral,
   kSearchedCase,
   kSimpleCase,
+  kSubqueryExpression,
   kUnaryExpression
 };
 

--- a/query_optimizer/expressions/ExpressionUtil.cpp
+++ b/query_optimizer/expressions/ExpressionUtil.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,6 +19,8 @@
 
 #include "query_optimizer/expressions/ExpressionUtil.hpp"
 
+#include <vector>
+
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 
@@ -29,7 +33,20 @@ AttributeReferencePtr ToRef(const NamedExpressionPtr &expression) {
                                     expression->attribute_name(),
                                     expression->attribute_alias(),
                                     expression->relation_name(),
-                                    expression->getValueType());
+                                    expression->getValueType(),
+                                    AttributeReferenceScope::kLocal);
+}
+
+std::vector<AttributeReferencePtr> GetAttributeReferencesWithinScope(
+    const std::vector<AttributeReferencePtr> &attributes,
+    const AttributeReferenceScope scope) {
+  std::vector<AttributeReferencePtr> filtered_attributes;
+  for (const auto& attr_it : attributes) {
+    if (attr_it->scope() == scope) {
+      filtered_attributes.emplace_back(attr_it);
+    }
+  }
+  return filtered_attributes;
 }
 
 }  // namespace expressions

--- a/query_optimizer/expressions/ExpressionUtil.hpp
+++ b/query_optimizer/expressions/ExpressionUtil.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -69,6 +71,7 @@ struct NamedExpressionHash {
 };
 
 typedef std::unordered_set<NamedExpressionPtr, NamedExpressionHash, NamedExpressionEqual> UnorderedNamedExpressionSet;
+typedef std::unordered_set<AttributeReferencePtr, NamedExpressionHash, NamedExpressionEqual> UnorderedAttributeSet;
 
 /**
  * @brief Checks whether \p expression_to_check is contained by \p expressions.
@@ -119,6 +122,19 @@ bool SubsetOfExpressions(
  * @return An AttributeReference of this named expression.
  */
 AttributeReferencePtr ToRef(const NamedExpressionPtr &expression);
+
+/**
+ * @brief Filter a vector of AttributeReferencePtr to get those which are in
+ *        the specified scope.
+ *
+ * @param attributes The vector of AttributeReferencePtr to be filtered.
+ * @param scope The specified reference scope.
+ *
+ * @return A vector of AttributeReferencePtr within the specified scope.
+ */
+std::vector<AttributeReferencePtr> GetAttributeReferencesWithinScope(
+    const std::vector<AttributeReferencePtr> &attributes,
+    const AttributeReferenceScope scope);
 
 /**
  * @brief Creates a list of AttributeReferences from a list of NamedExpressions

--- a/query_optimizer/expressions/SubqueryExpression.cpp
+++ b/query_optimizer/expressions/SubqueryExpression.cpp
@@ -1,0 +1,58 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "query_optimizer/expressions/SubqueryExpression.hpp"
+
+#include <string>
+#include <vector>
+
+#include "query_optimizer/OptimizerTree.hpp"
+#include "query_optimizer/expressions/AttributeReference.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+namespace optimizer {
+namespace expressions {
+
+::quickstep::Scalar* SubqueryExpression::concretize(
+    const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const {
+  LOG(FATAL) << "SubqueryExpression should not be concretized";
+  return nullptr;
+}
+
+std::vector<AttributeReferencePtr> SubqueryExpression::getReferencedAttributes() const {
+  // SubqueryExpression should be eliminated before any place that needs
+  // a call of getReferencedAttributes.
+  LOG(FATAL) << "SubqueryExpression::getReferencedAttributes() is not implemented";
+  return {};
+}
+
+void SubqueryExpression::getFieldStringItems(
+    std::vector<std::string> *inline_field_names,
+    std::vector<std::string> *inline_field_values,
+    std::vector<std::string> *non_container_child_field_names,
+    std::vector<OptimizerTreeBaseNodePtr> *non_container_child_fields,
+    std::vector<std::string> *container_child_field_names,
+    std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const {
+  non_container_child_field_names->push_back("subquery");
+  non_container_child_fields->push_back(subquery_);
+}
+
+}  // namespace expressions
+}  // namespace optimizer
+}  // namespace quickstep

--- a/query_optimizer/expressions/SubqueryExpression.hpp
+++ b/query_optimizer/expressions/SubqueryExpression.hpp
@@ -1,0 +1,126 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_OPTIMIZER_EXPRESSIONS_SUBQUERY_EXPRESSION_HPP_
+#define QUICKSTEP_QUERY_OPTIMIZER_EXPRESSIONS_SUBQUERY_EXPRESSION_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
+#include "query_optimizer/expressions/ExpressionType.hpp"
+#include "query_optimizer/expressions/Scalar.hpp"
+#include "query_optimizer/logical/Logical.hpp"
+#include "query_optimizer/OptimizerTree.hpp"
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+class Type;
+
+namespace optimizer {
+namespace expressions {
+
+/** \addtogroup OptimizerExpressions
+ *  @{
+ */
+
+class SubqueryExpression;
+typedef std::shared_ptr<const SubqueryExpression> SubqueryExpressionPtr;
+
+/**
+ * @brief A subquery used in an expression.
+ */
+class SubqueryExpression : public Scalar {
+ public:
+  ExpressionType getExpressionType() const override {
+    return ExpressionType::kSubqueryExpression;
+  }
+
+  std::string getName() const override { return "SubqueryExpression"; }
+
+  const Type& getValueType() const override {
+    return output_attribute_->getValueType();
+  }
+
+  bool isConstant() const override {
+    return output_attribute_->isConstant();
+  }
+
+  /**
+   * @return The referenced logical subquery node.
+   */
+  const logical::LogicalPtr& subquery() const {
+    return subquery_;
+  }
+
+  std::vector<AttributeReferencePtr> getReferencedAttributes() const override;
+
+  ExpressionPtr copyWithNewChildren(
+      const std::vector<ExpressionPtr> &new_children) const override {
+    DCHECK(new_children.empty());
+    return Create(subquery_);
+  }
+
+  ::quickstep::Scalar* concretize(
+      const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const override;
+
+  /**
+   * @brief Creates a subquery expression.
+   * @note This expression can only be used in a logical plan.
+   *
+   * @param subquery The logical subquery node.
+   * @return An immutable SubqueryExpression.
+   */
+  static SubqueryExpressionPtr Create(const logical::LogicalPtr& subquery) {
+    return SubqueryExpressionPtr(new SubqueryExpression(subquery));
+  }
+
+ protected:
+  void getFieldStringItems(
+      std::vector<std::string> *inline_field_names,
+      std::vector<std::string> *inline_field_values,
+      std::vector<std::string> *non_container_child_field_names,
+      std::vector<OptimizerTreeBaseNodePtr> *non_container_child_fields,
+      std::vector<std::string> *container_child_field_names,
+      std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const override;
+
+ private:
+  explicit SubqueryExpression(const logical::LogicalPtr& subquery)
+      : subquery_(subquery),
+        output_attribute_(subquery->getOutputAttributes()[0]) {
+    DCHECK(!subquery->getOutputAttributes().empty());
+  }
+
+  logical::LogicalPtr subquery_;
+  // Set to the first output attribute if the subquery is a multi-column table query.
+  const AttributeReferencePtr output_attribute_;
+
+  DISALLOW_COPY_AND_ASSIGN(SubqueryExpression);
+};
+
+/** @} */
+
+}  // namespace expressions
+}  // namespace optimizer
+}  // namespace quickstep
+
+#endif /* QUICKSTEP_QUERY_OPTIMIZER_EXPRESSIONS_SUBQUERY_EXPRESSION_HPP_ */

--- a/query_optimizer/logical/TableGenerator.hpp
+++ b/query_optimizer/logical/TableGenerator.hpp
@@ -1,6 +1,6 @@
 /**
  *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
- *   University of Wisconsin—Madison.
+ *     University of Wisconsin—Madison.
  *   Copyright 2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -153,7 +153,8 @@ class TableGenerator : public Logical {
             generator_function_handle->getOutputColumnName(i),
             table_alias,
             table_name,
-            generator_function_handle->getOutputColumnType(i)));
+            generator_function_handle->getOutputColumnType(i),
+            E::AttributeReferenceScope::kLocal));
     }
   }
 

--- a/query_optimizer/logical/TableReference.cpp
+++ b/query_optimizer/logical/TableReference.cpp
@@ -48,7 +48,8 @@ TableReference::TableReference(const CatalogRelation *catalog_relation,
             attribute_it->getName(),
             attribute_it->getDisplayName(),
             relation_alias,
-            attribute_it->getType()));
+            attribute_it->getType(),
+            E::AttributeReferenceScope::kLocal));
   }
 }
 

--- a/query_optimizer/resolver/CMakeLists.txt
+++ b/query_optimizer/resolver/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(quickstep_queryoptimizer_resolver_Resolver
                       quickstep_parser_ParseLiteralValue
                       quickstep_parser_ParseOrderBy
                       quickstep_parser_ParsePredicate
+                      quickstep_parser_ParsePredicateExists
                       quickstep_parser_ParseSelect
                       quickstep_parser_ParseSelectionClause
                       quickstep_parser_ParseSimpleTableReference
@@ -64,6 +65,7 @@ target_link_libraries(quickstep_queryoptimizer_resolver_Resolver
                       quickstep_queryoptimizer_expressions_BinaryExpression
                       quickstep_queryoptimizer_expressions_Cast
                       quickstep_queryoptimizer_expressions_ComparisonExpression
+                      quickstep_queryoptimizer_expressions_Exists
                       quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_LogicalAnd
@@ -77,6 +79,7 @@ target_link_libraries(quickstep_queryoptimizer_resolver_Resolver
                       quickstep_queryoptimizer_expressions_ScalarLiteral
                       quickstep_queryoptimizer_expressions_SearchedCase
                       quickstep_queryoptimizer_expressions_SimpleCase
+                      quickstep_queryoptimizer_expressions_SubqueryExpression
                       quickstep_queryoptimizer_expressions_UnaryExpression
                       quickstep_queryoptimizer_logical_Aggregate
                       quickstep_queryoptimizer_logical_CopyFrom

--- a/query_optimizer/resolver/NameResolver.hpp
+++ b/query_optimizer/resolver/NameResolver.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -47,8 +49,12 @@ class NameResolver {
  public:
   /**
    * @brief Constructor.
+   *
+   * @param parent_resolver The NameResolver inherited from the outer query.
+   *                        NULL if there is no outer query.
    */
-  NameResolver() {}
+  explicit NameResolver(const NameResolver *parent_resolver = nullptr)
+      : parent_resolver_(parent_resolver) {}
 
   /**
    * @brief Adds the attributes of the relation produced by \p logical
@@ -108,8 +114,10 @@ class NameResolver {
    * @brief Info of a relation and its visible attributes in the name scope.
    */
   struct RelationInfo {
-    explicit RelationInfo(const logical::LogicalPtr &logical_in)
-        : logical(logical_in),
+    explicit RelationInfo(const ParseString &parse_relation_name_in,
+                          const logical::LogicalPtr &logical_in)
+        : parse_relation_name(parse_relation_name_in),
+          logical(logical_in),
           attributes(logical->getOutputAttributes()) {
       int current_attribute_index = 0;
       for (const expressions::AttributeReferencePtr &attribute : attributes) {
@@ -133,6 +141,7 @@ class NameResolver {
     // relation. Returns NULL if no attribute with the given name is found.
     expressions::AttributeReferencePtr findAttributeByName(const ParseString *parse_attr_node) const;
 
+    const ParseString &parse_relation_name;
     logical::LogicalPtr logical;
 
     std::vector<expressions::AttributeReferencePtr> attributes;
@@ -141,6 +150,8 @@ class NameResolver {
     // For an ambiguous attribute, the value is -1.
     std::map<std::string, int> name_to_attribute_index_map;
   };
+
+  const NameResolver *parent_resolver_;
 
   /**
    * @brief Relation info in the name scope.

--- a/query_optimizer/resolver/Resolver.hpp
+++ b/query_optimizer/resolver/Resolver.hpp
@@ -27,6 +27,7 @@
 #include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
+#include "query_optimizer/expressions/SubqueryExpression.hpp"
 #include "query_optimizer/expressions/Scalar.hpp"
 #include "query_optimizer/logical/Logical.hpp"
 #include "utility/Macros.hpp"
@@ -59,6 +60,7 @@ class ParseStatementInsertTuple;
 class ParseStatementSelect;
 class ParseStatementUpdate;
 class ParseString;
+class ParseSubqueryExpression;
 class ParseTableReference;
 class ParseTableReferenceSignature;
 class ParseTreeNode;
@@ -154,12 +156,14 @@ class Resolver {
    * @param select_name The name for the SELECT query.
    * @param type_hints Type hints for the expressions in the SELECT clause. Can
    *                   be NULL if there is no expectation.
+   * @param parent_resolver The name resolver of the outer query if exists.
    * @return A logical plan for the SELECT query.
    */
   logical::LogicalPtr resolveSelect(
       const ParseSelect &select_statement,
       const std::string &select_name,
-      const std::vector<const Type*> *type_hints);
+      const std::vector<const Type*> *type_hints,
+      const NameResolver *parent_resolver);
 
   /**
    * @brief Resolves a CREATE TABLE query and returns a logical plan.
@@ -432,6 +436,19 @@ class Resolver {
    */
   std::vector<expressions::PredicatePtr> resolvePredicates(
       const PtrList<ParsePredicate> &parse_predicates,
+      ExpressionResolutionInfo *expression_resolution_info);
+
+  /**
+   * @brief Resolves a table/scalar subquery expression.
+   * 
+   * @param parse_subquery_expression The parsed subquery expression.
+   * @param type_hints The type hints for output columns by the subquery.
+   * @param expression_resolution_info Resolution info that contains the name
+   *        resolver and info to be updated after resolution.
+   */
+  expressions::SubqueryExpressionPtr resolveSubqueryExpression(
+      const ParseSubqueryExpression &parse_subquery_expression,
+      const std::vector<const Type*> *type_hints,
       ExpressionResolutionInfo *expression_resolution_info);
 
   /**

--- a/query_optimizer/tests/resolver/Select.test
+++ b/query_optimizer/tests/resolver/Select.test
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -2325,6 +2327,85 @@ TopLevelPlan
   | type=Long]
   +-AttributeReference[id=7,name=,alias=SUM(float_col),relation=,
     type=Double NULL]
+==
+
+SELECT i
+FROM generate_series(0, 100, 3) AS gs1(i)
+WHERE
+  EXISTS (
+    SELECT *
+    FROM generate_series(0, 100, 5) AS gs2(i)
+    WHERE gs1.i = gs2.i
+  )
+  AND NOT EXISTS (
+    SELECT *
+    FROM generate_series(0, 100, 10) AS gs3(i)
+    WHERE gs1.i = gs3.i
+  )
+  AND (i < 40 OR i > 60);
+--
+TopLevelPlan
++-plan=Project
+| +-input=Filter
+| | +-input=Project
+| | | +-input=TableGenerator[function_name=generate_series,table_alias=gs1]
+| | | | +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | |   relation=generate_series,type=Int]
+| | | +-project_list=
+| | |   +-Alias[id=1,name=i,relation=,type=Int]
+| | |     +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | |       relation=generate_series,type=Int]
+| | +-filter_predicate=And
+| |   +-Exists
+| |   | +-exists_subquery=SubqueryExpression
+| |   |   +-subquery=Project
+| |   |     +-input=Filter
+| |   |     | +-input=Project
+| |   |     | | +-input=TableGenerator[function_name=generate_series,
+| |   |     | | | table_alias=gs2]
+| |   |     | | | +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| |   |     | | |   relation=generate_series,type=Int]
+| |   |     | | +-project_list=
+| |   |     | |   +-Alias[id=3,name=i,relation=,type=Int]
+| |   |     | |     +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| |   |     | |       relation=generate_series,type=Int]
+| |   |     | +-filter_predicate=Equal
+| |   |     |   +-AttributeReference[id=1,name=i,relation=,type=Int,
+| |   |     |   | is_outer_reference=true]
+| |   |     |   +-AttributeReference[id=3,name=i,relation=,type=Int]
+| |   |     +-project_list=
+| |   |       +-AttributeReference[id=3,name=i,relation=,type=Int]
+| |   +-NOT
+| |   | +-Exists
+| |   |   +-exists_subquery=SubqueryExpression
+| |   |     +-subquery=Project
+| |   |       +-input=Filter
+| |   |       | +-input=Project
+| |   |       | | +-input=TableGenerator[function_name=generate_series,
+| |   |       | | | table_alias=gs3]
+| |   |       | | | +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| |   |       | | |   relation=generate_series,type=Int]
+| |   |       | | +-project_list=
+| |   |       | |   +-Alias[id=5,name=i,relation=,type=Int]
+| |   |       | |     +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| |   |       | |       relation=generate_series,type=Int]
+| |   |       | +-filter_predicate=Equal
+| |   |       |   +-AttributeReference[id=1,name=i,relation=,type=Int,
+| |   |       |   | is_outer_reference=true]
+| |   |       |   +-AttributeReference[id=5,name=i,relation=,type=Int]
+| |   |       +-project_list=
+| |   |         +-AttributeReference[id=5,name=i,relation=,type=Int]
+| |   +-Or
+| |     +-Less
+| |     | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| |     | +-Literal[value=40,type=Int]
+| |     +-Greater
+| |       +-AttributeReference[id=1,name=i,relation=,type=Int]
+| |       +-Literal[value=60,type=Int]
+| +-project_list=
+|   +-AttributeReference[id=1,name=i,relation=,type=Int]
++-output_attributes=
+  +-AttributeReference[id=1,name=i,relation=,type=Int]
 ==
 
 select interval '4 day' + interval '5 year'


### PR DESCRIPTION
This PR adds resolver support for the `EXISTS` subquery.

Main changes include:
1. Adds `class Exists` and `class SubqueryExpression` in `query_optimizer/expressions`.
2. Updates `NameResolver` to support resolving attributes from outer scopes (i.e. in nested queries, the inner query may involve attributes from the outer query's table references).