### PR TITLE
Stop preloading the buffer pool when it is full.

### DIFF
--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
            real_num_workers,
            (static_cast<double>(quickstep::FLAGS_buffer_pool_slots) * quickstep::kSlotSizeBytes)/quickstep::kAGigaByte);
   } else {
-    LOG(FATAL) << "Quickstep needs at least one worker thread";
+    LOG(FATAL) << "Quickstep needs at least one worker thread to run";
   }
 
 #ifdef QUICKSTEP_HAVE_FILE_MANAGER_HDFS
@@ -262,14 +262,19 @@ int main(int argc, char* argv[]) {
       DefaultsConfigurator::GetNumNUMANodesCoveredByWorkers(worker_cpu_affinities);
 
   if (quickstep::FLAGS_preload_buffer_pool) {
+    std::chrono::time_point<std::chrono::steady_clock> preLoadStart, preLoadEnd;
+    preLoadStart = std::chrono::steady_clock::now();
+    printf("Preloading the buffer pool ... ");
     quickstep::PreloaderThread preloader(*query_processor->getDefaultDatabase(),
                                          query_processor->getStorageManager(),
                                          worker_cpu_affinities.front());
-    printf("Preloading buffer pool... ");
+
     fflush(stdout);
     preloader.start();
     preloader.join();
-    printf("DONE\n");
+    preLoadEnd = std::chrono::steady_clock::now();
+    printf("in %g seconds\n",
+           std::chrono::duration<double>(preLoadEnd - preLoadStart).count());
   }
 
   Foreman foreman(&bus,

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -262,19 +262,19 @@ int main(int argc, char* argv[]) {
       DefaultsConfigurator::GetNumNUMANodesCoveredByWorkers(worker_cpu_affinities);
 
   if (quickstep::FLAGS_preload_buffer_pool) {
-    std::chrono::time_point<std::chrono::steady_clock> preLoadStart, preLoadEnd;
-    preLoadStart = std::chrono::steady_clock::now();
+    std::chrono::time_point<std::chrono::steady_clock> preload_start, preload_end;
+    preload_start = std::chrono::steady_clock::now();
     printf("Preloading the buffer pool ... ");
+    fflush(stdout);
     quickstep::PreloaderThread preloader(*query_processor->getDefaultDatabase(),
                                          query_processor->getStorageManager(),
                                          worker_cpu_affinities.front());
 
-    fflush(stdout);
     preloader.start();
     preloader.join();
-    preLoadEnd = std::chrono::steady_clock::now();
+    preload_end = std::chrono::steady_clock::now();
     printf("in %g seconds\n",
-           std::chrono::duration<double>(preLoadEnd - preLoadStart).count());
+           std::chrono::duration<double>(preload_end - preload_start).count());
   }
 
   Foreman foreman(&bus,

--- a/storage/PreloaderThread.cpp
+++ b/storage/PreloaderThread.cpp
@@ -34,7 +34,7 @@ void PreloaderThread::run() {
     ThreadUtil::BindToCPU(cpu_id_);
   }
 
-  const std::size_t numBufferPoolSlots = storage_manager_->getMaxBufferPoolSlots();
+  const std::size_t num_slots = storage_manager_->getMaxBufferPoolSlots();
   std::size_t blocksLoaded = 0;
 
   for (const CatalogRelation &relation : database_) {
@@ -46,8 +46,8 @@ void PreloaderThread::run() {
         LOG(INFO) << "Error after loading " << blocksLoaded << "blocks\n";
         throw;
       }
-      blocksLoaded++;
-      if (blocksLoaded == numBufferPoolSlots) {
+      ++blocksLoaded;
+      if (blocksLoaded == num_slots) {
         // The buffer pool has filled up. But, some database blocks are not loaded.
         printf(" The database is larger than the buffer pool. Only %lu blocks were loaded ",
                blocksLoaded);

--- a/storage/PreloaderThread.cpp
+++ b/storage/PreloaderThread.cpp
@@ -35,7 +35,7 @@ void PreloaderThread::run() {
   }
 
   const std::size_t num_slots = storage_manager_->getMaxBufferPoolSlots();
-  std::size_t blocksLoaded = 0;
+  std::size_t blocks_loaded = 0;
 
   for (const CatalogRelation &relation : database_) {
     std::vector<block_id> blocks = relation.getBlocksSnapshot();
@@ -43,19 +43,19 @@ void PreloaderThread::run() {
       try {
         BlockReference current_block = storage_manager_->getBlock(current_block_id, relation);
       } catch (...) {
-        LOG(INFO) << "Error after loading " << blocksLoaded << "blocks\n";
+        LOG(INFO) << "Error after loading " << blocks_loaded << "blocks\n";
         throw;
       }
-      ++blocksLoaded;
-      if (blocksLoaded == num_slots) {
+      ++blocks_loaded;
+      if (blocks_loaded == num_slots) {
         // The buffer pool has filled up. But, some database blocks are not loaded.
         printf(" The database is larger than the buffer pool. Only %lu blocks were loaded ",
-               blocksLoaded);
+               blocks_loaded);
         return;
       }
     }
   }
-  printf(" Loaded %lu blocks ", blocksLoaded);
+  printf(" Loaded %lu blocks ", blocks_loaded);
 }
 
 }  // namespace quickstep

--- a/storage/PreloaderThread.cpp
+++ b/storage/PreloaderThread.cpp
@@ -43,7 +43,7 @@ void PreloaderThread::run() {
       try {
         BlockReference current_block = storage_manager_->getBlock(current_block_id, relation);
       } catch (...) {
-        LOG(INFO) << "Error after loading " << blocks_loaded << "blocks\n";
+        LOG(ERROR) << "Error after loading " << blocks_loaded << "blocks\n";
         throw;
       }
       ++blocks_loaded;

--- a/storage/StorageManager.hpp
+++ b/storage/StorageManager.hpp
@@ -166,6 +166,22 @@ class StorageManager {
   }
 
   /**
+   * @brief Return the upper limit on the number of buffer pool slots that the
+   *        StorageManager can allocate. This number is specified during the
+   *        initialization of the StorageManager. The size of each slot is
+   *        kSlotSizeBytes.
+   * @note This information is provided for informational purposes. The memory
+   *       pool may grow larger than this upper limite temporarily, depending
+   *       on the path that is followed in a call to createBlock() or
+   *       loadBlock().
+   *
+   * @return The number of buffer pool slots managed by this StorageManager.
+   **/
+  std::size_t getMaxBufferPoolSlots() const {
+    return max_memory_usage_;
+  }
+
+  /**
    * @brief Create a new empty block.
    *
    * @param relation The relation which the new block will belong to (you must


### PR DESCRIPTION
This PR addressed issue #51.

When the database is larger than the buffer pool, a message is printed, and the preloading is stopped saving unnessary IOs. 

Also, the time to preload the buffer pool is now printed. 

Since this is a feature that is largely used for performance testing, no tests are added. To test this feature, create a database that has more than 10 blocks, and try the following: 
`./quickstep_cli_shell -preload_buffer_pool=true` and
`./quickstep_cli_shell -preload_buffer_pool=true -buffer_pool_slots=10`