### PR TITLE
Increase the size of the sharded lock manager

### DIFF
--- a/storage/StorageManager.hpp
+++ b/storage/StorageManager.hpp
@@ -482,7 +482,7 @@ class StorageManager {
   // TODO(jmp): Would be good to set this more intelligently in the future 
   //            based on the hardware concurrency, the amount of main memory
   //            and slot size.
-  static constexpr std::size_t kLockManagerNumShards = 16384;
+  static constexpr std::size_t kLockManagerNumShards = 8192;
   ShardedLockManager<block_id, kLockManagerNumShards, SpinSharedMutex<false>> lock_manager_;
 
   FRIEND_TEST(StorageManagerTest, DifferentNUMANodeBlobTestWithEviction);

--- a/storage/StorageManager.hpp
+++ b/storage/StorageManager.hpp
@@ -481,8 +481,9 @@ class StorageManager {
   //       block's lock shard.
   // TODO(jmp): Would be good to set this more intelligently in the future 
   //            based on the hardware concurrency, the amount of main memory
-  //            and slot size.
-  static constexpr std::size_t kLockManagerNumShards = 8192;
+  //            and slot size. For now pick the largest prime that is less
+  //            than 8K.
+  static constexpr std::size_t kLockManagerNumShards = 0x2000-1;
   ShardedLockManager<block_id, kLockManagerNumShards, SpinSharedMutex<false>> lock_manager_;
 
   FRIEND_TEST(StorageManagerTest, DifferentNUMANodeBlobTestWithEviction);

--- a/storage/StorageManager.hpp
+++ b/storage/StorageManager.hpp
@@ -479,7 +479,7 @@ class StorageManager {
   //   (2) If it is not safe to evict a block, then either that block's
   //       reference count is greater than 0 or a shared lock is held on the
   //       block's lock shard.
-  // TODO(jmp): Would be good to set this more intelligently in the future 
+  // TODO(jmp): Would be good to set this more intelligently in the future
   //            based on the hardware concurrency, the amount of main memory
   //            and slot size. For now pick the largest prime that is less
   //            than 8K.

--- a/storage/StorageManager.hpp
+++ b/storage/StorageManager.hpp
@@ -479,7 +479,10 @@ class StorageManager {
   //   (2) If it is not safe to evict a block, then either that block's
   //       reference count is greater than 0 or a shared lock is held on the
   //       block's lock shard.
-  static constexpr std::size_t kLockManagerNumShards = 256;
+  // TODO(jmp): Would be good to set this more intelligently in the future 
+  //            based on the hardware concurrency, the amount of main memory
+  //            and slot size.
+  static constexpr std::size_t kLockManagerNumShards = 16384;
   ShardedLockManager<block_id, kLockManagerNumShards, SpinSharedMutex<false>> lock_manager_;
 
   FRIEND_TEST(StorageManagerTest, DifferentNUMANodeBlobTestWithEviction);


### PR DESCRIPTION
Having small number of entries in the sharded lock manager introduces artificial conflict causing the buffer pool to grow. The size of an entry in the lock_manager_ is small, so don't be so stingy with the size of the lock manager. By default, we want to run well on large memory boxes.