### PR TITLE
Increase the default storage block size to 32MB.

### DIFF
--- a/query_optimizer/tests/logical_generator/Create.test
+++ b/query_optimizer/tests/logical_generator/Create.test
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 [default optimized_logical_plan]
-CREATE TABLE foo (attr int) WITH BLOCKPROPERTIES (TYPE rowstore, BLOCKSIZEMB 10)
+CREATE TABLE foo (attr int) WITH BLOCKPROPERTIES (TYPE rowstore, BLOCKSIZEMB 160)
 --
 TopLevelPlan
 +-plan=CreateTable[relation=foo]
@@ -27,7 +27,7 @@ TopLevelPlan
 ==
 
 CREATE TABLE foo (attr int, attr2 int) WITH BLOCKPROPERTIES
-(TYPE compressed_columnstore, SORT attr, COMPRESS ALL, BLOCKSIZEMB 10)
+(TYPE compressed_columnstore, SORT attr, COMPRESS ALL, BLOCKSIZEMB 160)
 --
 TopLevelPlan
 +-plan=CreateTable[relation=foo]

--- a/query_optimizer/tests/physical_generator/Create.test
+++ b/query_optimizer/tests/physical_generator/Create.test
@@ -86,8 +86,8 @@ TopLevelPlan
   +-AttributeReference[id=10,name=col11,relation=foo,type=Char(5) NULL]
   +-AttributeReference[id=11,name=col12,relation=foo,type=VarChar(5) NULL]
 ==
-CREATE TABLE foo (col1 INT) WITH BLOCKPROPERTIES 
-  (TYPE compressed_columnstore, SORT col1, COMPRESS ALL, BLOCKSIZEMB 5);
+CREATE TABLE foo (col1 INT) WITH BLOCKPROPERTIES
+  (TYPE compressed_columnstore, SORT col1, COMPRESS ALL, BLOCKSIZEMB 64);
 --
 [Optimized Logical Plan]
 TopLevelPlan

--- a/query_optimizer/tests/resolver/Create.test
+++ b/query_optimizer/tests/resolver/Create.test
@@ -123,7 +123,7 @@ BLOCKPROPERTIES (BLOCKSIZEMB 1...
 ==
 
 # Rowstores cannot have a sorted attribute.
-CREATE TABLE foo (attr INT) WITH BLOCKPROPERTIES 
+CREATE TABLE foo (attr INT) WITH BLOCKPROPERTIES
 (TYPE rowstore, SORT attr);
 --
 ERROR: The SORT property does not apply to this block type. (2 : 22)
@@ -167,7 +167,7 @@ ERROR: The COMPRESS property does not apply to this block type. (2 : 7)
 ==
 
 # Compress property is required for compressed blocks.
-CREATE TABLE foo (attr INT) WITH 
+CREATE TABLE foo (attr INT) WITH
 BLOCKPROPERTIES (TYPE compressed_rowstore);
 --
 ERROR: The COMPRESS property must be specified as ALL or a list of attributes. (2 : 1)
@@ -206,7 +206,7 @@ ERROR: The BLOCKSIZEMB property must be an integer. (2 : 17)
 CREATE TABLE foo (attr INT) WITH BLOCKPROPERTIES
 (TYPE rowstore, BLOCKSIZEMB 0);
 --
-ERROR: The BLOCKSIZEMB property must be between 2MB and 1024MB. (2 : 17)
+ERROR: The BLOCKSIZEMB property must be between 32MB and 1024MB. (2 : 17)
 (TYPE rowstore, BLOCKSIZEMB 0);
                 ^
 ==
@@ -215,6 +215,6 @@ ERROR: The BLOCKSIZEMB property must be between 2MB and 1024MB. (2 : 17)
 CREATE TABLE foo (attr INT) WITH BLOCKPROPERTIES
 (TYPE rowstore, BLOCKSIZEMB 2000);
 --
-ERROR: The BLOCKSIZEMB property must be between 2MB and 1024MB. (2 : 17)
+ERROR: The BLOCKSIZEMB property must be multiple times of 32MB. (2 : 17)
 (TYPE rowstore, BLOCKSIZEMB 2000);
                 ^

--- a/storage/StorageConstants.hpp
+++ b/storage/StorageConstants.hpp
@@ -33,7 +33,7 @@ namespace quickstep {
 //
 // TODO(chasseur): Possibly change this for non-x86 architectures with
 // different large page sizes.
-const std::size_t kSlotSizeBytes = 0x200000;
+const std::size_t kSlotSizeBytes = 0x2000000;  // 32 MB.
 
 // A GigaByte.
 const std::uint64_t kAGigaByte = (1 << 30);

--- a/storage/StorageConstants.hpp
+++ b/storage/StorageConstants.hpp
@@ -29,11 +29,11 @@ namespace quickstep {
 
 // Size of a memory slot managed by the StorageManager. This is the smallest
 // quantum of allocation for StorageBlocks and StorageBlobs. 4 MB is the large
-// page size on x86.
+// page size on x86. We want the default slot to be even larger.
 //
 // TODO(chasseur): Possibly change this for non-x86 architectures with
 // different large page sizes.
-const std::size_t kSlotSizeBytes = 0x400000;
+const std::size_t kSlotSizeBytes = 0x2000000;  // 32 MB.
 
 // A GigaByte.
 const std::uint64_t kAGigaByte = (1 << 30);
@@ -47,7 +47,7 @@ const std::uint64_t kBlockSizeUpperBoundBytes = kAGigaByte;
 const std::uint64_t kBlockSizeLowerBoundBytes = kSlotSizeBytes;
 
 // The default size of a new relation in terms of the number of slots.
-const std::uint64_t kDefaultBlockSizeInSlots = 8;
+const std::uint64_t kDefaultBlockSizeInSlots = 1;
 
 // To determine the size of a buffer pool, we use a threshold (see below)
 // to check if the system has "large" amounts of installed memory. This

--- a/storage/StorageConstants.hpp
+++ b/storage/StorageConstants.hpp
@@ -28,12 +28,12 @@ namespace quickstep {
  */
 
 // Size of a memory slot managed by the StorageManager. This is the smallest
-// quantum of allocation for StorageBlocks and StorageBlobs. 2 MB is the large
+// quantum of allocation for StorageBlocks and StorageBlobs. 4 MB is the large
 // page size on x86.
 //
 // TODO(chasseur): Possibly change this for non-x86 architectures with
 // different large page sizes.
-const std::size_t kSlotSizeBytes = 0x2000000;  // 32 MB.
+const std::size_t kSlotSizeBytes = 0x400000;
 
 // A GigaByte.
 const std::uint64_t kAGigaByte = (1 << 30);
@@ -44,11 +44,10 @@ const std::uint64_t kAMegaByte = (1 << 20);
 // the SQL clause BLOCKPROPERTIES.
 const std::uint64_t kBlockSizeUpperBoundBytes = kAGigaByte;
 
-// 2 Megabytes.
-const std::uint64_t kBlockSizeLowerBoundBytes = kAMegaByte << 1;
+const std::uint64_t kBlockSizeLowerBoundBytes = kSlotSizeBytes;
 
 // The default size of a new relation in terms of the number of slots.
-const std::uint64_t kDefaultBlockSizeInSlots = 1;
+const std::uint64_t kDefaultBlockSizeInSlots = 8;
 
 // To determine the size of a buffer pool, we use a threshold (see below)
 // to check if the system has "large" amounts of installed memory. This


### PR DESCRIPTION
The downside is some internal fragmentation for small files, and
potentially reduced concurrency as allocations for each thread is
larger now. But, query performance goes up by a huge amount for
large data sets.