### PR TITLE
Style fix for EXISTS subquery related changes

### DIFF
--- a/query_optimizer/expressions/CMakeLists.txt
+++ b/query_optimizer/expressions/CMakeLists.txt
@@ -120,6 +120,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_ComparisonExpression
 target_link_libraries(quickstep_queryoptimizer_expressions_Exists
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_ExpressionType
                       quickstep_queryoptimizer_expressions_Predicate
@@ -254,6 +255,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_SubqueryExpression
                       glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_ExpressionType
                       quickstep_queryoptimizer_expressions_Scalar

--- a/query_optimizer/expressions/Exists.cpp
+++ b/query_optimizer/expressions/Exists.cpp
@@ -34,7 +34,6 @@ namespace expressions {
   return nullptr;
 }
 
-
 void Exists::getFieldStringItems(
     std::vector<std::string> *inline_field_names,
     std::vector<std::string> *inline_field_values,
@@ -45,7 +44,6 @@ void Exists::getFieldStringItems(
   non_container_child_field_names->push_back("exists_subquery");
   non_container_child_fields->push_back(exists_subquery_);
 }
-
 
 }  // namespace expressions
 }  // namespace optimizer

--- a/query_optimizer/expressions/Exists.cpp
+++ b/query_optimizer/expressions/Exists.cpp
@@ -21,10 +21,15 @@
 #include <string>
 
 #include "query_optimizer/OptimizerTree.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
 
 #include "glog/logging.h"
 
 namespace quickstep {
+
+class CatalogAttribute;
+class Predicate;
+
 namespace optimizer {
 namespace expressions {
 

--- a/query_optimizer/expressions/Exists.hpp
+++ b/query_optimizer/expressions/Exists.hpp
@@ -67,7 +67,7 @@ class Exists : public Predicate {
 
   ExpressionPtr copyWithNewChildren(
       const std::vector<ExpressionPtr> &new_children) const override {
-    DCHECK_EQ(new_children.size(), 1u);
+    DCHECK_EQ(1u, new_children.size());
     return Create(std::static_pointer_cast<const SubqueryExpression>(new_children[0]));
   }
 

--- a/query_optimizer/expressions/Exists.hpp
+++ b/query_optimizer/expressions/Exists.hpp
@@ -20,17 +20,25 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/ExpressionType.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
 #include "query_optimizer/expressions/SubqueryExpression.hpp"
 #include "utility/Macros.hpp"
 
+#include "glog/logging.h"
+
 namespace quickstep {
+
+class CatalogAttribute;
+class Predicate;
+
 namespace optimizer {
 namespace expressions {
 

--- a/query_optimizer/expressions/ExpressionUtil.cpp
+++ b/query_optimizer/expressions/ExpressionUtil.cpp
@@ -41,7 +41,7 @@ std::vector<AttributeReferencePtr> GetAttributeReferencesWithinScope(
     const std::vector<AttributeReferencePtr> &attributes,
     const AttributeReferenceScope scope) {
   std::vector<AttributeReferencePtr> filtered_attributes;
-  for (const auto& attr_it : attributes) {
+  for (const auto &attr_it : attributes) {
     if (attr_it->scope() == scope) {
       filtered_attributes.emplace_back(attr_it);
     }

--- a/query_optimizer/expressions/PatternMatcher.hpp
+++ b/query_optimizer/expressions/PatternMatcher.hpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/query_optimizer/expressions/PatternMatcher.hpp
+++ b/query_optimizer/expressions/PatternMatcher.hpp
@@ -35,6 +35,7 @@ class BinaryExpression;
 class Cast;
 class ComparisonExpression;
 class Count;
+class Exists;
 class LogicalAnd;
 class LogicalNot;
 class LogicalOr;
@@ -115,6 +116,7 @@ using SomeAttributeReference = SomeExpressionNode<AttributeReference, Expression
 using SomeBinaryExpression = SomeExpressionNode<BinaryExpression, ExpressionType::kBinaryExpression>;
 using SomeCast = SomeExpressionNode<Cast, ExpressionType::kCast>;
 using SomeComparisonExpression = SomeExpressionNode<ComparisonExpression, ExpressionType::kComparisonExpression>;
+using SomeExists = SomeExpressionNode<Exists, ExpressionType::kExists>;
 using SomeLogicalAnd = SomeExpressionNode<LogicalAnd, ExpressionType::kLogicalAnd>;
 using SomeLogicalNot = SomeExpressionNode<LogicalNot, ExpressionType::kLogicalNot>;
 using SomeLogicalOr = SomeExpressionNode<LogicalOr, ExpressionType::kLogicalOr>;
@@ -123,6 +125,7 @@ using SomeNamedExpression = SomeExpressionNode<NamedExpression,
                                                ExpressionType::kAlias>;
 using SomePredicate = SomeExpressionNode<Predicate,
                                          ExpressionType::kComparisonExpression,
+                                         ExpressionType::kExists,
                                          ExpressionType::kLogicalAnd,
                                          ExpressionType::kLogicalNot,
                                          ExpressionType::kLogicalOr,

--- a/query_optimizer/expressions/SubqueryExpression.cpp
+++ b/query_optimizer/expressions/SubqueryExpression.cpp
@@ -22,24 +22,27 @@
 
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
 
 #include "glog/logging.h"
 
 namespace quickstep {
+
+class CatalogAttribute;
+class Scalar;
+
 namespace optimizer {
 namespace expressions {
 
 ::quickstep::Scalar* SubqueryExpression::concretize(
     const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
   LOG(FATAL) << "SubqueryExpression should not be concretized";
-  return nullptr;
 }
 
 std::vector<AttributeReferencePtr> SubqueryExpression::getReferencedAttributes() const {
   // SubqueryExpression should be eliminated before any place that needs
   // a call of getReferencedAttributes.
   LOG(FATAL) << "SubqueryExpression::getReferencedAttributes() is not implemented";
-  return {};
 }
 
 void SubqueryExpression::getFieldStringItems(

--- a/query_optimizer/expressions/SubqueryExpression.cpp
+++ b/query_optimizer/expressions/SubqueryExpression.cpp
@@ -30,7 +30,7 @@ namespace optimizer {
 namespace expressions {
 
 ::quickstep::Scalar* SubqueryExpression::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
   LOG(FATAL) << "SubqueryExpression should not be concretized";
   return nullptr;
 }

--- a/query_optimizer/expressions/SubqueryExpression.hpp
+++ b/query_optimizer/expressions/SubqueryExpression.hpp
@@ -81,7 +81,7 @@ class SubqueryExpression : public Scalar {
   }
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
 
   /**
    * @brief Creates a subquery expression.
@@ -90,7 +90,7 @@ class SubqueryExpression : public Scalar {
    * @param subquery The logical subquery node.
    * @return An immutable SubqueryExpression.
    */
-  static SubqueryExpressionPtr Create(const logical::LogicalPtr& subquery) {
+  static SubqueryExpressionPtr Create(const logical::LogicalPtr &subquery) {
     return SubqueryExpressionPtr(new SubqueryExpression(subquery));
   }
 
@@ -104,7 +104,7 @@ class SubqueryExpression : public Scalar {
       std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const override;
 
  private:
-  explicit SubqueryExpression(const logical::LogicalPtr& subquery)
+  explicit SubqueryExpression(const logical::LogicalPtr &subquery)
       : subquery_(subquery),
         output_attribute_(subquery->getOutputAttributes()[0]) {
     DCHECK(!subquery->getOutputAttributes().empty());

--- a/query_optimizer/expressions/SubqueryExpression.hpp
+++ b/query_optimizer/expressions/SubqueryExpression.hpp
@@ -20,9 +20,11 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/ExpressionType.hpp"
 #include "query_optimizer/expressions/Scalar.hpp"
@@ -34,6 +36,8 @@
 
 namespace quickstep {
 
+class CatalogAttribute;
+class Scalar;
 class Type;
 
 namespace optimizer {

--- a/query_optimizer/resolver/NameResolver.hpp
+++ b/query_optimizer/resolver/NameResolver.hpp
@@ -51,7 +51,7 @@ class NameResolver {
    * @brief Constructor.
    *
    * @param parent_resolver The NameResolver inherited from the outer query.
-   *                        NULL if there is no outer query.
+   *        NULL if there is no outer query.
    */
   explicit NameResolver(const NameResolver *parent_resolver = nullptr)
       : parent_resolver_(parent_resolver) {}


### PR DESCRIPTION
This PR fixes some code style issues for changes in #151, together with minor fixes to class `PatternMatcher` for class `Exists`,