### PR TITLE
Set up CatalogDatabaseCache proto in optimizer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
-#   Copyright 2015 Pivotal Software, Inc.
+#   Copyright 2015-2016 Pivotal Software, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -136,6 +136,8 @@ if (ENABLE_VECTOR_PREDICATE_SHORT_CIRCUIT)
     APPEND PROPERTY COMPILE_DEFINITIONS QUICKSTEP_ENABLE_VECTOR_PREDICATE_SHORT_CIRCUIT
   )
 endif()
+
+option(ENABLE_DISTRIBUTED "Use the distributed version of Quickstep" OFF)
 
 # Turn on the QUICKSTEP_DEBUG flag in the source if this is a debug build.
 if (CMAKE_MAJOR_VERSION GREATER 2)

--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -15,6 +15,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+if (ENABLE_DISTRIBUTED)
+  set(QUICKSTEP_DISTRIBUTED TRUE)
+endif()
+
+configure_file (
+  "${CMAKE_CURRENT_SOURCE_DIR}/QueryOptimizerConfig.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/QueryOptimizerConfig.h"
+)
+
 add_subdirectory(cost_model)
 add_subdirectory(expressions)
 add_subdirectory(logical)
@@ -125,6 +134,10 @@ target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
                       quickstep_types_containers_Tuple_proto
                       quickstep_utility_Macros
                       quickstep_utility_SqlError)
+if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
+                        quickstep_catalog_Catalog_proto)
+endif()
 target_link_libraries(quickstep_queryoptimizer_LogicalGenerator
                       glog
                       quickstep_parser_ParseStatement
@@ -170,6 +183,7 @@ target_link_libraries(quickstep_queryoptimizer_PhysicalGenerator
                       quickstep_queryoptimizer_Validator
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_QueryHandle
+                      quickstep_catalog_Catalog_proto
                       quickstep_queryexecution_QueryContext_proto
                       quickstep_queryoptimizer_QueryPlan
                       quickstep_utility_Macros)

--- a/query_optimizer/QueryHandle.hpp
+++ b/query_optimizer/QueryHandle.hpp
@@ -1,5 +1,5 @@
 /**
- *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2015-2016 Pivotal Software, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <memory>
 #include <utility>
 
+#include "catalog/Catalog.pb.h"
 #include "query_execution/QueryContext.pb.h"
 #include "query_optimizer/QueryPlan.hpp"
 #include "utility/Macros.hpp"
@@ -41,7 +42,7 @@ class QueryHandle {
   /**
    * @brief Constructor.
    *
-   * @param The given query id.
+   * @param query_id The given query id.
    */
   explicit QueryHandle(const std::size_t query_id)
       : query_id_(query_id),
@@ -81,6 +82,20 @@ class QueryHandle {
   }
 
   /**
+    * @return The catalog database cache in the protobuf format.
+    */
+  const serialization::CatalogDatabase& getCatalogDatabaseCacheProto() const {
+    return catalog_database_cache_proto_;
+  }
+
+  /**
+   * @return The mutable catalog database cache in the protobuf format.
+   */
+  serialization::CatalogDatabase* getCatalogDatabaseCacheProtoMutable() {
+    return &catalog_database_cache_proto_;
+  }
+
+  /**
    * @brief Get the query result relation.
    */
   const CatalogRelation* getQueryResultRelation() const {
@@ -100,6 +115,9 @@ class QueryHandle {
   std::unique_ptr<QueryPlan> query_plan_;
 
   serialization::QueryContext query_context_proto_;
+
+  // TODO(quickstep-team): Use Catalog to support multiple databases.
+  serialization::CatalogDatabase catalog_database_cache_proto_;
 
   // NOTE(zuyu): The relation gets created by the optimizer,
   //             and deleted by the Cli shell.

--- a/query_optimizer/QueryOptimizerConfig.h.in
+++ b/query_optimizer/QueryOptimizerConfig.h.in
@@ -1,0 +1,17 @@
+/**
+ *   Copyright 2016 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#cmakedefine QUICKSTEP_DISTRIBUTED


### PR DESCRIPTION
This small PR set up the `CatalogDatabaseCache` proto in the optimizer.

Note that it does not affect the single-node version, as we use a macro to ensure that it is only used in the distributed version.