### PR TITLE
Change default aggregate_hashtable_type from LinearOpenAddressing to SeparateChaining

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -135,7 +135,7 @@ static const volatile bool join_hashtable_type_dummy
     = gflags::RegisterFlagValidator(&FLAGS_join_hashtable_type,
                                     &ValidateHashTableImplTypeString);
 
-DEFINE_string(aggregate_hashtable_type, "LinearOpenAddressing",
+DEFINE_string(aggregate_hashtable_type, "SeparateChaining",
               "HashTable implementation to use for aggregates with GROUP BY "
               "(valid options are SeparateChaining or LinearOpenAddressing)");
 static const volatile bool aggregate_hashtable_type_dummy


### PR DESCRIPTION
This PR changes the default hashtable for aggregation from `LinearOpenAddressingHashTable` to `SeparateChainingHashTable`.

The reason is that the performance of  `LinearOpenAddressingHashTable` drops radically if the future hash table size is underestimated on its initialization, while `SeparateChainingHashTable` is more resilient to any initial size. This situation gets reflected if we run TPC-H query 18.

The long-term solution will be to develop a more accurate estimation of the hash table size during query optimization.
