### PR TITLE
Fixed the lock problem with AggregationHandleSum::mergeStates()

### DIFF
--- a/expressions/aggregation/AggregationHandleSum.cpp
+++ b/expressions/aggregation/AggregationHandleSum.cpp
@@ -144,7 +144,7 @@ void AggregationHandleSum::mergeStates(
   const AggregationStateSum &sum_source = static_cast<const AggregationStateSum&>(source);
   AggregationStateSum *sum_destination = static_cast<AggregationStateSum*>(destination);
 
-  SpinMutexLock(sum_destination->mutex_);
+  SpinMutexLock lock(sum_destination->mutex_);
   sum_destination->sum_ = merge_operator_->applyToTypedValues(sum_destination->sum_,
                                                               sum_source.sum_);
   sum_destination->null_ = sum_destination->null_ && sum_source.null_;


### PR DESCRIPTION
This PR is a one-line fix to the lock problem with `AggregationHandleSum::mergeStates()`. The fix is that we create a named variable for `SpinMutexLock`. The original line of code is somehow a typo that the lock is non-named and would be released immediately after creation, and causes non-deterministic results for TPC-H query 06.