### PR TITLE
Add print_query flag for printing input queries

### DIFF
--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -1,6 +1,8 @@
 /**
  *   Copyright 2011-2015 Quickstep Technologies LLC.
  *   Copyright 2015-2016 Pivotal Software, Inc.
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -144,6 +146,10 @@ DEFINE_string(worker_affinities, "",
               "means that they will all be runable on any CPU according to "
               "the kernel's own scheduling policy).");
 DEFINE_bool(initialize_db, false, "If true, initialize a database.");
+DEFINE_bool(print_query, false,
+            "Print each input query statement. This is useful when running a "
+            "large number of queries in a batch.");
+
 }  // namespace quickstep
 
 int main(int argc, char* argv[]) {
@@ -334,6 +340,10 @@ int main(int argc, char* argv[]) {
     if (command_string->size() == 0) {
       delete command_string;
       break;
+    }
+
+    if (quickstep::FLAGS_print_query) {
+      printf("\n%s\n", command_string->c_str());
     }
 
     parser_wrapper->feedNextBuffer(command_string);


### PR DESCRIPTION
This PR adds a gflag `print_query` for printing each input query before printing the query's result. This is useful when we run a large number of queries in a batch. That is, we can know easily which query that each result is corresponding to.
