### PR TITLE
Refactored how min and max BLOCKSIZEMBs are calculated.

### DIFF
--- a/query_optimizer/tests/logical_generator/Create.test
+++ b/query_optimizer/tests/logical_generator/Create.test
@@ -19,7 +19,7 @@ TopLevelPlan
 +-plan=CreateTable[relation=foo]
 | +-block_properties=ProtoDescription
 | | +-Property=ProtoProperty[Property=blocktype,Value=rowstore]
-| | +-Property=ProtoProperty[Property=slots,Value=4]
+| | +-Property=ProtoProperty[Property=slots,Value=5]
 | +-attributes=
 |   +-AttributeReference[id=0,name=attr,relation=foo,type=Int]
 +-output_attributes=
@@ -36,7 +36,7 @@ TopLevelPlan
 | | +-Property=ProtoProperty[Property=sort,Value=0]
 | | +-Property=ProtoProperty[Property=compress,Value=0]
 | | +-Property=ProtoProperty[Property=compress,Value=1]
-| | +-Property=ProtoProperty[Property=slots,Value=4]
+| | +-Property=ProtoProperty[Property=slots,Value=5]
 | +-attributes=
 |   +-AttributeReference[id=0,name=attr,relation=foo,type=Int]
 |   +-AttributeReference[id=1,name=attr2,relation=foo,type=Int]

--- a/query_optimizer/tests/resolver/Create.test
+++ b/query_optimizer/tests/resolver/Create.test
@@ -202,10 +202,19 @@ ERROR: The BLOCKSIZEMB property must be an integer. (2 : 17)
                 ^
 ==
 
-# BLOCKSIZEMB must not be 0.
+# BLOCKSIZEMB must be greater than the minimum (defined in StorageConstants.hpp).
 CREATE TABLE foo (attr INT) WITH BLOCKPROPERTIES
 (TYPE rowstore, BLOCKSIZEMB 0);
 --
-ERROR: The BLOCKSIZEMB property must be between 2Mb and 1000Mb. (2 : 17)
+ERROR: The BLOCKSIZEMB property must be between 2MB and 1024MB. (2 : 17)
 (TYPE rowstore, BLOCKSIZEMB 0);
+                ^
+==
+
+# BLOCKSIZEMB must be less than the maximum (defined in StorageConstants.hpp).
+CREATE TABLE foo (attr INT) WITH BLOCKPROPERTIES
+(TYPE rowstore, BLOCKSIZEMB 2000);
+--
+ERROR: The BLOCKSIZEMB property must be between 2MB and 1024MB. (2 : 17)
+(TYPE rowstore, BLOCKSIZEMB 2000);
                 ^

--- a/storage/StorageConstants.hpp
+++ b/storage/StorageConstants.hpp
@@ -37,6 +37,18 @@ const std::size_t kSlotSizeBytes = 0x200000;
 
 // A GigaByte.
 const std::uint64_t kAGigaByte = (1 << 30);
+// A MegaByte.
+const std::uint64_t kAMegaByte = (1 << 20);
+
+// Constants for the minimum and maximum user-specifiable BLOCKSIZEMB in
+// the SQL clause BLOCKPROPERTIES.
+const std::uint64_t kBlockSizeUpperBoundBytes = kAGigaByte;
+
+// 2 Megabytes.
+const std::uint64_t kBlockSizeLowerBoundBytes = kAMegaByte << 1;
+
+// The default size of a new relation in terms of the number of slots.
+const std::uint64_t kDefaultBlockSizeInSlots = 1;
 
 // To determine the size of a buffer pool, we use a threshold (see below)
 // to check if the system has "large" amounts of installed memory. This


### PR DESCRIPTION
This corrects an issue found by @pateljm . The original code essentially used magic numbers for max/min blocksize and used Mbi instead of Mb. The changes to the code correct both these issues and update corresponding tests.