### PR TITLE
Used libgtest in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ addons:
       - binutils-gold
       - libprotobuf-dev
       - protobuf-compiler
+      - libgtest-dev
       - python-networkx
       - libnuma-dev
 


### PR DESCRIPTION
Using pre-built `gtest` further reduces the total CI build time to `52 min 9 sec`:

Compiler | Env | Time
------------ | ----- | -------
gcc | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 52 min 9 sec
gcc | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 26 min
gcc | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none | 19 min 17 sec
gcc | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none | 15 min 49 sec
clang | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 26 min 13 sec
clang | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions | 26 min 9 sec
clang | BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none | 17 min 20 sec
clang | BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none | 16 min 2 sec