### PR TITLE
Removed optional bitweaving submodule from submodule file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
-[submodule "storage/bitweaving"]
-	path = storage/bitweaving
-	url = https://github.com/UWQuickstep/bitweaving.git


### PR DESCRIPTION
This was an oversight from #169 Adding the bitweaving index repo to the submodule file will be confusing to users who do not have access to the bitweaving repo.