### PR TITLE
Optimizer support for the EXISTS subquery.

### DIFF
--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015-2016 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -126,12 +128,15 @@ target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
 target_link_libraries(quickstep_queryoptimizer_LogicalGenerator
                       glog
                       quickstep_parser_ParseStatement
+                      quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_resolver_Resolver
                       quickstep_queryoptimizer_rules_CollapseProject
                       quickstep_queryoptimizer_rules_GenerateJoins
                       quickstep_queryoptimizer_rules_PushDownFilter
+                      quickstep_queryoptimizer_rules_PushDownSemiAntiJoin
                       quickstep_queryoptimizer_rules_Rule
+                      quickstep_queryoptimizer_rules_UnnestSubqueries
                       quickstep_queryoptimizer_Validator
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_LogicalToPhysicalMapper

--- a/query_optimizer/logical/Aggregate.cpp
+++ b/query_optimizer/logical/Aggregate.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/ExpressionUtil.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
+#include "query_optimizer/expressions/PatternMatcher.hpp"
 #include "utility/Cast.hpp"
 
 #include "glog/logging.h"
@@ -70,6 +73,35 @@ std::vector<E::AttributeReferencePtr> Aggregate::getReferencedAttributes() const
                                  referenced_attributes_in_expression.end());
   }
   return referenced_attributes;
