### PR TITLE
Reduced the Total CI time by Running the Most Time-consuming Build first.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,20 @@
 # speed up compilation in release build. Also, jobs can only use upto 20GB of
 # disk space. Hence, we minimize the amount of debug symbol using -g0 (DEBUG
 # builds were taking > 20GB of space with clang).
+# Also, to reduce the total CI time, we explicitly run the most time-consuming
+# build first, using gcc in debug build with joinwithbinaryexpressions.
 
 language: cpp
 
 compiler:
-  - clang
   - gcc
+  - clang
 
 env:
-  - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none
-  - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none
   - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
+  - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none
+  - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none
 
 install:
   - if [ "$VECTOR_COPY_ELISION_LEVEL" = "joinwithbinaryexpressions" ] && [ "$CC" = "gcc" ]; then


### PR DESCRIPTION
Since the most time-consuming build is on the critical path of the total CI time, the earlier the build finishes, the shorter the total time.

Total elapsed time after reordering is `1 hr 17 min` using the default `5` parallel jobs. On the other hand, a typical total CI time is between `1 hr 30 min` and `1 hr 50 min`, depending on the concurrent build loads.

Compiler | Env | Time
------------ | ----- | -------
gcc | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 1 hr 17 min
gcc | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 54 min 39 sec
gcc | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none | 19 min 7 sec
gcc | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none | 22 min 35 sec
clang | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 36 min 40 sec
clang | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 36 min 37 sec
clang | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none | 17 min 2 sec
clang | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none | 15 min 28 sec

The next step is, to optimize the build time for the most time-consuming job.