### PR TITLE
Fixed IWYU include paths.

### DIFF
--- a/third_party/iwyu/iwyu_helper.py
+++ b/third_party/iwyu/iwyu_helper.py
@@ -21,9 +21,10 @@ QUICKSTEP_INCLUDES = [ '.',
                        './build/third_party',
                        './build/third_party/protobuf/include',
                        './build/third_party/gflags/include',
-                       './third_party/gtest/include',
-                       './third_party/glog/src',
                        './third_party/benchmark/include',
+                       './third_party/glog/src',
+                       './third_party/googletest/googletest/include',
+                       './third_party/re2',
                        './third_party/tmb/include']
 QUICKSTEP_DEFINES = [ '-DQUICKSTEP_DEBUG',
                       '-DQUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION', ]


### PR DESCRIPTION
This small PR fixes some errors running `iwyu` due to missing / outdated include paths, as a result of merging both PRs #68 and #156.

Now running `iwyu` on the following files should work:
 * `types/operations/comparisons/PatternMatchingComparators.hpp`
 * `storage/StorageManager.hpp`