### PR TITLE
Minor fixes to displayed names for Comparison

### DIFF
--- a/parser/tests/TPCH.test
+++ b/parser/tests/TPCH.test
@@ -803,7 +803,7 @@ SelectStatement
           | +-Equal
           | | +-left_operand=AttributeReference[attribute_name=s_nationkey]
           | | +-right_operand=AttributeReference[attribute_name=n_nationkey]
-          | +-kLike
+          | +-Like
           |   +-left_operand=AttributeReference[attribute_name=p_name]
           |   +-right_operand=Literal
           |     +-StringLiteral[value=%ghost%]
@@ -1045,7 +1045,7 @@ SelectStatement
   |     |     | +-NumericLiteral[numeric_string=0,float_like=false]
   |     |     +-when_clauses=
   |     |       +-SearchedWhenClause
-  |     |         +-condition_predicate=kLike
+  |     |         +-condition_predicate=Like
   |     |         | +-left_operand=AttributeReference[attribute_name=p_type]
   |     |         | +-right_operand=Literal
   |     |         |   +-StringLiteral[value=PROMO%]

--- a/query_optimizer/expressions/ComparisonExpression.cpp
+++ b/query_optimizer/expressions/ComparisonExpression.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -48,22 +50,7 @@ ComparisonExpression::ComparisonExpression(const Comparison &comparison,
 }
 
 std::string ComparisonExpression::getName() const {
-  switch (comparison_.getComparisonID()) {
-    case ComparisonID::kEqual:
-      return "Equal";
-    case ComparisonID::kNotEqual:
-      return "NotEqual";
-    case ComparisonID::kLess:
-      return "Less";
-    case ComparisonID::kLessOrEqual:
-      return "LessOrEqual";
-    case ComparisonID::kGreater:
-      return "Greater";
-    case ComparisonID::kGreaterOrEqual:
-      return "GreaterOrEqual";
-    default:
-      LOG(FATAL) << "Unknown comparison type";
-  }
+  return comparison_.getName();
 }
 
 bool ComparisonExpression::isEqualityComparisonPredicate() const {

--- a/types/operations/comparisons/ComparisonID.cpp
+++ b/types/operations/comparisons/ComparisonID.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,10 +28,10 @@ const char *kComparisonNames[] = {
   "LessOrEqual",
   "Greater",
   "GreaterOrEqual",
-  "kLike",
-  "kNotLike",
-  "kRegexMatch",
-  "kNotRegexMatch"
+  "Like",
+  "NotLike",
+  "RegexMatch",
+  "NotRegexMatch"
 };
 
 const char *kComparisonShortNames[] = {


### PR DESCRIPTION
This PR fixes the displayed names for some of the  `Comparison` subclasses.