+}
+
+LogicalPtr Aggregate::copyWithNewInputExpressions(
+      const std::vector<E::ExpressionPtr>& input_expressions) const {
+  DCHECK_EQ(grouping_expressions_.size() + aggregate_expressions_.size(),
+            input_expressions.size());
+
+  std::vector<E::NamedExpressionPtr> new_grouping_expressions;
+  for (std::vector<E::ExpressionPtr>::size_type index = 0;
+       index < grouping_expressions_.size();
+       ++index) {
+    E::NamedExpressionPtr grouping_expression;
+    E::SomeNamedExpression::MatchesWithConditionalCast(input_expressions[index],
+                                                       &grouping_expression);
+    DCHECK(grouping_expression != nullptr);
+    new_grouping_expressions.emplace_back(grouping_expression);
+  }
+
+  std::vector<E::AliasPtr> new_aggregate_expressions;
+  for (std::vector<E::ExpressionPtr>::size_type index = grouping_expressions_.size();
+       index < input_expressions.size();
+       ++index) {
+    E::AliasPtr aggregate_expression;
+    E::SomeAlias::MatchesWithConditionalCast(input_expressions[index], &aggregate_expression);
+    DCHECK(aggregate_expression != nullptr);
+    new_aggregate_expressions.emplace_back(aggregate_expression);
+  }
+
+  return Create(input_, new_grouping_expressions, new_aggregate_expressions);
 }
 
 void Aggregate::getFieldStringItems(

--- a/query_optimizer/logical/Aggregate.cpp
+++ b/query_optimizer/logical/Aggregate.cpp
@@ -76,7 +76,7 @@ std::vector<E::AttributeReferencePtr> Aggregate::getReferencedAttributes() const
 }
 
 LogicalPtr Aggregate::copyWithNewInputExpressions(
-      const std::vector<E::ExpressionPtr>& input_expressions) const {
+    const std::vector<E::ExpressionPtr> &input_expressions) const {
   DCHECK_EQ(grouping_expressions_.size() + aggregate_expressions_.size(),
             input_expressions.size());
 

--- a/query_optimizer/logical/Aggregate.hpp
+++ b/query_optimizer/logical/Aggregate.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/expressions/Alias.hpp"
 #include "query_optimizer/logical/Logical.hpp"
@@ -73,6 +76,9 @@ class Aggregate : public Logical {
   LogicalPtr copyWithNewChildren(
       const std::vector<LogicalPtr> &new_children) const override;
 
+  LogicalPtr copyWithNewInputExpressions(
+      const std::vector<expressions::ExpressionPtr>& input_expressions) const override;
+
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override;
 
   std::vector<expressions::AttributeReferencePtr> getReferencedAttributes() const override;
@@ -110,6 +116,8 @@ class Aggregate : public Logical {
         grouping_expressions_(grouping_expressions),
         aggregate_expressions_(aggregate_expressions) {
     addChild(input_);
+    addInputExpressions(grouping_expressions_);
+    addInputExpressions(aggregate_expressions_);
   }
 
   LogicalPtr input_;

--- a/query_optimizer/logical/Aggregate.hpp
+++ b/query_optimizer/logical/Aggregate.hpp
@@ -77,7 +77,7 @@ class Aggregate : public Logical {
       const std::vector<LogicalPtr> &new_children) const override;
 
   LogicalPtr copyWithNewInputExpressions(
-      const std::vector<expressions::ExpressionPtr>& input_expressions) const override;
+      const std::vector<expressions::ExpressionPtr> &input_expressions) const override;
 
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override;
 

--- a/query_optimizer/logical/CMakeLists.txt
+++ b/query_optimizer/logical/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015-2016 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -48,8 +50,10 @@ target_link_libraries(quickstep_queryoptimizer_logical_Aggregate
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
+                      quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_utility_Cast
@@ -109,7 +113,9 @@ target_link_libraries(quickstep_queryoptimizer_logical_Filter
                       glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_LogicalAnd
+                      quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
@@ -119,6 +125,7 @@ target_link_libraries(quickstep_queryoptimizer_logical_HashJoin
                       glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_logical_BinaryJoin
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
@@ -146,6 +153,7 @@ target_link_libraries(quickstep_queryoptimizer_logical_Join
 target_link_libraries(quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_MultiwayCartesianJoin
@@ -160,6 +168,9 @@ target_link_libraries(quickstep_queryoptimizer_logical_MultiwayCartesianJoin
 target_link_libraries(quickstep_queryoptimizer_logical_NestedLoopsJoin
                       glog
                       quickstep_queryoptimizer_OptimizerTree
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
+                      quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_expressions_PredicateLiteral
                       quickstep_queryoptimizer_logical_BinaryJoin
@@ -172,8 +183,10 @@ target_link_libraries(quickstep_queryoptimizer_logical_Project
                       glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
+                      quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_utility_Cast
@@ -230,6 +243,7 @@ target_link_libraries(quickstep_queryoptimizer_logical_TopLevelPlan
                       glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_utility_Cast

--- a/query_optimizer/logical/Filter.hpp
+++ b/query_optimizer/logical/Filter.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/LogicalAnd.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
 #include "query_optimizer/logical/Logical.hpp"
@@ -70,6 +73,9 @@ class Filter : public Logical {
     DCHECK_EQ(new_children.size(), children().size());
     return Filter::Create(new_children[0], filter_predicate_);
   }
+
+  LogicalPtr copyWithNewInputExpressions(
+      const std::vector<expressions::ExpressionPtr>& input_expressions) const override;
 
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override {
     return input()->getOutputAttributes();

--- a/query_optimizer/logical/Filter.hpp
+++ b/query_optimizer/logical/Filter.hpp
@@ -75,7 +75,7 @@ class Filter : public Logical {
   }
 
   LogicalPtr copyWithNewInputExpressions(
-      const std::vector<expressions::ExpressionPtr>& input_expressions) const override;
+      const std::vector<expressions::ExpressionPtr> &input_expressions) const override;
 
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override {
     return input()->getOutputAttributes();

--- a/query_optimizer/logical/HashJoin.hpp
+++ b/query_optimizer/logical/HashJoin.hpp
@@ -54,7 +54,7 @@ typedef std::shared_ptr<const HashJoin> HashJoinPtr;
  */
 class HashJoin : public BinaryJoin {
  public:
-  enum JoinType {
+  enum class JoinType {
     kInnerJoin = 0,
     kLeftSemiJoin,
     kLeftAntiJoin
@@ -65,17 +65,16 @@ class HashJoin : public BinaryJoin {
 
   std::string getName() const override {
     switch (join_type_) {
-      case kInnerJoin:
+      case JoinType::kInnerJoin:
         return "HashJoin";
-      case kLeftSemiJoin:
+      case JoinType::kLeftSemiJoin:
         return "HashLeftSemiJoin";
-      case kLeftAntiJoin:
+      case JoinType::kLeftAntiJoin:
         return "HashLeftAntiJoin";
       default:
         LOG(FATAL) << "Invalid JoinType: "
                    << static_cast<typename std::underlying_type<JoinType>::type>(join_type_);
     }
-    QUICKSTEP_UNREACHABLE();
   }
 
   /**

--- a/query_optimizer/logical/HashJoin.hpp
+++ b/query_optimizer/logical/HashJoin.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -20,10 +22,12 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Predicate.hpp"
 #include "query_optimizer/logical/BinaryJoin.hpp"
 #include "query_optimizer/logical/Logical.hpp"
 #include "query_optimizer/logical/LogicalType.hpp"
@@ -50,9 +54,29 @@ typedef std::shared_ptr<const HashJoin> HashJoinPtr;
  */
 class HashJoin : public BinaryJoin {
  public:
+  enum JoinType {
+    kInnerJoin = 0,
+    kLeftSemiJoin,
+    kLeftAntiJoin
+  };
+
+
   LogicalType getLogicalType() const override { return LogicalType::kHashJoin; }
 
-  std::string getName() const override { return "HashJoin"; }
+  std::string getName() const override {
+    switch (join_type_) {
+      case kInnerJoin:
+        return "HashJoin";
+      case kLeftSemiJoin:
+        return "HashLeftSemiJoin";
+      case kLeftAntiJoin:
+        return "HashLeftAntiJoin";
+      default:
+        LOG(FATAL) << "Invalid JoinType: "
+                   << static_cast<typename std::underlying_type<JoinType>::type>(join_type_);
+    }
+    QUICKSTEP_UNREACHABLE();
+  }
 
   /**
    * @brief Join attributes in the left logical 'left_'.
@@ -68,13 +92,29 @@ class HashJoin : public BinaryJoin {
     return right_join_attributes_;
   }
 
+  /**
+   * @brief The filtering predicate evaluated after join.
+   */
+  const expressions::PredicatePtr& residual_predicate() const {
+    return residual_predicate_;
+  }
+
+  /**
+   * @return Join type of this hash join.
+   */
+  JoinType join_type() const {
+    return join_type_;
+  }
+
   LogicalPtr copyWithNewChildren(
       const std::vector<LogicalPtr> &new_children) const override {
     DCHECK_EQ(new_children.size(), children().size());
     return HashJoin::Create(new_children[0],
                             new_children[1],
                             left_join_attributes_,
-                            right_join_attributes_);
+                            right_join_attributes_,
+                            residual_predicate_,
+                            join_type_);
   }
 
   std::vector<expressions::AttributeReferencePtr> getReferencedAttributes() const override {
@@ -98,13 +138,22 @@ class HashJoin : public BinaryJoin {
    * @param right The right input operator.
    * @param left_join_attributes The join attributes in the 'left'.
    * @param right_join_attributes The join attributes in the 'right'.
+   * @param Join type of this hash join.
    * @return An immutable HashJoin.
    */
   static HashJoinPtr Create(const LogicalPtr &left,
                             const LogicalPtr &right,
                             const std::vector<expressions::AttributeReferencePtr> &left_join_attributes,
-                            const std::vector<expressions::AttributeReferencePtr> &right_join_attributes) {
-    return HashJoinPtr(new HashJoin(left, right, left_join_attributes, right_join_attributes));
+                            const std::vector<expressions::AttributeReferencePtr> &right_join_attributes,
+                            const expressions::PredicatePtr &residual_predicate,
+                            const JoinType join_type) {
+    return HashJoinPtr(
+        new HashJoin(left,
+                     right,
+                     left_join_attributes,
+                     right_join_attributes,
+                     residual_predicate,
+                     join_type));
   }
 
  protected:
@@ -132,16 +181,26 @@ class HashJoin : public BinaryJoin {
   HashJoin(const LogicalPtr &left,
            const LogicalPtr &right,
            const std::vector<expressions::AttributeReferencePtr> &left_join_attributes,
-           const std::vector<expressions::AttributeReferencePtr> &right_join_attributes)
+           const std::vector<expressions::AttributeReferencePtr> &right_join_attributes,
+           const expressions::PredicatePtr &residual_predicate,
+           const JoinType join_type)
       : BinaryJoin(left, right),
         left_join_attributes_(left_join_attributes),
-        right_join_attributes_(right_join_attributes) {
+        right_join_attributes_(right_join_attributes),
+        residual_predicate_(residual_predicate),
+        join_type_(join_type) {
     DCHECK_EQ(left_join_attributes.size(), right_join_attributes.size());
     DCHECK(!left_join_attributes.empty());
+
+    if (residual_predicate_ != nullptr) {
+      addInputExpression(residual_predicate_);
+    }
   }
 
   std::vector<expressions::AttributeReferencePtr> left_join_attributes_;
   std::vector<expressions::AttributeReferencePtr> right_join_attributes_;
+  expressions::PredicatePtr residual_predicate_;
+  const JoinType join_type_;
 
   DISALLOW_COPY_AND_ASSIGN(HashJoin);
 };

--- a/query_optimizer/logical/Logical.hpp
+++ b/query_optimizer/logical/Logical.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,8 +25,11 @@
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/logical/LogicalType.hpp"
 #include "utility/Macros.hpp"
+
+#include "glog/logging.h"
 
 namespace quickstep {
 namespace optimizer {
@@ -40,7 +45,8 @@ typedef std::shared_ptr<const Logical> LogicalPtr;
 /**
  * @brief Base class for all logical operator/node.
  */
-class Logical : public OptimizerTree<Logical> {
+class Logical : public OptimizerTree<Logical>,
+                public std::enable_shared_from_this<const Logical> {
  public:
   /**
    * @brief Destructor.
@@ -64,11 +70,61 @@ class Logical : public OptimizerTree<Logical> {
    */
   virtual std::vector<expressions::AttributeReferencePtr> getReferencedAttributes() const = 0;
 
+  /**
+   * @brief Make a copy of this logical node with input expressions replaced by
+   *        input_expression.
+   *
+   * @return A copy of this logical node with the new input expressions.
+   */
+  virtual LogicalPtr copyWithNewInputExpressions(
+      const std::vector<expressions::ExpressionPtr> &input_expressions) const {
+    // Default implementation: return a shared reference to "this" when there is
+    // no change.
+    DCHECK(input_expressions.empty());
+    return shared_from_this();
+  }
+
+  /**
+   * @return The input expressions in this Logical.
+   */
+  const std::vector<expressions::ExpressionPtr>& input_expressions() const {
+    return input_expressions_;
+  }
+
+  /**
+   * @return The input attributes, which are the union set of the output attributes of
+   *         all children.
+   */
+  std::vector<expressions::AttributeReferencePtr> getInputAttributes() const {
+    std::vector<expressions::AttributeReferencePtr> input_attributes;
+    for (const LogicalPtr &child : children()) {
+      const std::vector<expressions::AttributeReferencePtr> child_output_attributes =
+          child->getOutputAttributes();
+      input_attributes.insert(input_attributes.end(),
+                              child_output_attributes.begin(),
+                              child_output_attributes.end());
+    }
+    return input_attributes;
+  }
+
  protected:
   /**
    * @brief Constructor.
    */
   Logical() {}
+
+  template <class ExpressionClass>
+  void addInputExpressions(const std::vector<ExpressionClass> &new_input_expressions) {
+    input_expressions_.insert(input_expressions_.end(),
+                              new_input_expressions.begin(),
+                              new_input_expressions.end());
+  }
+
+  void addInputExpression(const expressions::ExpressionPtr &new_input_expression) {
+    input_expressions_.emplace_back(new_input_expression);
+  }
+
+  std::vector<expressions::ExpressionPtr> input_expressions_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(Logical);

--- a/query_optimizer/logical/Project.hpp
+++ b/query_optimizer/logical/Project.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +26,7 @@
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/logical/Logical.hpp"
 #include "query_optimizer/logical/LogicalType.hpp"
@@ -65,6 +68,9 @@ class Project : public Logical {
   LogicalPtr copyWithNewChildren(
       const std::vector<LogicalPtr> &new_children) const override;
 
+  LogicalPtr copyWithNewInputExpressions(
+      const std::vector<expressions::ExpressionPtr> &input_expressions) const override;
+
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override;
 
   std::vector<expressions::AttributeReferencePtr> getReferencedAttributes() const override;
@@ -98,6 +104,7 @@ class Project : public Logical {
       const std::vector<expressions::NamedExpressionPtr> &project_expressions)
       : input_(input), project_expressions_(project_expressions) {
     addChild(input);
+    addInputExpressions(project_expressions_);
   }
 
   LogicalPtr input_;

--- a/query_optimizer/physical/CMakeLists.txt
+++ b/query_optimizer/physical/CMakeLists.txt
@@ -232,8 +232,8 @@ target_link_libraries(quickstep_queryoptimizer_physical_TopLevelPlan
                       glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_ExpressionUtil
-                      quickstep_queryoptimizer_expressions_NamedExpression
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_physical_PhysicalType
                       quickstep_utility_Cast

--- a/query_optimizer/physical/HashJoin.cpp
+++ b/query_optimizer/physical/HashJoin.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -76,7 +78,8 @@ bool HashJoin::maybeCopyWithPrunedExpressions(
                      left_join_attributes_,
                      right_join_attributes_,
                      residual_predicate_,
-                     new_project_expressions);
+                     new_project_expressions,
+                     join_type_);
     return true;
   }
   return false;

--- a/query_optimizer/physical/HashJoin.hpp
+++ b/query_optimizer/physical/HashJoin.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -20,6 +22,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -50,9 +53,28 @@ typedef std::shared_ptr<const HashJoin> HashJoinPtr;
  */
 class HashJoin : public BinaryJoin {
  public:
+  enum JoinType {
+    kInnerJoin = 0,
+    kLeftSemiJoin,
+    kLeftAntiJoin
+  };
+
   PhysicalType getPhysicalType() const override { return PhysicalType::kHashJoin; }
 
-  std::string getName() const override { return "HashJoin"; }
+  std::string getName() const override {
+    switch (join_type_) {
+      case kInnerJoin:
+        return "HashJoin";
+      case kLeftSemiJoin:
+        return "HashLeftSemiJoin";
+      case kLeftAntiJoin:
+        return "HashLeftAntiJoin";
+      default:
+        LOG(FATAL) << "Invalid JoinType: "
+                   << static_cast<typename std::underlying_type<JoinType>::type>(join_type_);
+    }
+    QUICKSTEP_UNREACHABLE();
+  }
 
   /**
    * @brief Join attributes in the left logical 'left_'.
@@ -75,6 +97,13 @@ class HashJoin : public BinaryJoin {
     return residual_predicate_;
   }
 
+  /**
+   * @return Join type of this hash join.
+   */
+  JoinType join_type() const {
+    return join_type_;
+  }
+
   PhysicalPtr copyWithNewChildren(
       const std::vector<PhysicalPtr> &new_children) const override {
     DCHECK_EQ(children().size(), new_children.size());
@@ -83,7 +112,8 @@ class HashJoin : public BinaryJoin {
                   left_join_attributes_,
                   right_join_attributes_,
                   residual_predicate_,
-                  project_expressions());
+                  project_expressions(),
+                  join_type_);
   }
 
   std::vector<expressions::AttributeReferencePtr> getReferencedAttributes() const override;
@@ -102,6 +132,7 @@ class HashJoin : public BinaryJoin {
    * @param right_join_attributes The join attributes in the 'right'.
    * @param residual_predicate Optional filtering predicate evaluated after join.
    * @param project_expressions The project expressions.
+   * @param Join type of this hash join.
    * @return An immutable physical HashJoin.
    */
   static HashJoinPtr Create(
@@ -110,14 +141,16 @@ class HashJoin : public BinaryJoin {
       const std::vector<expressions::AttributeReferencePtr> &left_join_attributes,
       const std::vector<expressions::AttributeReferencePtr> &right_join_attributes,
       const expressions::PredicatePtr &residual_predicate,
-      const std::vector<expressions::NamedExpressionPtr> &project_expressions) {
+      const std::vector<expressions::NamedExpressionPtr> &project_expressions,
+      const JoinType join_type) {
     return HashJoinPtr(
         new HashJoin(left,
                      right,
                      left_join_attributes,
                      right_join_attributes,
                      residual_predicate,
-                     project_expressions));
+                     project_expressions,
+                     join_type));
   }
 
  protected:
@@ -136,15 +169,19 @@ class HashJoin : public BinaryJoin {
       const std::vector<expressions::AttributeReferencePtr> &left_join_attributes,
       const std::vector<expressions::AttributeReferencePtr> &right_join_attributes,
       const expressions::PredicatePtr &residual_predicate,
-      const std::vector<expressions::NamedExpressionPtr> &project_expressions)
+      const std::vector<expressions::NamedExpressionPtr> &project_expressions,
+      const JoinType join_type)
       : BinaryJoin(left, right, project_expressions),
         left_join_attributes_(left_join_attributes),
         right_join_attributes_(right_join_attributes),
-        residual_predicate_(residual_predicate) {}
+        residual_predicate_(residual_predicate),
+        join_type_(join_type) {
+  }
 
   std::vector<expressions::AttributeReferencePtr> left_join_attributes_;
   std::vector<expressions::AttributeReferencePtr> right_join_attributes_;
   expressions::PredicatePtr residual_predicate_;
+  const JoinType join_type_;
 
   DISALLOW_COPY_AND_ASSIGN(HashJoin);
 };

--- a/query_optimizer/physical/HashJoin.hpp
+++ b/query_optimizer/physical/HashJoin.hpp
@@ -53,7 +53,7 @@ typedef std::shared_ptr<const HashJoin> HashJoinPtr;
  */
 class HashJoin : public BinaryJoin {
  public:
-  enum JoinType {
+  enum class JoinType {
     kInnerJoin = 0,
     kLeftSemiJoin,
     kLeftAntiJoin
@@ -63,17 +63,16 @@ class HashJoin : public BinaryJoin {
 
   std::string getName() const override {
     switch (join_type_) {
-      case kInnerJoin:
+      case JoinType::kInnerJoin:
         return "HashJoin";
-      case kLeftSemiJoin:
+      case JoinType::kLeftSemiJoin:
         return "HashLeftSemiJoin";
-      case kLeftAntiJoin:
+      case JoinType::kLeftAntiJoin:
         return "HashLeftAntiJoin";
       default:
         LOG(FATAL) << "Invalid JoinType: "
                    << static_cast<typename std::underlying_type<JoinType>::type>(join_type_);
     }
-    QUICKSTEP_UNREACHABLE();
   }
 
   /**
@@ -181,7 +180,7 @@ class HashJoin : public BinaryJoin {
   std::vector<expressions::AttributeReferencePtr> left_join_attributes_;
   std::vector<expressions::AttributeReferencePtr> right_join_attributes_;
   expressions::PredicatePtr residual_predicate_;
-  const JoinType join_type_;
+  JoinType join_type_;
 
   DISALLOW_COPY_AND_ASSIGN(HashJoin);
 };

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -21,10 +23,13 @@ add_library(quickstep_queryoptimizer_rules_CollapseProject CollapseProject.cpp C
 add_library(quickstep_queryoptimizer_rules_GenerateJoins GenerateJoins.cpp GenerateJoins.hpp)
 add_library(quickstep_queryoptimizer_rules_PruneColumns PruneColumns.cpp PruneColumns.hpp)
 add_library(quickstep_queryoptimizer_rules_PushDownFilter PushDownFilter.cpp PushDownFilter.hpp)
+add_library(quickstep_queryoptimizer_rules_PushDownSemiAntiJoin PushDownSemiAntiJoin.cpp PushDownSemiAntiJoin.hpp)
 add_library(quickstep_queryoptimizer_rules_Rule ../../empty_src.cpp Rule.hpp)
 add_library(quickstep_queryoptimizer_rules_RuleHelper RuleHelper.cpp RuleHelper.hpp)
 add_library(quickstep_queryoptimizer_rules_TopDownRule ../../empty_src.cpp TopDownRule.hpp)
 add_library(quickstep_queryoptimizer_rules_UpdateExpression UpdateExpression.cpp UpdateExpression.hpp)
+add_library(quickstep_queryoptimizer_rules_UnnestSubqueries UnnestSubqueries.cpp UnnestSubqueries.hpp)
+
                       
 # Link dependencies:
 target_link_libraries(quickstep_queryoptimizer_rules_BottomUpRule
@@ -58,7 +63,6 @@ target_link_libraries(quickstep_queryoptimizer_rules_GenerateJoins
                       quickstep_queryoptimizer_rules_TopDownRule
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_utility_HashPair
                       quickstep_utility_Macros
                       quickstep_utility_VectorUtil)
 target_link_libraries(quickstep_queryoptimizer_rules_PruneColumns
@@ -81,6 +85,14 @@ target_link_libraries(quickstep_queryoptimizer_rules_PushDownFilter
                       quickstep_queryoptimizer_rules_RuleHelper
                       quickstep_queryoptimizer_rules_TopDownRule
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_queryoptimizer_rules_PushDownSemiAntiJoin
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExpressionUtil
+                      quickstep_queryoptimizer_logical_HashJoin
+                      quickstep_queryoptimizer_logical_Logical
+                      quickstep_queryoptimizer_logical_PatternMatcher
+                      quickstep_queryoptimizer_rules_TopDownRule
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_Rule
                       glog
                       quickstep_utility_Macros)
@@ -97,6 +109,36 @@ target_link_libraries(quickstep_queryoptimizer_rules_RuleHelper
 target_link_libraries(quickstep_queryoptimizer_rules_TopDownRule
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_queryoptimizer_rules_UnnestSubqueries
+                      quickstep_queryoptimizer_OptimizerContext
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ComparisonExpression
+                      quickstep_queryoptimizer_expressions_Exists
+                      quickstep_queryoptimizer_expressions_ExprId
+                      quickstep_queryoptimizer_expressions_Expression
+                      quickstep_queryoptimizer_expressions_ExpressionType
+                      quickstep_queryoptimizer_expressions_ExpressionUtil
+                      quickstep_queryoptimizer_expressions_LogicalAnd
+                      quickstep_queryoptimizer_expressions_LogicalNot
+                      quickstep_queryoptimizer_expressions_LogicalOr
+                      quickstep_queryoptimizer_expressions_NamedExpression
+                      quickstep_queryoptimizer_expressions_PatternMatcher
+                      quickstep_queryoptimizer_expressions_Predicate
+                      quickstep_queryoptimizer_expressions_SubqueryExpression
+                      quickstep_queryoptimizer_logical_Aggregate
+                      quickstep_queryoptimizer_logical_Filter
+                      quickstep_queryoptimizer_logical_HashJoin
+                      quickstep_queryoptimizer_logical_Logical
+                      quickstep_queryoptimizer_logical_LogicalType
+                      quickstep_queryoptimizer_logical_PatternMatcher
+                      quickstep_queryoptimizer_logical_Project
+                      quickstep_queryoptimizer_logical_TopLevelPlan
+                      quickstep_queryoptimizer_rules_BottomUpRule
+                      quickstep_queryoptimizer_rules_Rule
+                      quickstep_types_operations_comparisons_Comparison
+                      quickstep_types_operations_comparisons_ComparisonID
+                      quickstep_utility_Macros
+                      quickstep_utility_SqlError)
 target_link_libraries(quickstep_queryoptimizer_rules_UpdateExpression
                       glog
                       quickstep_queryoptimizer_expressions_ExprId
@@ -115,7 +157,9 @@ target_link_libraries(quickstep_queryoptimizer_rules
                       quickstep_queryoptimizer_rules_GenerateJoins
                       quickstep_queryoptimizer_rules_PruneColumns
                       quickstep_queryoptimizer_rules_PushDownFilter
+                      quickstep_queryoptimizer_rules_PushDownSemiAntiJoin
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_queryoptimizer_rules_RuleHelper
                       quickstep_queryoptimizer_rules_TopDownRule
-                      quickstep_queryoptimizer_rules_UpdateExpression)
+                      quickstep_queryoptimizer_rules_UpdateExpression
+                      quickstep_queryoptimizer_rules_UnnestSubqueries)

--- a/query_optimizer/rules/GenerateJoins.cpp
+++ b/query_optimizer/rules/GenerateJoins.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -35,7 +37,6 @@
 #include "query_optimizer/rules/RuleHelper.hpp"
 #include "types/operations/comparisons/ComparisonFactory.hpp"
 #include "types/operations/comparisons/ComparisonID.hpp"
-#include "utility/HashPair.hpp"
 #include "utility/VectorUtil.hpp"
 
 #include "glog/logging.h"
@@ -280,8 +281,8 @@ L::LogicalPtr GenerateJoins::applyToNode(const L::LogicalPtr &input) {
     // The predicates that are not used in any joins.
     std::vector<E::PredicatePtr> filter_predicates;
 
-    // First, create a HashJoin for each hash join predicate in the order as
-    // specified in the query.
+    // First, create an inner HashJoin for each hash join predicate in the order
+    // as specified in the query.
     for (const std::unique_ptr<const HashJoinPredicateInfo> &
              hash_join_predicate_info : hash_join_predicates) {
       const L::LogicalPtr left_logical =
@@ -296,7 +297,9 @@ L::LogicalPtr GenerateJoins::applyToNode(const L::LogicalPtr &input) {
             left_logical,
             right_logical,
             hash_join_predicate_info->left_join_attributes,
-            hash_join_predicate_info->right_join_attributes);
+            hash_join_predicate_info->right_join_attributes,
+            nullptr /* residual_predicate */,
+            L::HashJoin::kInnerJoin);
         UpdateLogicalVectors(left_logical,
                              right_logical,
                              logical_join,

--- a/query_optimizer/rules/GenerateJoins.cpp
+++ b/query_optimizer/rules/GenerateJoins.cpp
@@ -299,7 +299,7 @@ L::LogicalPtr GenerateJoins::applyToNode(const L::LogicalPtr &input) {
             hash_join_predicate_info->left_join_attributes,
             hash_join_predicate_info->right_join_attributes,
             nullptr /* residual_predicate */,
-            L::HashJoin::kInnerJoin);
+            L::HashJoin::JoinType::kInnerJoin);
         UpdateLogicalVectors(left_logical,
                              right_logical,
                              logical_join,

--- a/query_optimizer/rules/PushDownSemiAntiJoin.cpp
+++ b/query_optimizer/rules/PushDownSemiAntiJoin.cpp
@@ -1,0 +1,115 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "query_optimizer/rules/PushDownSemiAntiJoin.hpp"
+
+#include <vector>
+
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExpressionUtil.hpp"
+#include "query_optimizer/logical/HashJoin.hpp"
+#include "query_optimizer/logical/Logical.hpp"
+#include "query_optimizer/logical/PatternMatcher.hpp"
+
+namespace quickstep {
+namespace optimizer {
+
+namespace E = ::quickstep::optimizer::expressions;
+namespace L = ::quickstep::optimizer::logical;
+
+L::LogicalPtr PushDownSemiAntiJoin::applyToNode(const L::LogicalPtr &input) {
+  L::HashJoinPtr hash_join;
+
+  const std::vector<L::LogicalPtr> children = input->children();
+  std::vector<L::LogicalPtr> new_children;
+  bool has_changes = false;
+  for (const L::LogicalPtr& child : children) {
+    if (L::SomeHashJoin::MatchesWithConditionalCast(child, &hash_join)) {
+      if (hash_join->join_type() == L::HashJoin::kLeftSemiJoin
+          || hash_join->join_type() == L::HashJoin::kLeftAntiJoin) {
+        L::LogicalPtr new_child = pushDownSemiAntiJoin(hash_join);
+        if (new_child != child) {
+          has_changes = true;
+        }
+        new_children.push_back(new_child);
+      }
+    } else {
+      new_children.push_back(child);
+    }
+  }
+
+  if (has_changes) {
+    return input->copyWithNewChildren(new_children);
+  } else {
+    return input;
+  }
+}
+
+L::LogicalPtr PushDownSemiAntiJoin::pushDownSemiAntiJoin(
+    const L::HashJoinPtr &semi_anti_join) {
+  const L::LogicalPtr left_input = semi_anti_join->left();
+  std::vector<L::LogicalPtr> left_input_children = left_input->children();
+
+  if (!left_input_children.empty()) {
+    // Cannot push down a Filter down the right child of LeftOuterJoin.
+    std::vector<L::LogicalPtr>::size_type last_input_index = left_input_children.size();
+
+    std::vector<L::LogicalPtr>::size_type input_index = 0;
+    while (input_index < last_input_index) {
+      if (SubsetOfExpressions(semi_anti_join->left_join_attributes(),
+                              left_input_children[input_index]->getOutputAttributes())) {
+        break;
+      }
+      ++input_index;
+    }
+
+    if (input_index < last_input_index &&
+        semi_anti_join->residual_predicate() != nullptr) {
+      const std::vector<E::AttributeReferencePtr> input_child_output_attributes =
+          left_input_children[input_index]->getOutputAttributes();
+      const std::vector<E::AttributeReferencePtr> right_input_output_attributes =
+          semi_anti_join->right()->getOutputAttributes();
+      E::UnorderedAttributeSet visible_attribute_set(input_child_output_attributes.begin(),
+                                                     input_child_output_attributes.end());
+      visible_attribute_set.insert(right_input_output_attributes.begin(),
+                                   right_input_output_attributes.end());
+
+      const std::vector<E::AttributeReferencePtr> referenced_attrs_in_residual =
+          E::GetAttributeReferencesWithinScope(
+              semi_anti_join->residual_predicate()->getReferencedAttributes(),
+              E::AttributeReferenceScope::kLocal);
+      for (const E::AttributeReferencePtr& referenced_attr : referenced_attrs_in_residual) {
+        if (visible_attribute_set.find(referenced_attr) == visible_attribute_set.end()) {
+          input_index = last_input_index;
+          break;
+        }
+      }
+    }
+
+    if (input_index < last_input_index) {
+      left_input_children[input_index] =
+          semi_anti_join->copyWithNewChildren({left_input_children[input_index],
+                                               semi_anti_join->right()});
+      return left_input->copyWithNewChildren(left_input_children);
+    }
+  }
+
+  return semi_anti_join;
+}
+
+}  // namespace optimizer
+}  // namespace quickstep

--- a/query_optimizer/rules/PushDownSemiAntiJoin.hpp
+++ b/query_optimizer/rules/PushDownSemiAntiJoin.hpp
@@ -1,0 +1,49 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef MACHINE_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_
+#define MACHINE_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_
+
+#include <string>
+
+#include "query_optimizer/logical/HashJoin.hpp"
+#include "query_optimizer/logical/Logical.hpp"
+#include "query_optimizer/rules/TopDownRule.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace optimizer {
+
+class PushDownSemiAntiJoin : public TopDownRule<logical::Logical> {
+ public:
+  PushDownSemiAntiJoin() {}
+
+  std::string getName() const override { return "PushDownSemiAntiJoin"; }
+
+ protected:
+  logical::LogicalPtr applyToNode(const logical::LogicalPtr &input) override;
+
+ private:
+  logical::LogicalPtr pushDownSemiAntiJoin(const logical::HashJoinPtr& input);
+
+  DISALLOW_COPY_AND_ASSIGN(PushDownSemiAntiJoin);
+};
+
+}  // namespace optimizer
+}  // namespace quickstep
+
+#endif /* MACHINE_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_ */

--- a/query_optimizer/rules/PushDownSemiAntiJoin.hpp
+++ b/query_optimizer/rules/PushDownSemiAntiJoin.hpp
@@ -15,8 +15,8 @@
  *   limitations under the License.
  **/
 
-#ifndef MACHINE_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_
-#define MACHINE_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_
+#ifndef QUICKSTEP_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_
+#define QUICKSTEP_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_
 
 #include <string>
 
@@ -38,7 +38,7 @@ class PushDownSemiAntiJoin : public TopDownRule<logical::Logical> {
   logical::LogicalPtr applyToNode(const logical::LogicalPtr &input) override;
 
  private:
-  logical::LogicalPtr pushDownSemiAntiJoin(const logical::HashJoinPtr& input);
+  logical::LogicalPtr pushDownSemiAntiJoin(const logical::HashJoinPtr &input);
 
   DISALLOW_COPY_AND_ASSIGN(PushDownSemiAntiJoin);
 };
@@ -46,4 +46,4 @@ class PushDownSemiAntiJoin : public TopDownRule<logical::Logical> {
 }  // namespace optimizer
 }  // namespace quickstep
 
-#endif /* MACHINE_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_ */
+#endif /* QUICKSTEP_QUERY_OPTIMIZER_RULES_PUSH_DOWN_SEMI_ANTI_JOIN_HPP_ */

--- a/query_optimizer/rules/UnnestSubqueries.cpp
+++ b/query_optimizer/rules/UnnestSubqueries.cpp
@@ -1,0 +1,720 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "query_optimizer/rules/UnnestSubqueries.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "query_optimizer/OptimizerContext.hpp"
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ComparisonExpression.hpp"
+#include "query_optimizer/expressions/Exists.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
+#include "query_optimizer/expressions/ExpressionType.hpp"
+#include "query_optimizer/expressions/ExpressionUtil.hpp"
+#include "query_optimizer/expressions/LogicalAnd.hpp"
+#include "query_optimizer/expressions/LogicalNot.hpp"
+#include "query_optimizer/expressions/LogicalOr.hpp"
+#include "query_optimizer/expressions/NamedExpression.hpp"
+#include "query_optimizer/expressions/PatternMatcher.hpp"
+#include "query_optimizer/expressions/SubqueryExpression.hpp"
+#include "query_optimizer/logical/Aggregate.hpp"
+#include "query_optimizer/logical/Filter.hpp"
+#include "query_optimizer/logical/HashJoin.hpp"
+#include "query_optimizer/logical/Logical.hpp"
+#include "query_optimizer/logical/LogicalType.hpp"
+#include "query_optimizer/logical/PatternMatcher.hpp"
+#include "query_optimizer/logical/Project.hpp"
+#include "query_optimizer/logical/TopLevelPlan.hpp"
+#include "query_optimizer/rules/Rule.hpp"
+#include "types/operations/comparisons/Comparison.hpp"
+#include "types/operations/comparisons/ComparisonID.hpp"
+#include "utility/SqlError.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+namespace optimizer {
+
+namespace E = ::quickstep::optimizer::expressions;
+namespace L = ::quickstep::optimizer::logical;
+
+struct CorrelatedQueryInfo {
+  enum QueryType {
+    kHashJoin,
+    kSemiJoin,
+    kAntiJoin
+  };
+
+  CorrelatedQueryInfo(const QueryType query_type,
+                      const L::LogicalPtr &correlated_query_in,
+                      std::vector<E::AttributeReferencePtr> &&probe_join_attributes_in,
+                      std::vector<E::AttributeReferencePtr> &&build_join_attributes_in,
+                      std::vector<E::PredicatePtr> &&non_hash_join_predicates_in)
+      : query_type_(query_type),
+        correlated_query(correlated_query_in),
+        probe_join_attributes(std::move(probe_join_attributes_in)),
+        build_join_attributes(std::move(build_join_attributes_in)),
+        non_hash_join_predicates(std::move(non_hash_join_predicates_in)) {}
+
+  QueryType query_type_;
+  L::LogicalPtr correlated_query;
+  std::vector<E::AttributeReferencePtr> probe_join_attributes;
+  std::vector<E::AttributeReferencePtr> build_join_attributes;
+  std::vector<E::PredicatePtr> non_hash_join_predicates;
+};
+
+L::LogicalPtr UnnestSubqueries::apply(const L::LogicalPtr &input) {
+  DCHECK(L::SomeTopLevelPlan::Matches(input))
+      << "The input logical node must be of TopLevelPlan";
+
+  const L::TopLevelPlan* top_level_plan =
+      static_cast<const L::TopLevelPlan*>(input.get());
+
+  bool has_changes = false;
+
+  std::vector<E::AttributeReferencePtr> empty_probe_join_predicates;
+  std::vector<E::AttributeReferencePtr> empty_build_join_predicates;
+  std::vector<E::PredicatePtr> empty_correlated_non_hash_join_predicates;
+  std::unordered_map<E::ExprId, L::LogicalPtr> uncorrelated_subqueries;
+  expressions::UnorderedNamedExpressionSet empty_attributes;
+  UnnestSubqueriesForNonRootLogical unnest_rule(false /* scalar query */,
+                                                empty_attributes,
+                                                context_,
+                                                &uncorrelated_subqueries,
+                                                &empty_probe_join_predicates,
+                                                &empty_build_join_predicates,
+                                                &empty_correlated_non_hash_join_predicates);
+  DCHECK(empty_probe_join_predicates.empty());
+  DCHECK(empty_build_join_predicates.empty());
+  DCHECK(empty_correlated_non_hash_join_predicates.empty());
+
+  // Unnest subqueries in each subplan and the main plan.
+  std::vector<L::LogicalPtr> new_shared_subplans;
+  for (const L::LogicalPtr &shared_subplan : top_level_plan->shared_subplans()) {
+    const L::LogicalPtr new_shared_subplan = unnest_rule.apply(shared_subplan);
+    if (new_shared_subplan != shared_subplan && !has_changes) {
+      has_changes = true;
+    }
+    new_shared_subplans.emplace_back(new_shared_subplan);
+  }
+
+  const L::LogicalPtr new_main_plan = unnest_rule.apply(top_level_plan->plan());
+  if (new_main_plan != top_level_plan->plan() && !has_changes) {
+    has_changes = true;
+  }
+
+  std::unordered_map<E::ExprId, int> uncorrelated_map;
+  std::vector<L::LogicalPtr>::size_type subplan_id = new_shared_subplans.size();
+  for (const std::pair<const E::ExprId, L::LogicalPtr> &uncorrelated_query_info : uncorrelated_subqueries) {
+    uncorrelated_map.emplace(uncorrelated_query_info.first,
+                             subplan_id);
+    new_shared_subplans.emplace_back(uncorrelated_query_info.second);
+    ++subplan_id;
+  }
+
+  if (!uncorrelated_subqueries.empty() || has_changes) {
+    const L::LogicalPtr new_top_level_plan =
+        L::TopLevelPlan::Create(new_main_plan,
+                                new_shared_subplans,
+                                uncorrelated_map);
+    LOG_APPLYING_RULE(input, new_top_level_plan);
+    return new_top_level_plan;
+  }
+
+  LOG_IGNORING_RULE(input);
+  return input;
+}
+
+L::LogicalPtr UnnestSubqueriesForNonRootLogical::applyInternal(
+    const L::LogicalPtr &input,
+    E::UnorderedAttributeSet *inner_attributes,
+    std::vector<E::AttributeReferencePtr> *probe_join_attributes,
+    std::vector<E::AttributeReferencePtr> *build_join_attributes,
+    std::vector<E::PredicatePtr> *non_hash_join_predicates) {
+  DCHECK(inner_attributes->empty());
+  DCHECK(probe_join_attributes->empty());
+  DCHECK(build_join_attributes->empty());
+  DCHECK(non_hash_join_predicates->empty());
+
+  // First, handle subquery expressions in the children.
+  bool has_change = false;
+  std::vector<L::LogicalPtr> new_children;
+  for (const L::LogicalPtr &child : input->children()) {
+    E::UnorderedAttributeSet inner_attributes_in_child;
+    std::vector<E::AttributeReferencePtr> probe_join_predicates_in_child;
+    std::vector<E::AttributeReferencePtr> build_join_predicates_in_child;
+    std::vector<E::PredicatePtr> non_hash_join_predicates_in_child;
+    const L::LogicalPtr new_child =
+        applyInternal(child,
+                      &inner_attributes_in_child,
+                      &probe_join_predicates_in_child,
+                      &build_join_predicates_in_child,
+                      &non_hash_join_predicates_in_child);
+    inner_attributes->insert(inner_attributes_in_child.begin(),
+                             inner_attributes_in_child.end());
+    probe_join_attributes->insert(probe_join_attributes->end(),
+                                  probe_join_predicates_in_child.begin(),
+                                  probe_join_predicates_in_child.end());
+    build_join_attributes->insert(build_join_attributes->end(),
+                                  build_join_predicates_in_child.begin(),
+                                  build_join_predicates_in_child.end());
+    non_hash_join_predicates->insert(non_hash_join_predicates->end(),
+                                     non_hash_join_predicates_in_child.begin(),
+                                     non_hash_join_predicates_in_child.end());
+    if (new_child != child && !has_change) {
+      has_change = true;
+    }
+    new_children.emplace_back(new_child);
+  }
+
+  L::LogicalPtr input_with_new_children = input;
+  if (has_change) {
+    input_with_new_children = input->copyWithNewChildren(new_children);
+  }
+
+  // Next, process subquery expressions in the current node.
+  const L::LogicalPtr output = applyToNode(input_with_new_children,
+                                           inner_attributes,
+                                           probe_join_attributes,
+                                           build_join_attributes,
+                                           non_hash_join_predicates);
+  return output;
+}
+
+L::LogicalPtr UnnestSubqueriesForNonRootLogical::applyToNode(
+    const L::LogicalPtr &input,
+    E::UnorderedAttributeSet *inner_attributes,
+    std::vector<E::AttributeReferencePtr> *probe_join_attributes,
+    std::vector<E::AttributeReferencePtr> *build_join_attributes,
+    std::vector<E::PredicatePtr> *non_hash_join_predicates) {
+  // First eliminate subqueries expressions in this node (that is, this node is the outer query).
+  L::LogicalPtr input_with_no_subqueries = eliminateNestedScalarQueries(input);
+  DCHECK(input_with_no_subqueries != nullptr);
+
+  // Next determine whether this node has any outer reference (that is, this node is the inner query).
+  const std::vector<E::ExpressionPtr> &input_expressions = input_with_no_subqueries->input_expressions();
+  std::vector<E::ExpressionPtr> new_input_expressions;
+  bool has_change = false;
+  for (const E::ExpressionPtr &input_expression : input_expressions) {
+    const E::ExpressionPtr new_input_expression =
+        eliminateOuterAttributeReference(input_expression,
+                                         inner_attributes,
+                                         probe_join_attributes,
+                                         build_join_attributes,
+                                         non_hash_join_predicates);
+    if (new_input_expression != nullptr) {
+      new_input_expressions.emplace_back(new_input_expression);
+    }
+    if (new_input_expression != input_expression && !has_change) {
+      has_change = true;
+    }
+  }
+
+  switch (input_with_no_subqueries->getLogicalType()) {
+    case L::LogicalType::kAggregate: {
+      if (!non_hash_join_predicates->empty()) {
+        THROW_SQL_ERROR()
+            << "Non-equality join predicate with an outer query must be above any aggregate";
+      }
+
+      const L::Aggregate *aggregate = static_cast<const L::Aggregate*>(input_with_no_subqueries.get());
+      DCHECK(!has_change);
+      if (!inner_attributes->empty()) {
+        std::vector<E::NamedExpressionPtr> group_expressions = aggregate->grouping_expressions();
+        group_expressions.insert(group_expressions.end(),
+                                 inner_attributes->begin(),
+                                 inner_attributes->end());
+        return L::Aggregate::Create(aggregate->input(),
+                                    group_expressions,
+                                    aggregate->aggregate_expressions());
+      }
+      return input_with_no_subqueries;
+    }
+    case L::LogicalType::kFilter: {
+      if (new_input_expressions.empty()) {
+        const L::Filter* filter = static_cast<const L::Filter*>(input_with_no_subqueries.get());
+        return filter->input();
+      }
+      if (has_change) {
+        return input_with_no_subqueries->copyWithNewInputExpressions(new_input_expressions);
+      }
+      return input_with_no_subqueries;
+    }
+    case L::LogicalType::kProject: {
+      if (has_change) {
+        input_with_no_subqueries =
+            input_with_no_subqueries->copyWithNewInputExpressions(new_input_expressions);
+      }
+      if (!inner_attributes->empty()) {
+         const L::Project *project = static_cast<const L::Project*>(input_with_no_subqueries.get());
+         // Insert those inner attributes into the front of the project expression
+         // list rather than the back to help reduce unnecessary selection for
+         // reordering output attributes, since those attributes are usually also
+         // grouping attributes that proceed others in projection.
+         std::vector<E::NamedExpressionPtr> new_project_expressions;
+         const E::UnorderedNamedExpressionSet project_expression_set(project->project_expressions().begin(),
+                                                                     project->project_expressions().end());
+         for (const E::AttributeReferencePtr &inner_attribute : *inner_attributes) {
+           if (project_expression_set.find(inner_attribute) == project_expression_set.end()) {
+             new_project_expressions.emplace_back(inner_attribute);
+           }
+         }
+         new_project_expressions.insert(new_project_expressions.end(),
+                                        project_expression_set.begin(),
+                                        project_expression_set.end());
+         if (new_project_expressions.size() != project->project_expressions().size()) {
+           input_with_no_subqueries = L::Project::Create(project->input(),
+                                                         new_project_expressions);
+         }
+      }
+      return input_with_no_subqueries;
+    }
+    default:
+      if (has_change) {
+        return input_with_no_subqueries->copyWithNewInputExpressions(new_input_expressions);
+      }
+      return input_with_no_subqueries;
+  }
+}
+
+E::ExpressionPtr UnnestSubqueriesForNonRootLogical::eliminateOuterAttributeReference(
+    const E::ExpressionPtr &expression,
+    E::UnorderedAttributeSet *inner_attributes,
+    std::vector<E::AttributeReferencePtr> *probe_join_attributes,
+    std::vector<E::AttributeReferencePtr> *build_join_attributes,
+    std::vector<E::PredicatePtr>* non_hash_join_predicates) {
+  DCHECK(expression->getExpressionType() != E::ExpressionType::kExists);
+  DCHECK(expression->getExpressionType() != E::ExpressionType::kSubqueryExpression);
+
+  switch (expression->getExpressionType()) {
+    case E::ExpressionType::kPredicateLiteral:
+    case E::ExpressionType::kScalarLiteral:
+      return expression;
+    case E::ExpressionType::kLogicalAnd: {
+      const E::LogicalAnd* logical_and = static_cast<const E::LogicalAnd*>(expression.get());
+      bool has_change = false;
+      std::vector<E::PredicatePtr> new_children;
+      for (const E::PredicatePtr &child : logical_and->operands()) {
+        const E::ExpressionPtr new_child =
+            eliminateOuterAttributeReference(child,
+                                             inner_attributes,
+                                             probe_join_attributes,
+                                             build_join_attributes,
+                                             non_hash_join_predicates);
+        if (new_child != nullptr) {
+          new_children.emplace_back(
+              std::static_pointer_cast<const E::Predicate>(new_child));
+        }
+        if (new_child != child && !has_change) {
+          has_change = true;
+        }
+      }
+      if (has_change) {
+        if (new_children.empty()) {
+          return E::ExpressionPtr();
+        }
+        if (new_children.size() == 1u) {
+          return new_children[0];
+        }
+        return E::LogicalAnd::Create(new_children);
+      }
+      return expression;
+    }
+    case E::ExpressionType::kComparisonExpression: {
+      const E::ComparisonExpressionPtr comparison_expression =
+          std::static_pointer_cast<const E::ComparisonExpression>(expression);
+      E::AttributeReferencePtr outer_attribute;
+      E::AttributeReferencePtr inner_attribute;
+      // Hash-join predicate.
+      if (E::SomeAttributeReference::MatchesWithConditionalCast(comparison_expression->left(),
+                                                                &outer_attribute) &&
+          E::SomeAttributeReference::MatchesWithConditionalCast(comparison_expression->right(),
+                                                                &inner_attribute) &&
+          comparison_expression->comparison().getComparisonID() == ComparisonID::kEqual) {
+        if (!isCorrelatedOuterAttribute(outer_attribute)) {
+          if (!isCorrelatedOuterAttribute(inner_attribute)) {
+            return expression;
+          }
+          std::swap(outer_attribute, inner_attribute);
+        } else if (isCorrelatedOuterAttribute(inner_attribute)) {
+          THROW_SQL_ERROR() << "Comparison of two outer attribute references is not allowed";
+        }
+        if (visiable_attrs_from_outer_query_.find(outer_attribute) == visiable_attrs_from_outer_query_.end()) {
+          THROW_SQL_ERROR()
+              << "Nested queries can only reference attributes in the outer query one level above";
+        }
+        outer_attribute =
+            E::AttributeReference::Create(outer_attribute->id(),
+                                          outer_attribute->attribute_name(),
+                                          outer_attribute->attribute_alias(),
+                                          outer_attribute->relation_name(),
+                                          outer_attribute->getValueType(),
+                                          E::AttributeReferenceScope::kLocal);
+
+        inner_attributes->emplace(inner_attribute);
+        probe_join_attributes->emplace_back(outer_attribute);
+        build_join_attributes->emplace_back(inner_attribute);
+        return E::ExpressionPtr();
+      } else {
+        DeOuterAttributeReference de_outer_reference_rule(!scalar_query_,
+                                                          *uncorrelated_subqueries_,
+                                                          visiable_attrs_from_outer_query_);
+        const E::ExpressionPtr new_expression =
+            de_outer_reference_rule.apply(expression);
+        if (new_expression != expression) {
+          // All the inner attributes should be insert into the inner_attributes,
+          // so that they will be visible from the outer query.
+          // Note that we use expression instead of new_expression, since
+          // the outer attribute reference in new_expression is de-outer referenced.
+          const std::vector<E::AttributeReferencePtr> &inner_attrs_vec =
+              E::GetAttributeReferencesWithinScope(expression->getReferencedAttributes(),
+                                                   E::AttributeReferenceScope::kLocal);
+          for (const E::AttributeReferencePtr &attr : inner_attrs_vec) {
+            inner_attributes->emplace(attr);
+          }
+
+          non_hash_join_predicates->emplace_back(
+              std::static_pointer_cast<const E::Predicate>(new_expression));
+          return E::ExpressionPtr();
+        }
+      }
+      return expression;
+    }
+    default: {
+      validateNonOuterAttributeReference(expression);
+      return expression;
+    }
+  }
+}
+
+void UnnestSubqueriesForNonRootLogical::validateNonOuterAttributeReference(
+    const E::ExpressionPtr &expression) {
+  const std::vector<E::AttributeReferencePtr> referenced_attributes =
+      expression->getReferencedAttributes();
+  for (const E::AttributeReferencePtr &referenced_attribute : referenced_attributes) {
+    if (isCorrelatedOuterAttribute(referenced_attribute)) {
+      THROW_SQL_ERROR()
+          << "Outer attribute reference can only appear in a single-attribute equality predicate";
+    }
+  }
+}
+
+bool UnnestSubqueriesForNonRootLogical::isCorrelatedOuterAttribute(
+    const E::AttributeReferencePtr &attribute) const {
+  return attribute->scope() == E::AttributeReferenceScope::kOuter
+         && uncorrelated_subqueries_->find(attribute->id()) == uncorrelated_subqueries_->end();
+}
+
+L::LogicalPtr UnnestSubqueriesForNonRootLogical::eliminateNestedScalarQueries(const L::LogicalPtr &node) {
+  const std::vector<E::ExpressionPtr> &input_expressions = node->input_expressions();
+  const std::vector<E::AttributeReferencePtr> input_attributes =
+      node->getInputAttributes();
+  E::UnorderedNamedExpressionSet input_attribute_set(input_attributes.begin(),
+                                                     input_attributes.end());
+
+  // Transform subquery experssions into non-subquery expressions.
+  std::vector<CorrelatedQueryInfo> correlated_query_info_vec;
+  std::vector<E::ExpressionPtr> new_input_expressions;
+  bool has_changed_expression = false;
+  for (const E::ExpressionPtr &input_expression : input_expressions) {
+//    std::cerr << "to unnest expr: " << input_expression->toString();
+    std::vector<E::PredicatePtr> correlated_predicates;
+    UnnestSubqueriesForExpession unnest_rule_for_expr(
+        input_attribute_set,
+        context_,
+        uncorrelated_subqueries_,
+        &correlated_query_info_vec);
+    const E::ExpressionPtr new_input_expression =
+        unnest_rule_for_expr.apply(input_expression);
+    if (new_input_expression != input_expression && !has_changed_expression) {
+      has_changed_expression = true;
+    }
+    new_input_expressions.emplace_back(new_input_expression);
+  }
+
+  if (has_changed_expression) {
+    // If there are correlated subquery expressions, add logical joins.
+    if (!correlated_query_info_vec.empty()) {
+      L::LogicalPtr new_child;
+
+      if (new_input_expressions[0] == nullptr
+          && node->getLogicalType() == L::LogicalType::kNestedLoopsJoin) {
+        new_child = node;
+      } else {
+        DCHECK_EQ(node->children().size(), 1u);
+        new_child = node->children()[0];
+      }
+
+      for (CorrelatedQueryInfo &correlated_query_info : correlated_query_info_vec) {
+        DCHECK(!correlated_query_info.probe_join_attributes.empty());
+        if (correlated_query_info.query_type_ == CorrelatedQueryInfo::kHashJoin) {
+          DCHECK(correlated_query_info.non_hash_join_predicates.empty())
+              << correlated_query_info.non_hash_join_predicates[0]->toString();
+          new_child = L::HashJoin::Create(new_child,
+                                          correlated_query_info.correlated_query,
+                                          correlated_query_info.probe_join_attributes,
+                                          correlated_query_info.build_join_attributes,
+                                          nullptr, /* residual_predicate */
+                                          L::HashJoin::kInnerJoin);
+        } else {
+          E::PredicatePtr filter_predicate;
+          if (correlated_query_info.non_hash_join_predicates.size() > 1u) {
+            filter_predicate = E::LogicalAnd::Create(correlated_query_info.non_hash_join_predicates);
+          } else if (!correlated_query_info.non_hash_join_predicates.empty()) {
+            filter_predicate = correlated_query_info.non_hash_join_predicates[0];
+          }
+
+          L::HashJoin::JoinType join_type =
+              (correlated_query_info.query_type_ == CorrelatedQueryInfo::kSemiJoin)
+                  ? L::HashJoin::kLeftSemiJoin
+                  : L::HashJoin::kLeftAntiJoin;
+          new_child = L::HashJoin::Create(new_child,
+                                          correlated_query_info.correlated_query,
+                                          correlated_query_info.probe_join_attributes,
+                                          correlated_query_info.build_join_attributes,
+                                          filter_predicate,
+                                          join_type);
+        }
+      }
+
+      // Special case for filter and nested loops join which may contain EXISTS and IN.
+      if (new_input_expressions[0] == nullptr) {
+        DCHECK_EQ(new_input_expressions.size(), 1u);
+        DCHECK(node->getLogicalType() == L::LogicalType::kFilter
+               || node->getLogicalType() == L::LogicalType::kNestedLoopsJoin) << node->toString();
+        LOG_APPLYING_RULE(node, new_child);
+        return new_child;
+      }
+
+      L::LogicalPtr new_logical = node->copyWithNewInputExpressions(new_input_expressions);
+      new_logical = new_logical->copyWithNewChildren({new_child});
+      LOG_APPLYING_RULE(node, new_logical);
+      return new_logical;
+    }
+
+    L::LogicalPtr new_logical = node->copyWithNewInputExpressions(new_input_expressions);
+    LOG_APPLYING_RULE(node, new_logical);
+    return new_logical;
+  }
+
+  LOG_IGNORING_RULE(node);
+  return node;
+}
+
+E::ExpressionPtr UnnestSubqueriesForExpession::applyInternal(
+    bool allow_exists_or_in,
+    const E::ExpressionPtr &node) {
+  switch (node->getExpressionType()) {
+    case E::ExpressionType::kSubqueryExpression: {
+      const E::SubqueryExpression *subquery_expression =
+          static_cast<const E::SubqueryExpression*>(node.get());
+
+      std::vector<E::AttributeReferencePtr> probe_join_attributes;
+      std::vector<E::AttributeReferencePtr> build_join_attributes;
+      std::vector<E::PredicatePtr> non_hash_join_predicates;
+      UnnestSubqueriesForNonRootLogical unnest_logical_rule(true,  // scalar_query
+                                                            visible_attributes_from_outer_query_,
+                                                            context_,
+                                                            uncorrelated_subqueries_,
+                                                            &probe_join_attributes,
+                                                            &build_join_attributes,
+                                                            &non_hash_join_predicates);
+      const L::LogicalPtr subquery = subquery_expression->subquery();
+      const L::LogicalPtr new_subquery = unnest_logical_rule.apply(subquery);
+      const E::AttributeReferencePtr output_attribute = subquery->getOutputAttributes()[0];
+      DCHECK(!new_subquery->getOutputAttributes().empty());
+      if (probe_join_attributes.empty()) {
+        DCHECK(non_hash_join_predicates.empty());
+        DCHECK_EQ(1u, new_subquery->getOutputAttributes().size()) << node->toString();
+        const E::AttributeReferencePtr new_outer_attribute_reference =
+            E::AttributeReference::Create(context_->nextExprId(),
+                                          output_attribute->attribute_name(),
+                                          output_attribute->attribute_alias(),
+                                          output_attribute->relation_name(),
+                                          output_attribute->getValueType(),
+                                          E::AttributeReferenceScope::kOuter);
+        uncorrelated_subqueries_->emplace(new_outer_attribute_reference->id(),
+                                          new_subquery);
+        return new_outer_attribute_reference;
+      } else {
+        correlated_query_info_vec_->emplace_back(CorrelatedQueryInfo::kHashJoin,
+                                                 new_subquery,
+                                                 std::move(probe_join_attributes),
+                                                 std::move(build_join_attributes),
+                                                 std::move(non_hash_join_predicates));
+      }
+
+      return output_attribute;
+    }
+    case E::ExpressionType::kExists: {
+      if (!allow_exists_or_in) {
+        THROW_SQL_ERROR() << "EXISTS can only appear in (un-nested) NOT, AND or by itself";
+      }
+      const E::Exists *exists = static_cast<const E::Exists*>(node.get());
+      transformExists(exists);
+      return E::ExpressionPtr();
+    }
+    case E::ExpressionType::kLogicalNot: {
+      const E::LogicalNot *logical_not =
+          static_cast<const E::LogicalNot*>(node.get());
+      const E::PredicatePtr &operand = logical_not->operand();
+      if (operand->getExpressionType() == E::ExpressionType::kExists) {
+        if (!allow_exists_or_in) {
+          THROW_SQL_ERROR() << "EXISTS can only appear in (un-nested) NOT, AND or by itself";
+        }
+        transformExists(static_cast<const E::Exists*>(operand.get()));
+        correlated_query_info_vec_->back().query_type_ = CorrelatedQueryInfo::kAntiJoin;
+        return E::PredicatePtr();
+      }
+      const E::ExpressionPtr new_operand =
+          applyInternal(false /* allow_exists_or_in */,
+                        operand);
+      if (new_operand != operand) {
+        return E::LogicalNot::Create(std::static_pointer_cast<const E::Predicate>(new_operand));
+      } else {
+        return node;
+      }
+    }
+    case E::ExpressionType::kLogicalAnd: {
+      const E::LogicalAnd *logical_and =
+          static_cast<const E::LogicalAnd*>(node.get());
+
+      std::vector<E::PredicatePtr> new_operands;
+      bool has_change = false;
+      for (const E::PredicatePtr &operand : logical_and->operands()) {
+        const E::ExpressionPtr new_operand =
+            applyInternal(allow_exists_or_in,
+                          operand);
+        if (new_operand != operand && !has_change) {
+          has_change = true;
+        }
+        if (new_operand != nullptr) {
+          new_operands.emplace_back(std::static_pointer_cast<const E::Predicate>(new_operand));
+        }
+      }
+
+      if (new_operands.empty()) {
+        return E::PredicatePtr();
+      } else if (new_operands.size() == 1u) {
+        return new_operands[0];
+      }
+
+      if (has_change) {
+        return E::LogicalAnd::Create(new_operands);
+      }
+      return node;
+    }
+    case E::ExpressionType::kLogicalOr: {
+      const E::LogicalOr *logical_or =
+          static_cast<const E::LogicalOr*>(node.get());
+
+      std::vector<E::PredicatePtr> new_operands;
+      bool has_change = false;
+      for (const E::PredicatePtr &operand : logical_or->operands()) {
+        const E::ExpressionPtr new_operand =
+            applyInternal(false,
+                          operand);
+        if (new_operand != operand && !has_change) {
+          has_change = true;
+        }
+        DCHECK(new_operand != nullptr);
+        new_operands.emplace_back(std::static_pointer_cast<const E::Predicate>(new_operand));
+      }
+
+      if (has_change) {
+        return E::LogicalOr::Create(new_operands);
+      }
+      return node;
+    }
+    default:
+      std::vector<E::ExpressionPtr> new_children;
+      bool has_change = false;
+      for (const E::ExpressionPtr &child : node->children()) {
+        const E::ExpressionPtr new_child =
+            applyInternal(allow_exists_or_in, child);
+        if (new_child != child && !has_change) {
+          has_change = true;
+        }
+        DCHECK(child != nullptr);
+        new_children.emplace_back(new_child);
+      }
+
+      if (has_change) {
+        return node->copyWithNewChildren(new_children);
+      }
+      return node;
+  }
+}
+
+void UnnestSubqueriesForExpession::transformExists(
+    const E::Exists *exists_predicate) {
+  std::vector<E::AttributeReferencePtr> probe_join_attributes;
+  std::vector<E::AttributeReferencePtr> build_join_attributes;
+  std::vector<E::PredicatePtr> non_hash_join_predicates;
+  UnnestSubqueriesForNonRootLogical unnest_logical_rule(false,  // scalar_query
+                                                        visible_attributes_from_outer_query_,
+                                                        context_,
+                                                        uncorrelated_subqueries_,
+                                                        &probe_join_attributes,
+                                                        &build_join_attributes,
+                                                        &non_hash_join_predicates);
+  DCHECK_EQ(probe_join_attributes.size(), build_join_attributes.size());
+  const L::LogicalPtr new_subquery =
+      unnest_logical_rule.apply(exists_predicate->exists_subquery()->subquery());
+
+  if (probe_join_attributes.empty()) {
+    if (!non_hash_join_predicates.empty()) {
+      THROW_SQL_ERROR() << "Correlated queries must have an equality join predicate with the outer query";
+    }
+    THROW_SQL_ERROR() << "EXISTS subquery cannot be un-correlated with the outer query";
+  }
+
+  correlated_query_info_vec_->emplace_back(CorrelatedQueryInfo::kSemiJoin,
+                                           new_subquery,
+                                           std::move(probe_join_attributes),
+                                           std::move(build_join_attributes),
+                                           std::move(non_hash_join_predicates));
+}
+
+E::ExpressionPtr DeOuterAttributeReference::applyToNode(const E::ExpressionPtr &input) {
+  E::AttributeReferencePtr attr;
+  if (E::SomeAttributeReference::MatchesWithConditionalCast(input, &attr)
+      && attr->scope() == E::AttributeReferenceScope::kOuter
+      && uncorrelated_subqueries_.find(attr->id()) == uncorrelated_subqueries_.end()) {
+    if (!allow_outer_reference_) {
+      THROW_SQL_ERROR() << "Non-equality join predicate is not allowed in scalar subqueries";
+    }
+    if (visiable_attrs_from_outer_query_.find(attr) == visiable_attrs_from_outer_query_.end()) {
+      THROW_SQL_ERROR()
+          << "Nested queries can only reference attributes in the outer query one level above";
+    }
+    return E::AttributeReference::Create(attr->id(),
+                                         attr->attribute_name(),
+                                         attr->attribute_alias(),
+                                         attr->relation_name(),
+                                         attr->getValueType(),
+                                         E::AttributeReferenceScope::kLocal);
+  }
+  return input;
+}
+
+}  // namespace optimizer
+}  // namespace quickstep

--- a/query_optimizer/rules/UnnestSubqueries.hpp
+++ b/query_optimizer/rules/UnnestSubqueries.hpp
@@ -1,0 +1,219 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_OPTIMIZER_RULES_UNNEST_SUBQUERIES_HPP_
+#define QUICKSTEP_QUERY_OPTIMIZER_RULES_UNNEST_SUBQUERIES_HPP_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
+#include "query_optimizer/expressions/Expression.hpp"
+#include "query_optimizer/expressions/ExpressionUtil.hpp"
+#include "query_optimizer/expressions/Predicate.hpp"
+#include "query_optimizer/logical/Logical.hpp"
+#include "query_optimizer/rules/Rule.hpp"
+#include "query_optimizer/rules/BottomUpRule.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace optimizer {
+
+class OptimizerContext;
+
+namespace expressions {
+
+class Exists;
+
+}
+
+struct CorrelatedQueryInfo;
+
+/**
+ * @brief Rule that removes subquery expressions including IN with a subquery,
+ *        Exists and scalar subquery expressions.
+ */
+class UnnestSubqueries : public Rule<logical::Logical> {
+ public:
+  explicit UnnestSubqueries(OptimizerContext *context)
+      : context_(context) {}
+
+  std::string getName() const override { return "UnnestSubqueries"; }
+
+  logical::LogicalPtr apply(const logical::LogicalPtr &input) override;
+
+ private:
+  OptimizerContext *context_;
+
+  DISALLOW_COPY_AND_ASSIGN(UnnestSubqueries);
+};
+
+class UnnestSubqueriesForNonRootLogical : public Rule<logical::Logical> {
+ public:
+  UnnestSubqueriesForNonRootLogical(
+      bool scalar_query,
+      const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query,
+      OptimizerContext *context,
+      std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries,
+      std::vector<expressions::AttributeReferencePtr> *probe_join_attributes,
+      std::vector<expressions::AttributeReferencePtr> *build_join_attributes,
+      std::vector<expressions::PredicatePtr> *correlated_non_hash_join_predicates)
+      : scalar_query_(scalar_query),
+        context_(context),
+        visiable_attrs_from_outer_query_(visiable_attrs_from_outer_query),
+        uncorrelated_subqueries_(uncorrelated_subqueries),
+        probe_join_attributes_(probe_join_attributes),
+        build_join_attributes_(build_join_attributes),
+        correlated_non_hash_join_predicates_(correlated_non_hash_join_predicates) {}
+
+  std::string getName() const override { return "UnnestScalarSubuqeryForLogical"; }
+
+  logical::LogicalPtr apply(const logical::LogicalPtr &input) override {
+    expressions::UnorderedAttributeSet inner_attributes;
+    std::vector<expressions::AttributeReferencePtr> probe_join_attributes;
+    std::vector<expressions::AttributeReferencePtr> build_join_attributes;
+    std::vector<expressions::PredicatePtr> non_hash_join_predicates;
+
+    const logical::LogicalPtr output =
+        applyInternal(input,
+                      &inner_attributes,
+                      &probe_join_attributes,
+                      &build_join_attributes,
+                      &non_hash_join_predicates);
+
+    probe_join_attributes_->insert(probe_join_attributes_->end(),
+                                   probe_join_attributes.begin(),
+                                   probe_join_attributes.end());
+    build_join_attributes_->insert(build_join_attributes_->end(),
+                                   build_join_attributes.begin(),
+                                   build_join_attributes.end());
+    correlated_non_hash_join_predicates_->insert(correlated_non_hash_join_predicates_->end(),
+                                                 non_hash_join_predicates.begin(),
+                                                 non_hash_join_predicates.end());
+
+    return output;
+  }
+
+ private:
+  logical::LogicalPtr applyInternal(const logical::LogicalPtr &input,
+                                    expressions::UnorderedAttributeSet *inner_attributes,
+                                    std::vector<expressions::AttributeReferencePtr> *probe_join_attributes,
+                                    std::vector<expressions::AttributeReferencePtr> *build_join_attributes,
+                                    std::vector<expressions::PredicatePtr> *non_hash_join_predicates);
+
+  logical::LogicalPtr applyToNode(
+      const logical::LogicalPtr &input,
+      expressions::UnorderedAttributeSet *inner_attributes,
+      std::vector<expressions::AttributeReferencePtr> *probe_join_attributes,
+      std::vector<expressions::AttributeReferencePtr> *build_join_attributes,
+      std::vector<expressions::PredicatePtr> *non_hash_join_predicates);
+
+  // For each input expression, call UnnestSubqueriesForExpession to
+  // eliminate any subquery expressions in it and add a join if necessary.
+  logical::LogicalPtr eliminateNestedScalarQueries(const logical::LogicalPtr &node);
+
+  // Eliminate outer attribute references in this node, add predicates with
+  // outer attribute references into join attributes or non_hash_join_predicates.
+  expressions::ExpressionPtr eliminateOuterAttributeReference(
+      const expressions::ExpressionPtr &expression,
+      expressions::UnorderedAttributeSet *inner_attributes,
+      std::vector<expressions::AttributeReferencePtr> *probe_join_attributes,
+      std::vector<expressions::AttributeReferencePtr> *build_join_attributes,
+      std::vector<expressions::PredicatePtr>* non_hash_join_predicates);
+
+  void validateNonOuterAttributeReference(const expressions::ExpressionPtr &expression);
+
+  bool isCorrelatedOuterAttribute(const expressions::AttributeReferencePtr &attribute) const;
+
+  bool scalar_query_;
+  OptimizerContext *context_;
+  const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query_;
+  std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries_;
+  std::vector<expressions::AttributeReferencePtr> *probe_join_attributes_;
+  std::vector<expressions::AttributeReferencePtr> *build_join_attributes_;
+  std::vector<expressions::PredicatePtr> *correlated_non_hash_join_predicates_;
+
+  DISALLOW_COPY_AND_ASSIGN(UnnestSubqueriesForNonRootLogical);
+};
+
+class UnnestSubqueriesForExpession : public Rule<expressions::Expression> {
+ public:
+  UnnestSubqueriesForExpession(
+      const expressions::UnorderedNamedExpressionSet &visible_attributes_from_outer_query,
+      OptimizerContext *context,
+      std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries,
+      std::vector<CorrelatedQueryInfo> *correlated_query_info_vec)
+      : visible_attributes_from_outer_query_(visible_attributes_from_outer_query),
+        context_(context),
+        uncorrelated_subqueries_(uncorrelated_subqueries),
+        correlated_query_info_vec_(correlated_query_info_vec) {}
+
+  std::string getName() const override { return "UnnestScalarSubqueryForExpession"; }
+
+  expressions::ExpressionPtr apply(const expressions::ExpressionPtr &node) override {
+    return applyInternal(true /* allow_exists_or_in */,
+                         node);
+  }
+
+ private:
+  const expressions::UnorderedNamedExpressionSet &visible_attributes_from_outer_query_;
+
+  expressions::ExpressionPtr applyInternal(
+      bool allow_exists_or_in,
+      const expressions::ExpressionPtr &node);
+
+  void transformExists(const expressions::Exists *exists_predicate);
+
+  OptimizerContext *context_;
+  std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries_;
+  std::vector<CorrelatedQueryInfo> *correlated_query_info_vec_;
+
+  DISALLOW_COPY_AND_ASSIGN(UnnestSubqueriesForExpession);
+};
+
+class DeOuterAttributeReference : public BottomUpRule<expressions::Expression> {
+ public:
+  DeOuterAttributeReference(
+      bool allow_outer_reference,
+      const std::unordered_map<expressions::ExprId, logical::LogicalPtr> &uncorrelated_subqueries,
+      const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query)
+      : allow_outer_reference_(allow_outer_reference),
+        uncorrelated_subqueries_(uncorrelated_subqueries),
+        visiable_attrs_from_outer_query_(visiable_attrs_from_outer_query) {}
+
+  std::string getName() const override {
+    return "DeOuterAttributeReference";
+  }
+
+ protected:
+  expressions::ExpressionPtr applyToNode(const expressions::ExpressionPtr &input) override;
+
+ private:
+  const bool allow_outer_reference_;
+  const std::unordered_map<expressions::ExprId, logical::LogicalPtr> &uncorrelated_subqueries_;
+  const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query_;
+
+  DISALLOW_COPY_AND_ASSIGN(DeOuterAttributeReference);
+};
+
+}  // namespace optimizer
+}  // namespace quickstep
+
+#endif /* QUICKSTEP_QUERY_OPTIMIZER_RULES_UNNEST_SUBQUERIES_HPP_ */

--- a/query_optimizer/rules/UnnestSubqueries.hpp
+++ b/query_optimizer/rules/UnnestSubqueries.hpp
@@ -68,7 +68,7 @@ class UnnestSubqueries : public Rule<logical::Logical> {
 class UnnestSubqueriesForNonRootLogical : public Rule<logical::Logical> {
  public:
   UnnestSubqueriesForNonRootLogical(
-      bool scalar_query,
+      const bool scalar_query,
       const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query,
       OptimizerContext *context,
       std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries,
@@ -136,13 +136,13 @@ class UnnestSubqueriesForNonRootLogical : public Rule<logical::Logical> {
       expressions::UnorderedAttributeSet *inner_attributes,
       std::vector<expressions::AttributeReferencePtr> *probe_join_attributes,
       std::vector<expressions::AttributeReferencePtr> *build_join_attributes,
-      std::vector<expressions::PredicatePtr>* non_hash_join_predicates);
+      std::vector<expressions::PredicatePtr> *non_hash_join_predicates);
 
   void validateNonOuterAttributeReference(const expressions::ExpressionPtr &expression);
 
   bool isCorrelatedOuterAttribute(const expressions::AttributeReferencePtr &attribute) const;
 
-  bool scalar_query_;
+  const bool scalar_query_;
   OptimizerContext *context_;
   const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query_;
   std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries_;
@@ -176,10 +176,10 @@ class UnnestSubqueriesForExpession : public Rule<expressions::Expression> {
   const expressions::UnorderedNamedExpressionSet &visible_attributes_from_outer_query_;
 
   expressions::ExpressionPtr applyInternal(
-      bool allow_exists_or_in,
+      const bool allow_exists_or_in,
       const expressions::ExpressionPtr &node);
 
-  void transformExists(const expressions::Exists *exists_predicate);
+  void transformExists(const expressions::Exists &exists_predicate);
 
   OptimizerContext *context_;
   std::unordered_map<expressions::ExprId, logical::LogicalPtr> *uncorrelated_subqueries_;
@@ -191,7 +191,7 @@ class UnnestSubqueriesForExpession : public Rule<expressions::Expression> {
 class DeOuterAttributeReference : public BottomUpRule<expressions::Expression> {
  public:
   DeOuterAttributeReference(
-      bool allow_outer_reference,
+      const bool allow_outer_reference,
       const std::unordered_map<expressions::ExprId, logical::LogicalPtr> &uncorrelated_subqueries,
       const expressions::UnorderedNamedExpressionSet &visiable_attrs_from_outer_query)
       : allow_outer_reference_(allow_outer_reference),

--- a/query_optimizer/rules/tests/GenerateJoins_unittest.cpp
+++ b/query_optimizer/rules/tests/GenerateJoins_unittest.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,6 +19,8 @@
 
 #include "query_optimizer/rules/GenerateJoins.hpp"
 
+#include <cstddef>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -30,16 +34,16 @@
 #include "query_optimizer/logical/MultiwayCartesianJoin.hpp"
 #include "query_optimizer/logical/NestedLoopsJoin.hpp"
 #include "query_optimizer/logical/TableReference.hpp"
+#include "query_optimizer/rules/Rule.hpp"
 #include "query_optimizer/rules/tests/LogicalRuleTest.hpp"
 #include "query_optimizer/rules/tests/RuleTest.hpp"
-#include "types/operations/binary_operations/BinaryOperation.hpp"
 #include "types/operations/binary_operations/BinaryOperationFactory.hpp"
 #include "types/operations/binary_operations/BinaryOperationID.hpp"
-#include "types/operations/comparisons/Comparison.hpp"
 #include "types/operations/comparisons/ComparisonFactory.hpp"
 #include "types/operations/comparisons/ComparisonID.hpp"
 #include "utility/Macros.hpp"
 
+#include "glog/logging.h"
 #include "gtest/gtest.h"
 
 namespace quickstep {
@@ -102,12 +106,16 @@ class JoinGeneratorTest : public LogicalRuleTest {
         join_operands[0],
         join_operands[1],
         {join_attribute_pairs[0].first},
-        {join_attribute_pairs[0].second});
+        {join_attribute_pairs[0].second},
+        nullptr /* residual_predicate */,
+        L::HashJoin::kInnerJoin);
     for (size_t i = 2; i < join_operands.size(); ++i) {
       hash_join = L::HashJoin::Create(hash_join,
                                       join_operands[i],
                                       {join_attribute_pairs[i - 1].first},
-                                      {join_attribute_pairs[i - 1].second});
+                                      {join_attribute_pairs[i - 1].second},
+                                      nullptr /* residual_predicate */,
+                                      L::HashJoin::kInnerJoin);
     }
     return hash_join;
   }
@@ -216,7 +224,9 @@ TEST_F(JoinGeneratorTest, MultiAttributesHashJoin) {
                                             {relation_attribute_reference_0_0_,
                                              relation_attribute_reference_0_1_},
                                             {relation_attribute_reference_1_0_,
-                                             relation_attribute_reference_1_1_}),
+                                             relation_attribute_reference_1_1_},
+                                            nullptr /* residual_predicate */,
+                                            L::HashJoin::kInnerJoin),
                         single_table_predicate);
   APPLY_RULE_AND_CHECK_OUTPUT();
 }

--- a/query_optimizer/rules/tests/GenerateJoins_unittest.cpp
+++ b/query_optimizer/rules/tests/GenerateJoins_unittest.cpp
@@ -108,14 +108,14 @@ class JoinGeneratorTest : public LogicalRuleTest {
         {join_attribute_pairs[0].first},
         {join_attribute_pairs[0].second},
         nullptr /* residual_predicate */,
-        L::HashJoin::kInnerJoin);
+        L::HashJoin::JoinType::kInnerJoin);
     for (size_t i = 2; i < join_operands.size(); ++i) {
       hash_join = L::HashJoin::Create(hash_join,
                                       join_operands[i],
                                       {join_attribute_pairs[i - 1].first},
                                       {join_attribute_pairs[i - 1].second},
                                       nullptr /* residual_predicate */,
-                                      L::HashJoin::kInnerJoin);
+                                      L::HashJoin::JoinType::kInnerJoin);
     }
     return hash_join;
   }
@@ -226,7 +226,7 @@ TEST_F(JoinGeneratorTest, MultiAttributesHashJoin) {
                                             {relation_attribute_reference_1_0_,
                                              relation_attribute_reference_1_1_},
                                             nullptr /* residual_predicate */,
-                                            L::HashJoin::kInnerJoin),
+                                            L::HashJoin::JoinType::kInnerJoin),
                         single_table_predicate);
   APPLY_RULE_AND_CHECK_OUTPUT();
 }

--- a/query_optimizer/rules/tests/PruneColumns_unittest.cpp
+++ b/query_optimizer/rules/tests/PruneColumns_unittest.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -20,7 +22,6 @@
 #include <memory>
 #include <vector>
 
-#include "query_optimizer/expressions/Alias.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
@@ -36,6 +37,9 @@
 #include "query_optimizer/rules/tests/RuleTest.hpp"
 #include "utility/Cast.hpp"
 #include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
 
 namespace quickstep {
 namespace optimizer {
@@ -91,7 +95,8 @@ TEST_F(PruneColumnTest, PrimaryTest) {
                                                        {relation_attribute_reference_0_0_},
                                                        {relation_attribute_reference_1_0_},
                                                        E::PredicatePtr(),
-                                                       project_expressions_with_redundancy);
+                                                       project_expressions_with_redundancy,
+                                                       P::HashJoin::kInnerJoin);
 
   // alias_add_literal_0_: relation_attribute_reference_0_0_ + literal_0_.
   // filter_predicate_1_: relation_attribute_reference_1_0_ > literal_0_.
@@ -118,7 +123,8 @@ TEST_F(PruneColumnTest, PrimaryTest) {
       {relation_attribute_reference_0_0_},
       {relation_attribute_reference_1_0_},
       E::PredicatePtr(),
-      pruned_project_expressions_for_join);
+      pruned_project_expressions_for_join,
+      P::HashJoin::kInnerJoin);
   const P::SelectionPtr new_selection = std::static_pointer_cast<const P::Selection>(
       selection->copyWithNewChildren({new_hash_join} /* new_children */));
   expect_output_ = P::TopLevelPlan::Create(new_selection);

--- a/query_optimizer/rules/tests/PruneColumns_unittest.cpp
+++ b/query_optimizer/rules/tests/PruneColumns_unittest.cpp
@@ -96,7 +96,7 @@ TEST_F(PruneColumnTest, PrimaryTest) {
                                                        {relation_attribute_reference_1_0_},
                                                        E::PredicatePtr(),
                                                        project_expressions_with_redundancy,
-                                                       P::HashJoin::kInnerJoin);
+                                                       P::HashJoin::JoinType::kInnerJoin);
 
   // alias_add_literal_0_: relation_attribute_reference_0_0_ + literal_0_.
   // filter_predicate_1_: relation_attribute_reference_1_0_ > literal_0_.
@@ -124,7 +124,7 @@ TEST_F(PruneColumnTest, PrimaryTest) {
       {relation_attribute_reference_1_0_},
       E::PredicatePtr(),
       pruned_project_expressions_for_join,
-      P::HashJoin::kInnerJoin);
+      P::HashJoin::JoinType::kInnerJoin);
   const P::SelectionPtr new_selection = std::static_pointer_cast<const P::Selection>(
       selection->copyWithNewChildren({new_hash_join} /* new_children */));
   expect_output_ = P::TopLevelPlan::Create(new_selection);

--- a/query_optimizer/strategy/CMakeLists.txt
+++ b/query_optimizer/strategy/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -43,8 +45,6 @@ target_link_libraries(quickstep_queryoptimizer_strategy_Aggregate
 target_link_libraries(quickstep_queryoptimizer_strategy_Join
                       glog
                       quickstep_queryoptimizer_LogicalToPhysicalMapper
-                      quickstep_queryoptimizer_OptimizerContext
-                      quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ComparisonExpression
                       quickstep_queryoptimizer_expressions_Expression
@@ -80,7 +80,6 @@ target_link_libraries(quickstep_queryoptimizer_strategy_OneToOne
                       quickstep_queryoptimizer_logical_DropTable
                       quickstep_queryoptimizer_logical_InsertSelection
                       quickstep_queryoptimizer_logical_InsertTuple
-                      quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_queryoptimizer_logical_Sample

--- a/query_optimizer/strategy/Join.cpp
+++ b/query_optimizer/strategy/Join.cpp
@@ -89,7 +89,7 @@ bool Join::generatePlan(const L::LogicalPtr &logical_input,
       L::SomeFilter::MatchesWithConditionalCast(logical_project->input(), &logical_filter)) {
     if (L::SomeHashJoin::MatchesWithConditionalCast(logical_filter->input(),
                                                     &logical_hash_join)) {
-      if (logical_hash_join->join_type() == L::HashJoin::kInnerJoin) {
+      if (logical_hash_join->join_type() == L::HashJoin::JoinType::kInnerJoin) {
         addHashJoin(logical_project,
                     logical_filter,
                     logical_hash_join,
@@ -115,7 +115,7 @@ bool Join::generatePlan(const L::LogicalPtr &logical_input,
   if (L::SomeFilter::MatchesWithConditionalCast(logical_input, &logical_filter)) {
     if (L::SomeHashJoin::MatchesWithConditionalCast(logical_filter->input(),
                                                     &logical_hash_join)) {
-      if (logical_hash_join->join_type() == L::HashJoin::kInnerJoin) {
+      if (logical_hash_join->join_type() == L::HashJoin::JoinType::kInnerJoin) {
         addHashJoin(nullptr /* logical_project */,
                     logical_filter,
                     logical_hash_join,
@@ -305,14 +305,14 @@ void Join::addHashJoin(const logical::ProjectPtr &logical_project,
 
   P::HashJoin::JoinType join_type;
   switch (logical_hash_join->join_type()) {
-    case L::HashJoin::kInnerJoin:
-      join_type = P::HashJoin::kInnerJoin;
+    case L::HashJoin::JoinType::kInnerJoin:
+      join_type = P::HashJoin::JoinType::kInnerJoin;
       break;
-    case L::HashJoin::kLeftSemiJoin:
-      join_type = P::HashJoin::kLeftSemiJoin;
+    case L::HashJoin::JoinType::kLeftSemiJoin:
+      join_type = P::HashJoin::JoinType::kLeftSemiJoin;
       break;
-    case L::HashJoin::kLeftAntiJoin:
-      join_type = P::HashJoin::kLeftAntiJoin;
+    case L::HashJoin::JoinType::kLeftAntiJoin:
+      join_type = P::HashJoin::JoinType::kLeftAntiJoin;
       break;
     default:
       LOG(FATAL) << "Invalid logical::HashJoin::JoinType: "

--- a/query_optimizer/strategy/Join.cpp
+++ b/query_optimizer/strategy/Join.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,11 +19,10 @@
 
 #include "query_optimizer/strategy/Join.hpp"
 
+#include <type_traits>
 #include <vector>
 
 #include "query_optimizer/LogicalToPhysicalMapper.hpp"
-#include "query_optimizer/OptimizerContext.hpp"
-#include "query_optimizer/expressions/Alias.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/ComparisonExpression.hpp"
 #include "query_optimizer/expressions/Expression.hpp"
@@ -66,7 +67,7 @@ bool Join::generatePlan(const L::LogicalPtr &logical_input,
     if (L::SomeHashJoin::MatchesWithConditionalCast(logical_project->input(),
                                                     &logical_hash_join)) {
       addHashJoin(logical_project,
-                  logical_filter,
+                  nullptr /* logical_filter */,
                   logical_hash_join,
                   physical_output);
       return true;
@@ -83,15 +84,18 @@ bool Join::generatePlan(const L::LogicalPtr &logical_input,
   }
 
   // Collapse project-filter-join.
+  // Note that Filter cannot be pushed into the semi-join, anti-join or outer-join.
   if (logical_project != nullptr &&
       L::SomeFilter::MatchesWithConditionalCast(logical_project->input(), &logical_filter)) {
     if (L::SomeHashJoin::MatchesWithConditionalCast(logical_filter->input(),
                                                     &logical_hash_join)) {
-      addHashJoin(logical_project,
-                  logical_filter,
-                  logical_hash_join,
-                  physical_output);
-      return true;
+      if (logical_hash_join->join_type() == L::HashJoin::kInnerJoin) {
+        addHashJoin(logical_project,
+                    logical_filter,
+                    logical_hash_join,
+                    physical_output);
+        return true;
+      }
     }
 
     if (L::SomeNestedLoopsJoin::MatchesWithConditionalCast(logical_filter->input(),
@@ -107,14 +111,17 @@ bool Join::generatePlan(const L::LogicalPtr &logical_input,
   }
 
   // Collapse filter-join.
+  // Note that Filter cannot be pushed into the semi-join, anti-join or outer-join.
   if (L::SomeFilter::MatchesWithConditionalCast(logical_input, &logical_filter)) {
     if (L::SomeHashJoin::MatchesWithConditionalCast(logical_filter->input(),
                                                     &logical_hash_join)) {
-      addHashJoin(logical_project,
-                  logical_filter,
-                  logical_hash_join,
-                  physical_output);
-      return true;
+      if (logical_hash_join->join_type() == L::HashJoin::kInnerJoin) {
+        addHashJoin(nullptr /* logical_project */,
+                    logical_filter,
+                    logical_hash_join,
+                    physical_output);
+        return true;
+      }
     }
 
     if (L::SomeNestedLoopsJoin::MatchesWithConditionalCast(logical_filter->input(),
@@ -132,8 +139,8 @@ bool Join::generatePlan(const L::LogicalPtr &logical_input,
 
   // Convert a single binary join.
   if (L::SomeHashJoin::MatchesWithConditionalCast(logical_input, &logical_hash_join)) {
-    addHashJoin(logical_project,
-                logical_filter,
+    addHashJoin(nullptr /* logical_project */,
+                nullptr /* logical_filter */,
                 logical_hash_join,
                 physical_output);
     return true;
@@ -169,6 +176,11 @@ void Join::addHashJoin(const logical::ProjectPtr &logical_project,
   std::vector<E::AttributeReferencePtr> left_join_attributes = logical_hash_join->left_join_attributes();
   std::vector<E::AttributeReferencePtr> right_join_attributes = logical_hash_join->right_join_attributes();
   std::vector<E::ExpressionPtr> non_hash_join_predicates;
+
+  if (logical_hash_join->residual_predicate() != nullptr) {
+    non_hash_join_predicates.emplace_back(logical_hash_join->residual_predicate());
+  }
+
   if (logical_filter != nullptr) {
     std::vector<E::PredicatePtr> filter_predicates;
     const std::vector<E::AttributeReferencePtr> left_input_attributes =
@@ -291,13 +303,31 @@ void Join::addHashJoin(const logical::ProjectPtr &logical_project,
     residual_predicate = E::LogicalAnd::Create(CastSharedPtrVector<E::Predicate>(non_hash_join_predicates));
   }
 
+  P::HashJoin::JoinType join_type;
+  switch (logical_hash_join->join_type()) {
+    case L::HashJoin::kInnerJoin:
+      join_type = P::HashJoin::kInnerJoin;
+      break;
+    case L::HashJoin::kLeftSemiJoin:
+      join_type = P::HashJoin::kLeftSemiJoin;
+      break;
+    case L::HashJoin::kLeftAntiJoin:
+      join_type = P::HashJoin::kLeftAntiJoin;
+      break;
+    default:
+      LOG(FATAL) << "Invalid logical::HashJoin::JoinType: "
+                 << static_cast<typename std::underlying_type<L::HashJoin::JoinType>::type>(
+                        logical_hash_join->join_type());
+  }
+
   *physical_output =
       P::HashJoin::Create(left,
                           right,
                           left_join_attributes,
                           right_join_attributes,
                           residual_predicate,
-                          project_expressions);
+                          project_expressions,
+                          join_type);
 }
 
 void Join::addNestedLoopsJoin(const L::NestedLoopsJoinPtr &logical_nested_loops_join,

--- a/query_optimizer/strategy/Join.hpp
+++ b/query_optimizer/strategy/Join.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,7 +24,6 @@
 #include <vector>
 
 #include "query_optimizer/expressions/NamedExpression.hpp"
-#include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
 #include "query_optimizer/logical/Filter.hpp"
 #include "query_optimizer/logical/HashJoin.hpp"
@@ -70,7 +71,6 @@ class Join : public Strategy {
    * @param logical_project The project to be folded into the hash join.
    * @param logical_filter The filter to be folded into the hash join.
    * @param logical_hash_join The hash join to be transformed.
-   * @param project_expressions The project expressions for the join.
    * @param physical_output The output physical plan.
    */
   void addHashJoin(const logical::ProjectPtr &logical_project,

--- a/query_optimizer/strategy/tests/Join_unittest.cpp
+++ b/query_optimizer/strategy/tests/Join_unittest.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,7 +29,6 @@
 #include "query_optimizer/expressions/ExpressionUtil.hpp"
 #include "query_optimizer/expressions/LogicalAnd.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
-#include "query_optimizer/expressions/Scalar.hpp"
 #include "query_optimizer/logical/Filter.hpp"
 #include "query_optimizer/logical/HashJoin.hpp"
 #include "query_optimizer/logical/Logical.hpp"
@@ -38,15 +39,9 @@
 #include "query_optimizer/physical/NestedLoopsJoin.hpp"
 #include "query_optimizer/physical/Physical.hpp"
 #include "query_optimizer/physical/Selection.hpp"
-#include "query_optimizer/physical/TableReference.hpp"
 #include "query_optimizer/strategy/tests/StrategyTest.hpp"
-#include "types/operations/binary_operations/BinaryOperation.hpp"
-#include "types/operations/binary_operations/BinaryOperationFactory.hpp"
-#include "types/operations/binary_operations/BinaryOperationID.hpp"
-#include "types/operations/comparisons/Comparison.hpp"
 #include "types/operations/comparisons/ComparisonFactory.hpp"
 #include "types/operations/comparisons/ComparisonID.hpp"
-#include "utility/Cast.hpp"
 #include "utility/Macros.hpp"
 
 #include "glog/logging.h"
@@ -77,7 +72,10 @@ class JoinTest : public StrategyTest {
         logical_table_reference_0_,
         logical_table_reference_1_,
         {relation_attribute_reference_0_0_},
-        {relation_attribute_reference_1_0_});
+        {relation_attribute_reference_1_0_},
+        nullptr /* residual_predicate */,
+        L::HashJoin::kInnerJoin);
+
 
     std::vector<E::NamedExpressionPtr> project_expressions(
         E::ToNamedExpressions(logical_table_reference_0_->getOutputAttributes()));
@@ -98,7 +96,8 @@ class JoinTest : public StrategyTest {
                             {relation_attribute_reference_0_0_},
                             {relation_attribute_reference_1_0_},
                             E::PredicatePtr(),
-                            project_expressions);
+                            project_expressions,
+                            P::HashJoin::kInnerJoin);
   }
 
   void setupStrategy(std::unique_ptr<Strategy> *strategy) override {
@@ -143,7 +142,8 @@ TEST_F(JoinTest, ProjectOnJoin) {
       {relation_attribute_reference_0_0_},
       {relation_attribute_reference_1_0_},
       E::PredicatePtr(),
-      logical_project_0_->project_expressions());
+      logical_project_0_->project_expressions(),
+      P::HashJoin::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 
@@ -183,7 +183,8 @@ TEST_F(JoinTest, ProjectOnFilterOnHashJoin) {
       {relation_attribute_reference_1_0_,
        relation_attribute_reference_1_1_},
       filter_predicate_0_,
-      logical_project_1_->project_expressions());
+      logical_project_1_->project_expressions(),
+      P::HashJoin::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 
@@ -211,7 +212,8 @@ TEST_F(JoinTest, FilterOnHashJoin) {
       {relation_attribute_reference_0_0_},
       {relation_attribute_reference_1_0_},
       filter_predicate_0_,
-      physical_nested_loops_join_->project_expressions());
+      physical_nested_loops_join_->project_expressions(),
+      P::HashJoin::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 
@@ -222,7 +224,9 @@ TEST_F(JoinTest, HashJoinOnSelection) {
       L::HashJoin::Create(logical_project_0_,
                           logical_project_on_filter_1_,
                           {relation_attribute_reference_0_0_},
-                          {relation_attribute_reference_1_0_});
+                          {relation_attribute_reference_1_0_},
+                          nullptr /* residual_predicate */,
+                          L::HashJoin::kInnerJoin);
   // References an attribute created by the left underlying project of the hash
   // join.
   const E::AliasPtr alias_on_alias_reference = E::Alias::Create(
@@ -244,7 +248,8 @@ TEST_F(JoinTest, HashJoinOnSelection) {
       {relation_attribute_reference_0_0_},
       {relation_attribute_reference_1_0_},
       E::PredicatePtr(),
-      {alias_on_alias_reference_after_pullup} /* project_expressions */);
+      {alias_on_alias_reference_after_pullup} /* project_expressions */,
+      P::HashJoin::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 
   // HashJoin -- Project
@@ -269,7 +274,9 @@ TEST_F(JoinTest, HashJoinOnSelection) {
   input_logical_ = L::HashJoin::Create(logical_project_0_,
                                        logical_project_on_attribute_reference,
                                        {E::ToRef(alias_add_literal_0_)},
-                                       {relation_attribute_reference_1_0_});
+                                       {relation_attribute_reference_1_0_},
+                                       nullptr /* residual_predicate */,
+                                       L::HashJoin::kInnerJoin);
   std::vector<E::NamedExpressionPtr> project_expressions(
       E::ToNamedExpressions(physical_project_0_->getOutputAttributes()));
   project_expressions.push_back(alias_on_attribute_reference);
@@ -279,7 +286,8 @@ TEST_F(JoinTest, HashJoinOnSelection) {
                           {E::ToRef(alias_add_literal_0_)},
                           {relation_attribute_reference_1_0_},
                           E::PredicatePtr(),
-                          project_expressions);
+                          project_expressions,
+                          P::HashJoin::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 

--- a/query_optimizer/strategy/tests/Join_unittest.cpp
+++ b/query_optimizer/strategy/tests/Join_unittest.cpp
@@ -74,7 +74,7 @@ class JoinTest : public StrategyTest {
         {relation_attribute_reference_0_0_},
         {relation_attribute_reference_1_0_},
         nullptr /* residual_predicate */,
-        L::HashJoin::kInnerJoin);
+        L::HashJoin::JoinType::kInnerJoin);
 
 
     std::vector<E::NamedExpressionPtr> project_expressions(
@@ -97,7 +97,7 @@ class JoinTest : public StrategyTest {
                             {relation_attribute_reference_1_0_},
                             E::PredicatePtr(),
                             project_expressions,
-                            P::HashJoin::kInnerJoin);
+                            P::HashJoin::JoinType::kInnerJoin);
   }
 
   void setupStrategy(std::unique_ptr<Strategy> *strategy) override {
@@ -143,7 +143,7 @@ TEST_F(JoinTest, ProjectOnJoin) {
       {relation_attribute_reference_1_0_},
       E::PredicatePtr(),
       logical_project_0_->project_expressions(),
-      P::HashJoin::kInnerJoin);
+      P::HashJoin::JoinType::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 
@@ -184,7 +184,7 @@ TEST_F(JoinTest, ProjectOnFilterOnHashJoin) {
        relation_attribute_reference_1_1_},
       filter_predicate_0_,
       logical_project_1_->project_expressions(),
-      P::HashJoin::kInnerJoin);
+      P::HashJoin::JoinType::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 
@@ -213,7 +213,7 @@ TEST_F(JoinTest, FilterOnHashJoin) {
       {relation_attribute_reference_1_0_},
       filter_predicate_0_,
       physical_nested_loops_join_->project_expressions(),
-      P::HashJoin::kInnerJoin);
+      P::HashJoin::JoinType::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 
@@ -226,7 +226,7 @@ TEST_F(JoinTest, HashJoinOnSelection) {
                           {relation_attribute_reference_0_0_},
                           {relation_attribute_reference_1_0_},
                           nullptr /* residual_predicate */,
-                          L::HashJoin::kInnerJoin);
+                          L::HashJoin::JoinType::kInnerJoin);
   // References an attribute created by the left underlying project of the hash
   // join.
   const E::AliasPtr alias_on_alias_reference = E::Alias::Create(
@@ -249,7 +249,7 @@ TEST_F(JoinTest, HashJoinOnSelection) {
       {relation_attribute_reference_1_0_},
       E::PredicatePtr(),
       {alias_on_alias_reference_after_pullup} /* project_expressions */,
-      P::HashJoin::kInnerJoin);
+      P::HashJoin::JoinType::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 
   // HashJoin -- Project
@@ -276,7 +276,7 @@ TEST_F(JoinTest, HashJoinOnSelection) {
                                        {E::ToRef(alias_add_literal_0_)},
                                        {relation_attribute_reference_1_0_},
                                        nullptr /* residual_predicate */,
-                                       L::HashJoin::kInnerJoin);
+                                       L::HashJoin::JoinType::kInnerJoin);
   std::vector<E::NamedExpressionPtr> project_expressions(
       E::ToNamedExpressions(physical_project_0_->getOutputAttributes()));
   project_expressions.push_back(alias_on_attribute_reference);
@@ -287,7 +287,7 @@ TEST_F(JoinTest, HashJoinOnSelection) {
                           {relation_attribute_reference_1_0_},
                           E::PredicatePtr(),
                           project_expressions,
-                          P::HashJoin::kInnerJoin);
+                          P::HashJoin::JoinType::kInnerJoin);
   EXPECT_CORRECT_PHYSICAL();
 }
 

--- a/query_optimizer/tests/logical_generator/Select.test
+++ b/query_optimizer/tests/logical_generator/Select.test
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -653,3 +655,68 @@ TopLevelPlan
   | type=Long]
   +-AttributeReference[id=7,name=,alias=SUM(float_col),relation=,
     type=Double NULL]
+==
+
+SELECT i
+FROM generate_series(0, 100, 3) AS gs1(i)
+WHERE
+  EXISTS (
+    SELECT *
+    FROM generate_series(0, 100, 5) AS gs2(i)
+    WHERE gs1.i = gs2.i
+  )
+  AND NOT EXISTS (
+    SELECT *
+    FROM generate_series(0, 100, 10) AS gs3(i)
+    WHERE gs1.i = gs3.i
+  )
+  AND (i < 40 OR i > 60);
+--
+TopLevelPlan
++-plan=Project
+| +-input=HashLeftSemiJoin
+| | +-left=HashLeftAntiJoin
+| | | +-left=Filter
+| | | | +-input=Project
+| | | | | +-input=TableGenerator[function_name=generate_series,table_alias=gs1]
+| | | | | | +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | | | |   relation=generate_series,type=Int]
+| | | | | +-project_list=
+| | | | |   +-Alias[id=1,name=i,relation=,type=Int]
+| | | | |     +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | | |       relation=generate_series,type=Int]
+| | | | +-filter_predicate=Or
+| | | |   +-Less
+| | | |   | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | | |   | +-Literal[value=40,type=Int]
+| | | |   +-Greater
+| | | |     +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | | |     +-Literal[value=60,type=Int]
+| | | +-right=Project
+| | | | +-input=TableGenerator[function_name=generate_series,table_alias=gs3]
+| | | | | +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| | | | |   relation=generate_series,type=Int]
+| | | | +-project_list=
+| | | |   +-Alias[id=5,name=i,relation=,type=Int]
+| | | |     +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| | | |       relation=generate_series,type=Int]
+| | | +-left_join_attributes=
+| | | | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | | +-right_join_attributes=
+| | |   +-AttributeReference[id=5,name=i,relation=,type=Int]
+| | +-right=Project
+| | | +-input=TableGenerator[function_name=generate_series,table_alias=gs2]
+| | | | +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| | | |   relation=generate_series,type=Int]
+| | | +-project_list=
+| | |   +-Alias[id=3,name=i,relation=,type=Int]
+| | |     +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| | |       relation=generate_series,type=Int]
+| | +-left_join_attributes=
+| | | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | +-right_join_attributes=
+| |   +-AttributeReference[id=3,name=i,relation=,type=Int]
+| +-project_list=
+|   +-AttributeReference[id=1,name=i,relation=,type=Int]
++-output_attributes=
+  +-AttributeReference[id=1,name=i,relation=,type=Int]

--- a/query_optimizer/tests/physical_generator/Select.test
+++ b/query_optimizer/tests/physical_generator/Select.test
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -1691,3 +1693,112 @@ TopLevelPlan
   | type=Long]
   +-AttributeReference[id=7,name=,alias=SUM(float_col),relation=,
     type=Double NULL]
+==
+
+SELECT i
+FROM generate_series(0, 100, 3) AS gs1(i)
+WHERE
+  EXISTS (
+    SELECT *
+    FROM generate_series(0, 100, 5) AS gs2(i)
+    WHERE gs1.i = gs2.i
+  )
+  AND NOT EXISTS (
+    SELECT *
+    FROM generate_series(0, 100, 10) AS gs3(i)
+    WHERE gs1.i = gs3.i
+  )
+  AND (i < 40 OR i > 60);
+--
+[Optimized Logical Plan]
+TopLevelPlan
++-plan=Project
+| +-input=HashLeftSemiJoin
+| | +-left=HashLeftAntiJoin
+| | | +-left=Filter
+| | | | +-input=Project
+| | | | | +-input=TableGenerator[function_name=generate_series,table_alias=gs1]
+| | | | | | +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | | | |   relation=generate_series,type=Int]
+| | | | | +-project_list=
+| | | | |   +-Alias[id=1,name=i,relation=,type=Int]
+| | | | |     +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | | |       relation=generate_series,type=Int]
+| | | | +-filter_predicate=Or
+| | | |   +-Less
+| | | |   | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | | |   | +-Literal[value=40,type=Int]
+| | | |   +-Greater
+| | | |     +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | | |     +-Literal[value=60,type=Int]
+| | | +-right=Project
+| | | | +-input=TableGenerator[function_name=generate_series,table_alias=gs3]
+| | | | | +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| | | | |   relation=generate_series,type=Int]
+| | | | +-project_list=
+| | | |   +-Alias[id=5,name=i,relation=,type=Int]
+| | | |     +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| | | |       relation=generate_series,type=Int]
+| | | +-left_join_attributes=
+| | | | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | | +-right_join_attributes=
+| | |   +-AttributeReference[id=5,name=i,relation=,type=Int]
+| | +-right=Project
+| | | +-input=TableGenerator[function_name=generate_series,table_alias=gs2]
+| | | | +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| | | |   relation=generate_series,type=Int]
+| | | +-project_list=
+| | |   +-Alias[id=3,name=i,relation=,type=Int]
+| | |     +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| | |       relation=generate_series,type=Int]
+| | +-left_join_attributes=
+| | | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | +-right_join_attributes=
+| |   +-AttributeReference[id=3,name=i,relation=,type=Int]
+| +-project_list=
+|   +-AttributeReference[id=1,name=i,relation=,type=Int]
++-output_attributes=
+  +-AttributeReference[id=1,name=i,relation=,type=Int]
+[Physical Plan]
+TopLevelPlan
++-plan=HashLeftSemiJoin
+| +-left=HashLeftAntiJoin
+| | +-left=Selection
+| | | +-input=TableGenerator[function_name=generate_series,table_alias=gs1]
+| | | | +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | |   relation=generate_series,type=Int]
+| | | +-filter_predicate=Or
+| | | | +-Less
+| | | | | +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | | | | relation=generate_series,type=Int]
+| | | | | +-Literal[value=40,type=Int]
+| | | | +-Greater
+| | | |   +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | | |   | relation=generate_series,type=Int]
+| | | |   +-Literal[value=60,type=Int]
+| | | +-project_expressions=
+| | |   +-Alias[id=1,name=i,relation=,type=Int]
+| | |     +-AttributeReference[id=0,name=generate_series,alias=gs1,
+| | |       relation=generate_series,type=Int]
+| | +-right=TableGenerator[function_name=generate_series,table_alias=gs3]
+| | | +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| | |   relation=generate_series,type=Int]
+| | +-project_expressions=
+| | | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | +-left_join_attributes=
+| | | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| | +-right_join_attributes=
+| |   +-AttributeReference[id=4,name=generate_series,alias=gs3,
+| |     relation=generate_series,type=Int]
+| +-right=TableGenerator[function_name=generate_series,table_alias=gs2]
+| | +-AttributeReference[id=2,name=generate_series,alias=gs2,
+| |   relation=generate_series,type=Int]
+| +-project_expressions=
+| | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| +-left_join_attributes=
+| | +-AttributeReference[id=1,name=i,relation=,type=Int]
+| +-right_join_attributes=
+|   +-AttributeReference[id=2,name=generate_series,alias=gs2,
+|     relation=generate_series,type=Int]
++-output_attributes=
+  +-AttributeReference[id=1,name=i,relation=,type=Int]


### PR DESCRIPTION
This PR adds the optimizer support for `EXISTS` subqueries. An `EXISTS` subquery will be converted into _left semi_ hash join or _left anti_ hash join by the `UnnestSubqueries` logical transformation.