### PR TITLE
Initial partition-aware changes for hash join.

### DIFF
--- a/catalog/CatalogDatabase.hpp
+++ b/catalog/CatalogDatabase.hpp
@@ -290,7 +290,7 @@ class CatalogDatabase : public CatalogDatabaseLite {
    * @param id The id to search for.
    * @return The relation with the given ID.
    **/
-  const CatalogRelation* getRelationById(const relation_id id) const {
+  const CatalogRelation* getRelationById(const relation_id id) const override {
     SpinSharedMutexSharedLock<false> lock(relations_mutex_);
     if (hasRelationWithIdUnsafe(id)) {
       return &rel_vec_[id];

--- a/catalog/CatalogDatabase.hpp
+++ b/catalog/CatalogDatabase.hpp
@@ -290,7 +290,7 @@ class CatalogDatabase : public CatalogDatabaseLite {
    * @param id The id to search for.
    * @return The relation with the given ID.
    **/
-  const CatalogRelation* getRelationById(const relation_id id) const override{
+  const CatalogRelation* getRelationById(const relation_id id) const {
     SpinSharedMutexSharedLock<false> lock(relations_mutex_);
     if (hasRelationWithIdUnsafe(id)) {
       return &rel_vec_[id];

--- a/catalog/CatalogDatabase.hpp
+++ b/catalog/CatalogDatabase.hpp
@@ -290,7 +290,7 @@ class CatalogDatabase : public CatalogDatabaseLite {
    * @param id The id to search for.
    * @return The relation with the given ID.
    **/
-  const CatalogRelation* getRelationById(const relation_id id) const {
+  const CatalogRelation* getRelationById(const relation_id id) const override{
     SpinSharedMutexSharedLock<false> lock(relations_mutex_);
     if (hasRelationWithIdUnsafe(id)) {
       return &rel_vec_[id];

--- a/catalog/CatalogDatabaseLite.hpp
+++ b/catalog/CatalogDatabaseLite.hpp
@@ -23,6 +23,7 @@
 namespace quickstep {
 
 class CatalogRelationSchema;
+class CatalogRelation;
 
 /** \addtogroup Catalog
  *  @{
@@ -67,6 +68,16 @@ class CatalogDatabaseLite {
    * @return The relation schema with the given ID.
    **/
   virtual const CatalogRelationSchema& getRelationSchemaById(const relation_id id) const = 0;
+
+  /**
+   * @brief Get a relation by ID.
+   *
+   * @param id The id to search for.
+   * @return The relation with the given ID.
+   **/
+  virtual const CatalogRelation* getRelationById(const relation_id id) const {
+    return nullptr;
+  }
 
   /**
    * @brief Drop (delete) a relation by id.

--- a/query_execution/QueryContext.cpp
+++ b/query_execution/QueryContext.cpp
@@ -73,10 +73,13 @@ QueryContext::QueryContext(const serialization::QueryContext &proto,
         std::unique_ptr<const GeneratorFunctionHandle>(func_handle));
   }
 
-  for (int i = 0; i < proto.join_hash_tables_size(); ++i) {
-    join_hash_tables_.emplace_back(
-        JoinHashTableFactory::CreateResizableFromProto(proto.join_hash_tables(i),
-                                                       storage_manager));
+  join_hash_tables_.resize(proto.join_hash_table_groups_size());
+  for (int i = 0; i < proto.join_hash_table_groups_size(); ++i) {
+    for (int j = 0; j < proto.join_hash_table_groups(i).join_hash_tables_size(); ++j) {
+      join_hash_tables_[i].emplace_back(
+          JoinHashTableFactory::CreateResizableFromProto(proto.join_hash_table_groups(i).join_hash_tables(j),
+                                                         storage_manager));
+    }
   }
 
   for (int i = 0; i < proto.insert_destinations_size(); ++i) {
@@ -153,9 +156,11 @@ bool QueryContext::ProtoIsValid(const serialization::QueryContext &proto,
     }
   }
 
-  for (int i = 0; i < proto.join_hash_tables_size(); ++i) {
-    if (!JoinHashTableFactory::ProtoIsValid(proto.join_hash_tables(i))) {
-      return false;
+  for (int i = 0; i < proto.join_hash_table_groups_size(); ++i) {
+    for (int j = 0; j < proto.join_hash_table_groups(i).join_hash_tables_size(); ++j) {
+      if (!JoinHashTableFactory::ProtoIsValid(proto.join_hash_table_groups(i).join_hash_tables(j))) {
+        return false;
+      }
     }
   }
 

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -303,6 +303,7 @@ class QueryContext {
   /**
    * @brief Whether the given JoinHashTable id is valid.
    *
+   * @param gid The JoinHashTable group id.
    * @param id The JoinHashTable id.
    *
    * @return True if valid, otherwise false.
@@ -314,11 +315,13 @@ class QueryContext {
   /**
    * @brief Get the JoinHashTable.
    *
+   * @param gid The JoinHashTable group id.
    * @param id The JoinHashTable id in the query.
    *
    * @return The JoinHashTable, already created in the constructor.
    **/
   inline JoinHashTable* getJoinHashTable(const join_hash_table_group_id gid, const join_hash_table_id id = 0) {
+    DCHECK_LT(gid, join_hash_tables_.size());
     DCHECK_LT(id, join_hash_tables_[gid].size());
     return join_hash_tables_[gid][id].get();
   }
@@ -326,9 +329,11 @@ class QueryContext {
   /**
    * @brief Destory the given JoinHashTable.
    *
+   * @param gid The JoinHashTable group id.
    * @param id The id of the JoinHashTable to destroy.
    **/
   inline void destroyJoinHashTable(const join_hash_table_group_id gid, const join_hash_table_id id = 0) {
+    DCHECK_LT(gid, join_hash_tables_.size());
     DCHECK_LT(id, join_hash_tables_[gid].size());
     join_hash_tables_[gid][id].reset();
   }

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -81,6 +81,11 @@ class QueryContext {
   typedef std::uint32_t join_hash_table_id;
 
   /**
+   * @brief A unique identifier for a group of hash tables per query.
+   **/
+  typedef std::uint32_t join_hash_table_group_id;
+
+  /**
    * @brief A unique identifier for a Predicate per query.
    *
    * @note A negative value indicates a null Predicate.
@@ -248,8 +253,8 @@ class QueryContext {
    *
    * @return True if valid, otherwise false.
    **/
-  bool isValidJoinHashTableId(const join_hash_table_id id) const {
-    return id < join_hash_tables_.size();
+  bool isValidJoinHashTableId(const join_hash_table_group_id gid, const join_hash_table_id id = 0) const {
+    return gid < join_hash_tables_.size() && id < join_hash_tables_[gid].size();
   }
 
   /**
@@ -259,9 +264,9 @@ class QueryContext {
    *
    * @return The JoinHashTable, alreadly created in the constructor.
    **/
-  inline JoinHashTable* getJoinHashTable(const join_hash_table_id id) {
-    DCHECK_LT(id, join_hash_tables_.size());
-    return join_hash_tables_[id].get();
+  inline JoinHashTable* getJoinHashTable(const join_hash_table_group_id gid, const join_hash_table_id id = 0) {
+    DCHECK_LT(id, join_hash_tables_[gid].size());
+    return join_hash_tables_[gid][id].get();
   }
 
   /**
@@ -269,9 +274,9 @@ class QueryContext {
    *
    * @param id The id of the JoinHashTable to destroy.
    **/
-  inline void destroyJoinHashTable(const join_hash_table_id id) {
-    DCHECK_LT(id, join_hash_tables_.size());
-    join_hash_tables_[id].reset();
+  inline void destroyJoinHashTable(const join_hash_table_group_id gid, const join_hash_table_id id = 0) {
+    DCHECK_LT(id, join_hash_tables_[gid].size());
+    join_hash_tables_[gid][id].reset();
   }
 
   /**
@@ -410,7 +415,7 @@ class QueryContext {
   std::vector<std::unique_ptr<AggregationOperationState>> aggregation_states_;
   std::vector<std::unique_ptr<const GeneratorFunctionHandle>> generator_functions_;
   std::vector<std::unique_ptr<InsertDestination>> insert_destinations_;
-  std::vector<std::unique_ptr<JoinHashTable>> join_hash_tables_;
+  std::vector<std::vector<std::unique_ptr<JoinHashTable>>> join_hash_tables_;
   std::vector<std::unique_ptr<const Predicate>> predicates_;
   std::vector<std::vector<std::unique_ptr<const Scalar>>> scalar_groups_;
   std::vector<std::unique_ptr<const SortConfiguration>> sort_configs_;

--- a/query_execution/QueryContext.proto
+++ b/query_execution/QueryContext.proto
@@ -41,8 +41,13 @@ message QueryContext {
     repeated UpdateAssignment update_assignments = 2;
   }
 
+  // HashTableGroup is a vector of HashTables.
+  message HashTableGroup {
+    repeated HashTable join_hash_tables = 1;
+  }
+
   repeated AggregationOperationState aggregation_states = 1;
-  repeated HashTable join_hash_tables = 2;
+  repeated HashTableGroup join_hash_table_groups = 2;
   repeated InsertDestination insert_destinations = 3;
   repeated Predicate predicates = 4;
   repeated ScalarGroup scalar_groups = 5;

--- a/query_execution/QueryContext.proto
+++ b/query_execution/QueryContext.proto
@@ -46,16 +46,15 @@ message QueryContext {
   message HashTableGroup {
     repeated HashTable join_hash_tables = 1;
   }
-
   repeated AggregationOperationState aggregation_states = 1;
-  repeated HashTableGroup join_hash_table_groups = 2;
-  repeated InsertDestination insert_destinations = 3;
-  repeated Predicate predicates = 4;
-  repeated ScalarGroup scalar_groups = 5;
-  repeated SortConfiguration sort_configs = 6;
-  repeated Tuple tuples = 7;
-  repeated GeneratorFunctionHandle generator_functions = 8;
-  repeated BloomFilter bloom_filters = 9;
+  repeated BloomFilter bloom_filters = 2;
+  repeated GeneratorFunctionHandle generator_functions = 3;
+  repeated HashTableGroup join_hash_table_groups = 4;
+  repeated InsertDestination insert_destinations = 5;
+  repeated Predicate predicates = 6;
+  repeated ScalarGroup scalar_groups = 7;
+  repeated SortConfiguration sort_configs = 8;
+  repeated Tuple tuples = 9;
 
   // NOTE(zuyu): For UpdateWorkOrder only.
   repeated UpdateGroup update_groups = 10;

--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-#   Copyright 2011-2015 Quickstep Technologies LLC.
+#   Copyright 2013-2015 Quickstep Technologies LLC.
 #   Copyright 2015-2016 Pivotal Software, Inc.
 #   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
 #     University of Wisconsin—Madison.
@@ -57,6 +57,8 @@ target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionScheme
+                      quickstep_catalog_PartitionSchemeHeader
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_aggregation_AggregateFunction
                       quickstep_expressions_aggregation_AggregateFunction_proto

--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-#   Copyright 2013-2015 Quickstep Technologies LLC.
+#   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015-2016 Pivotal Software, Inc.
 #   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
 #     University of Wisconsin—Madison.

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -756,13 +756,12 @@ void ExecutionGenerator::convertHashJoin(const P::HashJoinPtr &physical_plan) {
           }
 
           hash_table_proto[part_id]->set_estimated_num_entries(build_cardinality);
-
         }
       }
     }
   } else {
-    hash_table_proto.emplace_back(query_context_proto_->mutable_join_hash_table_groups(join_hash_table_group_index)->add_join_hash_tables());
-
+    hash_table_proto.emplace_back(
+        query_context_proto_->mutable_join_hash_table_groups(join_hash_table_group_index)->add_join_hash_tables());
     // SimplifyHashTableImplTypeProto() switches the hash table implementation
     // from SeparateChaining to SimpleScalarSeparateChaining when there is a
     // single scalar key type with a reversible hash function.

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -882,7 +882,7 @@ void ExecutionGenerator::convertHashJoin(const P::HashJoinPtr &physical_plan) {
                                            referenced_stored_probe_relation,
                                            std::move(build_original_attribute_ids),
                                            std::move(probe_original_attribute_ids),
-                                           join_hash_table_index);
+                                           join_hash_table_group_index);
   }
 }
 

--- a/query_optimizer/ExecutionHeuristics.hpp
+++ b/query_optimizer/ExecutionHeuristics.hpp
@@ -67,14 +67,14 @@ class ExecutionHeuristics {
                  const CatalogRelation *referenced_stored_probe_relation,
                  std::vector<attribute_id> &&build_attributes,
                  std::vector<attribute_id> &&probe_attributes,
-                 const QueryContext::join_hash_table_id join_hash_table_id)
+                 const QueryContext::join_hash_table_group_id join_hash_table_group_id)
         : build_operator_index_(build_operator_index),
           join_operator_index_(join_operator_index),
           referenced_stored_build_relation_(referenced_stored_build_relation),
           referenced_stored_probe_relation_(referenced_stored_probe_relation),
           build_attributes_(std::move(build_attributes)),
           probe_attributes_(std::move(probe_attributes)),
-          join_hash_table_id_(join_hash_table_id) {
+          join_hash_table_group_id_(join_hash_table_group_id) {
     }
 
     const QueryPlan::DAGNodeIndex build_operator_index_;
@@ -83,7 +83,7 @@ class ExecutionHeuristics {
     const CatalogRelation *referenced_stored_probe_relation_;
     const std::vector<attribute_id> build_attributes_;
     const std::vector<attribute_id> probe_attributes_;
-    const QueryContext::join_hash_table_id join_hash_table_id_;
+    const QueryContext::join_hash_table_group_id join_hash_table_group_id_;
   };
 
 
@@ -102,7 +102,7 @@ class ExecutionHeuristics {
    * @param probe_relation_id Id of the relation on which hash table is being probed.
    * @param build_attributes List of attributes on which hash table is being built.
    * @param probe_attributes List of attributes on which hash table is being probed.
-   * @param join_hash_table_id Id of the hash table which refers to the actual hash
+   * @param join_hash_table_group_id Id of the hash table which refers to the actual hash
    *        table within the query context.
    **/
   inline void addHashJoinInfo(const QueryPlan::DAGNodeIndex build_operator_index,
@@ -111,14 +111,14 @@ class ExecutionHeuristics {
                               const CatalogRelation *referenced_stored_probe_relation,
                               std::vector<attribute_id> &&build_attributes,
                               std::vector<attribute_id> &&probe_attributes,
-                              const QueryContext::join_hash_table_id join_hash_table_id) {
+                              const QueryContext::join_hash_table_group_id join_hash_table_group_id) {
     hash_joins_.push_back(HashJoinInfo(build_operator_index,
                                        join_operator_index,
                                        referenced_stored_build_relation,
                                        referenced_stored_probe_relation,
                                        std::move(build_attributes),
                                        std::move(probe_attributes),
-                                       join_hash_table_id));
+                                       join_hash_table_group_id));
   }
 
   /**

--- a/query_optimizer/tests/ExecutionHeuristics_unittest.cpp
+++ b/query_optimizer/tests/ExecutionHeuristics_unittest.cpp
@@ -56,7 +56,7 @@ class ExecutionHeuristicsTest : public ::testing::Test {
                             const CatalogRelation *probe_relation,
                             const attribute_id build_attribute_id,
                             const attribute_id probe_attribute_id,
-                            const QueryContext::join_hash_table_id join_hash_table_id) {
+                            const QueryContext::join_hash_table_group_id join_hash_table_group_id) {
     std::vector<attribute_id> build_attribute_ids(1, build_attribute_id);
     std::vector<attribute_id> probe_attribute_ids(1, probe_attribute_id);
     execution_heuristics->addHashJoinInfo(build_operator_index,
@@ -65,13 +65,13 @@ class ExecutionHeuristicsTest : public ::testing::Test {
                                           probe_relation,
                                           std::move(build_attribute_ids),
                                           std::move(probe_attribute_ids),
-                                          join_hash_table_id);
+                                          join_hash_table_group_id);
   }
 
   QueryPlan::DAGNodeIndex createDummyBuildHashOperator(QueryPlan *query_plan,
                                                        const CatalogRelation *build_relation,
                                                        const attribute_id build_attribute_id,
-                                                       const QueryContext::join_hash_table_id join_hash_table_index) {
+                                                       const QueryContext::join_hash_table_group_id join_hash_table_group_index) {
     std::vector<attribute_id> build_attribute_ids;
     build_attribute_ids.push_back(build_attribute_id);
     QueryPlan::DAGNodeIndex build_operator_index =
@@ -79,7 +79,7 @@ class ExecutionHeuristicsTest : public ::testing::Test {
                                                                 true,
                                                                 build_attribute_ids,
                                                                 false,
-                                                                join_hash_table_index));
+                                                                join_hash_table_group_index));
     return build_operator_index;
   }
 
@@ -87,7 +87,7 @@ class ExecutionHeuristicsTest : public ::testing::Test {
                                                       const CatalogRelation *build_relation,
                                                       const CatalogRelation *probe_relation,
                                                       const attribute_id probe_attribute_id,
-                                                      const QueryContext::join_hash_table_id join_hash_table_index) {
+                                                      const QueryContext::join_hash_table_group_id join_hash_table_group_index) {
     std::vector<attribute_id> probe_attribute_ids;
     probe_attribute_ids.push_back(probe_attribute_id);
     QueryPlan::DAGNodeIndex join_operator_index =
@@ -98,7 +98,7 @@ class ExecutionHeuristicsTest : public ::testing::Test {
                                                                false,
                                                                *probe_relation,
                                                                0,
-                                                               join_hash_table_index,
+                                                               join_hash_table_group_index,
                                                                0,
                                                                0));
     return join_operator_index;
@@ -128,40 +128,40 @@ TEST_F(ExecutionHeuristicsTest, HashJoinOptimizedTest) {
   const attribute_id probe_attribute_id_2 = 2;
   const attribute_id probe_attribute_id_3 = 3;
 
-  const QueryContext::join_hash_table_id join_hash_table_index_1 = 0;
-  const QueryContext::join_hash_table_id join_hash_table_index_2 = 1;
-  const QueryContext::join_hash_table_id join_hash_table_index_3 = 2;
-  query_context_proto_->add_join_hash_tables();
-  query_context_proto_->add_join_hash_tables();
-  query_context_proto_->add_join_hash_tables();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index_1 = 0;
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index_2 = 1;
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index_3 = 2;
+  query_context_proto_->add_join_hash_table_groups()->add_join_hash_tables();
+  query_context_proto_->add_join_hash_table_groups()->add_join_hash_tables();
+  query_context_proto_->add_join_hash_table_groups()->add_join_hash_tables();
 
   const QueryPlan::DAGNodeIndex build_operator_index_1 = createDummyBuildHashOperator(query_plan_.get(),
                                                                                       build_relation_1,
                                                                                       build_attribute_id_1,
-                                                                                      join_hash_table_index_1);
+                                                                                      join_hash_table_group_index_1);
   const QueryPlan::DAGNodeIndex probe_operator_index_1 = createDummyHashJoinOperator(query_plan_.get(),
                                                                                      build_relation_1,
                                                                                      probe_relation_1,
                                                                                      probe_attribute_id_1,
-                                                                                     join_hash_table_index_1);
+                                                                                     join_hash_table_group_index_1);
   const QueryPlan::DAGNodeIndex build_operator_index_2 = createDummyBuildHashOperator(query_plan_.get(),
                                                                                       build_relation_2,
                                                                                       build_attribute_id_2,
-                                                                                      join_hash_table_index_2);
+                                                                                      join_hash_table_group_index_2);
   const QueryPlan::DAGNodeIndex probe_operator_index_2 = createDummyHashJoinOperator(query_plan_.get(),
                                                                                      build_relation_2,
                                                                                      probe_relation_1,
                                                                                      probe_attribute_id_2,
-                                                                                     join_hash_table_index_2);
+                                                                                     join_hash_table_group_index_2);
   const QueryPlan::DAGNodeIndex build_operator_index_3 = createDummyBuildHashOperator(query_plan_.get(),
                                                                                       build_relation_3,
                                                                                       build_attribute_id_3,
-                                                                                      join_hash_table_index_3);
+                                                                                      join_hash_table_group_index_3);
   const QueryPlan::DAGNodeIndex probe_operator_index_3 = createDummyHashJoinOperator(query_plan_.get(),
                                                                                      build_relation_3,
                                                                                      probe_relation_1,
                                                                                      probe_attribute_id_3,
-                                                                                     join_hash_table_index_3);
+                                                                                     join_hash_table_group_index_3);
 
   addDummyHashJoinInfo(execution_heuristics_.get(),
                        build_operator_index_1,
@@ -170,7 +170,7 @@ TEST_F(ExecutionHeuristicsTest, HashJoinOptimizedTest) {
                        probe_relation_1,
                        build_attribute_id_1,
                        probe_attribute_id_1,
-                       join_hash_table_index_1);
+                       join_hash_table_group_index_1);
   addDummyHashJoinInfo(execution_heuristics_.get(),
                        build_operator_index_2,
                        probe_operator_index_2,
@@ -178,7 +178,7 @@ TEST_F(ExecutionHeuristicsTest, HashJoinOptimizedTest) {
                        probe_relation_1,
                        build_attribute_id_2,
                        probe_attribute_id_2,
-                       join_hash_table_index_2);
+                       join_hash_table_group_index_2);
   addDummyHashJoinInfo(execution_heuristics_.get(),
                        build_operator_index_3,
                        probe_operator_index_3,
@@ -186,15 +186,15 @@ TEST_F(ExecutionHeuristicsTest, HashJoinOptimizedTest) {
                        probe_relation_1,
                        build_attribute_id_3,
                        probe_attribute_id_3,
-                       join_hash_table_index_3);
+                       join_hash_table_group_index_3);
 
   execution_heuristics_->optimizeExecutionPlan(query_plan_.get(), query_context_proto_.get());
 
   // Test whether correct number of bloom filters were added.
-  EXPECT_EQ(1, query_context_proto_->join_hash_tables(0).build_side_bloom_filter_id_size());
-  EXPECT_EQ(1, query_context_proto_->join_hash_tables(1).build_side_bloom_filter_id_size());
-  EXPECT_EQ(1, query_context_proto_->join_hash_tables(2).build_side_bloom_filter_id_size());
-  EXPECT_EQ(3, query_context_proto_->join_hash_tables(0).probe_side_bloom_filters_size());
+  EXPECT_EQ(1, query_context_proto_->join_hash_table_groups(0).join_hash_tables(0).build_side_bloom_filter_id_size());
+  EXPECT_EQ(1, query_context_proto_->join_hash_table_groups(1).join_hash_tables(0).build_side_bloom_filter_id_size());
+  EXPECT_EQ(1, query_context_proto_->join_hash_table_groups(2).join_hash_tables(0).build_side_bloom_filter_id_size());
+  EXPECT_EQ(3, query_context_proto_->join_hash_table_groups(0).join_hash_tables(0).probe_side_bloom_filters_size());
 
   // Test that the DAG was modified correctly or not.
   // Probe operator 1 should have now build operator 1 and build operator 2 added as dependencies.
@@ -222,40 +222,40 @@ TEST_F(ExecutionHeuristicsTest, HashJoinNotOptimizedTest) {
   const attribute_id probe_attribute_id_2 = 2;
   const attribute_id probe_attribute_id_3 = 3;
 
-  const QueryContext::join_hash_table_id join_hash_table_index_1 = 0;
-  const QueryContext::join_hash_table_id join_hash_table_index_2 = 1;
-  const QueryContext::join_hash_table_id join_hash_table_index_3 = 2;
-  query_context_proto_->add_join_hash_tables();
-  query_context_proto_->add_join_hash_tables();
-  query_context_proto_->add_join_hash_tables();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index_1 = 0;
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index_2 = 1;
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index_3 = 2;
+  query_context_proto_->add_join_hash_table_groups()->add_join_hash_tables();
+  query_context_proto_->add_join_hash_table_groups()->add_join_hash_tables();
+  query_context_proto_->add_join_hash_table_groups()->add_join_hash_tables();
 
   const QueryPlan::DAGNodeIndex build_operator_index_1 = createDummyBuildHashOperator(query_plan_.get(),
                                                                                       build_relation_1,
                                                                                       build_attribute_id_1,
-                                                                                      join_hash_table_index_1);
+                                                                                      join_hash_table_group_index_1);
   const QueryPlan::DAGNodeIndex probe_operator_index_1 = createDummyHashJoinOperator(query_plan_.get(),
                                                                                      build_relation_1,
                                                                                      probe_relation_1,
                                                                                      probe_attribute_id_1,
-                                                                                     join_hash_table_index_1);
+                                                                                     join_hash_table_group_index_1);
   const QueryPlan::DAGNodeIndex build_operator_index_2 = createDummyBuildHashOperator(query_plan_.get(),
                                                                                       build_relation_2,
                                                                                       build_attribute_id_2,
-                                                                                      join_hash_table_index_2);
+                                                                                      join_hash_table_group_index_2);
   const QueryPlan::DAGNodeIndex probe_operator_index_2 = createDummyHashJoinOperator(query_plan_.get(),
                                                                                      build_relation_2,
                                                                                      probe_relation_2,
                                                                                      probe_attribute_id_2,
-                                                                                     join_hash_table_index_2);
+                                                                                     join_hash_table_group_index_2);
   const QueryPlan::DAGNodeIndex build_operator_index_3 = createDummyBuildHashOperator(query_plan_.get(),
                                                                                       build_relation_3,
                                                                                       build_attribute_id_3,
-                                                                                      join_hash_table_index_3);
+                                                                                      join_hash_table_group_index_3);
   const QueryPlan::DAGNodeIndex probe_operator_index_3 = createDummyHashJoinOperator(query_plan_.get(),
                                                                                      build_relation_3,
                                                                                      probe_relation_3,
                                                                                      probe_attribute_id_3,
-                                                                                     join_hash_table_index_3);
+                                                                                     join_hash_table_group_index_3);
 
   addDummyHashJoinInfo(execution_heuristics_.get(),
                        build_operator_index_1,
@@ -264,7 +264,7 @@ TEST_F(ExecutionHeuristicsTest, HashJoinNotOptimizedTest) {
                        probe_relation_1,
                        build_attribute_id_1,
                        probe_attribute_id_1,
-                       join_hash_table_index_1);
+                       join_hash_table_group_index_1);
   addDummyHashJoinInfo(execution_heuristics_.get(),
                        build_operator_index_2,
                        probe_operator_index_2,
@@ -272,7 +272,7 @@ TEST_F(ExecutionHeuristicsTest, HashJoinNotOptimizedTest) {
                        probe_relation_2,
                        build_attribute_id_2,
                        probe_attribute_id_2,
-                       join_hash_table_index_2);
+                       join_hash_table_group_index_2);
   addDummyHashJoinInfo(execution_heuristics_.get(),
                        build_operator_index_3,
                        probe_operator_index_3,
@@ -280,15 +280,15 @@ TEST_F(ExecutionHeuristicsTest, HashJoinNotOptimizedTest) {
                        probe_relation_3,
                        build_attribute_id_3,
                        probe_attribute_id_3,
-                       join_hash_table_index_3);
+                       join_hash_table_group_index_3);
 
   execution_heuristics_->optimizeExecutionPlan(query_plan_.get(), query_context_proto_.get());
 
   // Test that no bloom filters were added.
-  EXPECT_EQ(0, query_context_proto_->join_hash_tables(0).build_side_bloom_filter_id_size());
-  EXPECT_EQ(0, query_context_proto_->join_hash_tables(1).build_side_bloom_filter_id_size());
-  EXPECT_EQ(0, query_context_proto_->join_hash_tables(2).build_side_bloom_filter_id_size());
-  EXPECT_EQ(0, query_context_proto_->join_hash_tables(0).probe_side_bloom_filters_size());
+  EXPECT_EQ(0, query_context_proto_->join_hash_table_groups(0).join_hash_tables(0).build_side_bloom_filter_id_size());
+  EXPECT_EQ(0, query_context_proto_->join_hash_table_groups(1).join_hash_tables(0).build_side_bloom_filter_id_size());
+  EXPECT_EQ(0, query_context_proto_->join_hash_table_groups(2).join_hash_tables(0).build_side_bloom_filter_id_size());
+  EXPECT_EQ(0, query_context_proto_->join_hash_table_groups(0).join_hash_tables(0).probe_side_bloom_filters_size());
 
   // Test that the DAG was not modified at all.
   // Probe operator 1 should not have build operator 1 and build operator 2 added as dependencies.

--- a/query_optimizer/tests/ExecutionHeuristics_unittest.cpp
+++ b/query_optimizer/tests/ExecutionHeuristics_unittest.cpp
@@ -68,10 +68,11 @@ class ExecutionHeuristicsTest : public ::testing::Test {
                                           join_hash_table_group_id);
   }
 
-  QueryPlan::DAGNodeIndex createDummyBuildHashOperator(QueryPlan *query_plan,
-                                                       const CatalogRelation *build_relation,
-                                                       const attribute_id build_attribute_id,
-                                                       const QueryContext::join_hash_table_group_id join_hash_table_group_index) {
+  QueryPlan::DAGNodeIndex createDummyBuildHashOperator(
+      QueryPlan *query_plan,
+      const CatalogRelation *build_relation,
+      const attribute_id build_attribute_id,
+      const QueryContext::join_hash_table_group_id join_hash_table_group_index) {
     std::vector<attribute_id> build_attribute_ids;
     build_attribute_ids.push_back(build_attribute_id);
     QueryPlan::DAGNodeIndex build_operator_index =
@@ -83,11 +84,12 @@ class ExecutionHeuristicsTest : public ::testing::Test {
     return build_operator_index;
   }
 
-  QueryPlan::DAGNodeIndex createDummyHashJoinOperator(QueryPlan *query_plan,
-                                                      const CatalogRelation *build_relation,
-                                                      const CatalogRelation *probe_relation,
-                                                      const attribute_id probe_attribute_id,
-                                                      const QueryContext::join_hash_table_group_id join_hash_table_group_index) {
+  QueryPlan::DAGNodeIndex createDummyHashJoinOperator(
+      QueryPlan *query_plan,
+      const CatalogRelation *build_relation,
+      const CatalogRelation *probe_relation,
+      const attribute_id probe_attribute_id,
+      const QueryContext::join_hash_table_group_id join_hash_table_group_index) {
     std::vector<attribute_id> probe_attribute_ids;
     probe_attribute_ids.push_back(probe_attribute_id);
     QueryPlan::DAGNodeIndex join_operator_index =

--- a/relational_operators/BuildHashOperator.cpp
+++ b/relational_operators/BuildHashOperator.cpp
@@ -57,7 +57,7 @@ class TupleReferenceGenerator {
 void BuildHashOperator::addWorkOrders(WorkOrdersContainer *container,
                                       QueryContext *query_context,
                                       StorageManager *storage_manager) {
-  JoinHashTable *hash_table = query_context->getJoinHashTable(hash_table_indices_[0]);
+  JoinHashTable *hash_table = query_context->getJoinHashTable(hash_table_group_index_);
   if (input_relation_is_stored_) {
     for (const block_id input_block_id : input_relation_block_ids_) {
       container->addNormalWorkOrder(new BuildHashWorkOrder(input_relation_,
@@ -91,7 +91,7 @@ void BuildHashOperator::addPartitionAwareWorkOrders(WorkOrdersContainer *contain
   if (input_relation_is_stored_) {
     for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
       for (const block_id input_block_id : input_relation_block_ids_in_partition_[part_id]) {
-        JoinHashTable *hash_table = query_context->getJoinHashTable(hash_table_indices_[part_id]);
+        JoinHashTable *hash_table = query_context->getJoinHashTable(hash_table_group_index_, part_id);
         container->addNormalWorkOrder(new BuildHashWorkOrder(input_relation_,
                                                              join_key_attributes_,
                                                              any_join_key_attributes_nullable_,
@@ -104,7 +104,7 @@ void BuildHashOperator::addPartitionAwareWorkOrders(WorkOrdersContainer *contain
     }
   } else {
     for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
-      JoinHashTable *hash_table = query_context->getJoinHashTable(hash_table_indices_[part_id]);
+      JoinHashTable *hash_table = query_context->getJoinHashTable(hash_table_group_index_, part_id);
       while (num_workorders_generated_in_partition_[part_id] <
              input_relation_block_ids_in_partition_[part_id].size()) {
         block_id block_in_partition =

--- a/relational_operators/BuildHashOperator.cpp
+++ b/relational_operators/BuildHashOperator.cpp
@@ -166,7 +166,8 @@ bool BuildHashOperator::getAllWorkOrders(WorkOrdersContainer *container,
 }
 
 void BuildHashWorkOrder::execute() {
-  BlockReference block(storage_manager_->getBlock(build_block_id_, input_relation_, getPreferredNUMANodes()[0]));
+  BlockReference block(storage_manager_->getBlock(
+      build_block_id_, input_relation_, getPreferredNUMANodes().empty() ? -1 : getPreferredNUMANodes()[0]));
 
   TupleReferenceGenerator generator(build_block_id_);
   std::unique_ptr<ValueAccessor> accessor(block->getTupleStorageSubBlock().createValueAccessor());

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -199,14 +199,16 @@ class BuildHashWorkOrder : public WorkOrder {
                      const block_id build_block_id,
                      JoinHashTable *hash_table,
                      StorageManager *storage_manager,
-                     const numa_node_id numa_node = 0)
+                     const numa_node_id numa_node = -1)
       : input_relation_(input_relation),
         join_key_attributes_(join_key_attributes),
         any_join_key_attributes_nullable_(any_join_key_attributes_nullable),
         build_block_id_(build_block_id),
         hash_table_(DCHECK_NOTNULL(hash_table)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   /**
@@ -226,14 +228,16 @@ class BuildHashWorkOrder : public WorkOrder {
                      const block_id build_block_id,
                      JoinHashTable *hash_table,
                      StorageManager *storage_manager,
-                     const numa_node_id numa_node = 0)
+                     const numa_node_id numa_node = -1)
       : input_relation_(input_relation),
         join_key_attributes_(std::move(join_key_attributes)),
         any_join_key_attributes_nullable_(any_join_key_attributes_nullable),
         build_block_id_(build_block_id),
         hash_table_(DCHECK_NOTNULL(hash_table)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   ~BuildHashWorkOrder() override {}

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -134,6 +134,8 @@ target_link_libraries(quickstep_relationaloperators_DeleteOperator
                       tmb)
 target_link_libraries(quickstep_relationaloperators_DestroyHashOperator
                       glog
+                      quickstep_catalog_CatalogRelation
+                      quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_PartitionSchemeHeader
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrdersContainer

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       glog
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionSchemeHeader
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrdersContainer
                       quickstep_relationaloperators_RelationalOperator
@@ -95,6 +96,10 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       quickstep_storage_ValueAccessor
                       quickstep_utility_Macros
                       tmb)
+if(QUICKSTEP_HAVE_LIBNUMA)
+target_link_libraries(quickstep_relationaloperators_BuildHashOperator
+                      quickstep_catalog_NUMAPlacementScheme)
+endif()
 target_link_libraries(quickstep_relationaloperators_CreateIndexOperator
                       glog
                       quickstep_catalog_CatalogRelation
@@ -129,12 +134,17 @@ target_link_libraries(quickstep_relationaloperators_DeleteOperator
                       tmb)
 target_link_libraries(quickstep_relationaloperators_DestroyHashOperator
                       glog
+                      quickstep_catalog_PartitionSchemeHeader
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrdersContainer
                       quickstep_relationaloperators_RelationalOperator
                       quickstep_relationaloperators_WorkOrder
                       quickstep_utility_Macros
                       tmb)
+if(QUICKSTEP_HAVE_LIBNUMA)
+target_link_libraries(quickstep_relationaloperators_DestroyHashOperator
+                      quickstep_catalog_NUMAPlacementScheme)
+endif()
 target_link_libraries(quickstep_relationaloperators_DropTableOperator
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -165,6 +175,7 @@ target_link_libraries(quickstep_relationaloperators_HashJoinOperator
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionSchemeHeader
                       quickstep_expressions_predicate_Predicate
                       quickstep_expressions_scalar_Scalar
                       quickstep_queryexecution_QueryContext
@@ -187,6 +198,10 @@ target_link_libraries(quickstep_relationaloperators_HashJoinOperator
                       quickstep_types_containers_ColumnVectorsValueAccessor
                       quickstep_utility_Macros
                       tmb)
+if(QUICKSTEP_HAVE_LIBNUMA)
+target_link_libraries(quickstep_relationaloperators_HashJoinOperator
+                      quickstep_catalog_NUMAPlacementScheme)
+endif()
 target_link_libraries(quickstep_relationaloperators_InsertOperator
                       glog
                       quickstep_catalog_CatalogRelation

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -32,17 +32,22 @@ bool DestroyHashOperator::getAllWorkOrders(
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;
-    std::size_t num_partitions = hash_table_indices_.size();
-    for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
-      container->addNormalWorkOrder(new DestroyHashWorkOrder(hash_table_indices_[part_id], query_context),
-                                    op_index_);
-    }
+    container->addNormalWorkOrder(new DestroyHashWorkOrder(input_relation_, hash_table_group_index_, query_context),
+                                  op_index_);
   }
   return work_generated_;
 }
 
 void DestroyHashWorkOrder::execute() {
-  query_context_->destroyJoinHashTable(hash_table_index_);
+  if (input_relation_.hasPartitionScheme()) {
+    const std::size_t num_partitions =
+        input_relation_.getPartitionScheme().getPartitionSchemeHeader().getNumPartitions();
+    for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
+      query_context_->destroyJoinHashTable(hash_table_group_index_, part_id);
+    }
+  } else {
+    query_context_->destroyJoinHashTable(hash_table_group_index_);
+  }
 }
 
 }  // namespace quickstep

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -32,8 +32,11 @@ bool DestroyHashOperator::getAllWorkOrders(
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
     work_generated_ = true;
-    container->addNormalWorkOrder(new DestroyHashWorkOrder(hash_table_index_, query_context),
-                                  op_index_);
+    std::size_t num_partitions = hash_table_indices_.size();
+    for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
+      container->addNormalWorkOrder(new DestroyHashWorkOrder(hash_table_indices_[part_id], query_context),
+                                    op_index_);
+    }
   }
   return work_generated_;
 }

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -95,11 +95,13 @@ class DestroyHashWorkOrder : public WorkOrder {
   DestroyHashWorkOrder(const CatalogRelation &input_relation,
                        const QueryContext::join_hash_table_group_id hash_table_group_index,
                        QueryContext *query_context,
-                       const numa_node_id numa_node = 0)
+                       const numa_node_id numa_node = -1)
       : input_relation_(input_relation),
         hash_table_group_index_(hash_table_group_index),
         query_context_(DCHECK_NOTNULL(query_context)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   ~DestroyHashWorkOrder() override {}

--- a/relational_operators/HashJoinOperator.cpp
+++ b/relational_operators/HashJoinOperator.cpp
@@ -250,7 +250,7 @@ void HashJoinOperator::addWorkOrders(WorkOrdersContainer *container,
                                      const Predicate *residual_predicate,
                                      const std::vector<std::unique_ptr<const Scalar>> &selection,
                                      InsertDestination *output_destination) {
-  const JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_indices_[0]));
+  const JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_group_index_));
 
     if (probe_relation_is_stored_) {
       for (const block_id probe_block_id : probe_relation_block_ids_) {
@@ -300,7 +300,7 @@ void HashJoinOperator::addPartitionAwareWorkOrders(WorkOrdersContainer *containe
     for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
       for (const block_id input_block_id :
            probe_relation_block_ids_in_partition_[part_id]) {
-        JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_indices_[part_id]));
+        JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_group_index_, part_id));
         container->addNormalWorkOrder(
             new JoinWorkOrderClass(build_relation_,
                                    probe_relation_,
@@ -318,7 +318,7 @@ void HashJoinOperator::addPartitionAwareWorkOrders(WorkOrdersContainer *containe
     }
   } else {
     for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
-      JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_indices_[part_id]));
+      JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_group_index_, part_id));
       while (num_workorders_generated_in_partition_[part_id] <
              probe_relation_block_ids_in_partition_[part_id].size()) {
         block_id block_in_partition
@@ -468,7 +468,7 @@ bool HashJoinOperator::getAllOuterJoinWorkOrders(
     WorkOrdersContainer *container,
     QueryContext *query_context,
     StorageManager *storage_manager) {
-  const JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_indices_[0]));
+  const JoinHashTable &hash_table = *(query_context->getJoinHashTable(hash_table_group_index_));
   // We wait until the building of global hash table is complete.
   if (blocking_dependencies_met_) {
     DCHECK(query_context != nullptr);

--- a/relational_operators/HashJoinOperator.cpp
+++ b/relational_operators/HashJoinOperator.cpp
@@ -535,7 +535,7 @@ void HashInnerJoinWorkOrder::executeWithCollectorType() {
   BlockReference probe_block(
       storage_manager_->getBlock(block_id_,
                                  probe_relation_,
-                                 getPreferredNUMANodes()[0]));
+                                 getPreferredNUMANodes().empty() ? -1 : getPreferredNUMANodes()[0]));
   const TupleStorageSubBlock &probe_store = probe_block->getTupleStorageSubBlock();
 
   std::unique_ptr<ValueAccessor> probe_accessor(probe_store.createValueAccessor());
@@ -560,8 +560,8 @@ void HashInnerJoinWorkOrder::executeWithCollectorType() {
 
   for (std::pair<const block_id, std::vector<std::pair<tuple_id, tuple_id>>>
            &build_block_entry : *collector.getJoinedTuples()) {
-    BlockReference build_block =
-        storage_manager_->getBlock(build_block_entry.first, build_relation_, getPreferredNUMANodes()[0]);
+    BlockReference build_block = storage_manager_->getBlock(
+        build_block_entry.first, build_relation_, getPreferredNUMANodes().empty() ? -1 : getPreferredNUMANodes()[0]);
     const TupleStorageSubBlock &build_store = build_block->getTupleStorageSubBlock();
     std::unique_ptr<ValueAccessor> build_accessor(build_store.createValueAccessor());
 

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -103,7 +103,7 @@ class HashJoinOperator : public RelationalOperator {
    * @param output_relation The output relation.
    * @param output_destination_index The index of the InsertDestination in the
    *        QueryContext to insert the join results.
-   * @param hash_table_index The index of the JoinHashTable in QueryContext.
+   * @param hash_table_indices The index of the JoinHashTable in QueryContext.
    * @param residual_predicate_index If not kInvalidPredicateId, apply as an
    *        additional filter to pairs of tuples that match the hash-join (i.e.
    *        key equality) predicate. Effectively, this makes the join predicate
@@ -125,7 +125,7 @@ class HashJoinOperator : public RelationalOperator {
                    const bool any_join_key_attributes_nullable,
                    const CatalogRelation &output_relation,
                    const QueryContext::insert_destination_id output_destination_index,
-                   const std::vector<QueryContext::join_hash_table_id> &hash_table_index,
+                   const std::vector<QueryContext::join_hash_table_id> &hash_table_indices,
                    const QueryContext::predicate_id residual_predicate_index,
                    const QueryContext::scalar_group_id selection_index,
                    const std::vector<bool> *is_selection_on_build = nullptr,
@@ -161,7 +161,7 @@ class HashJoinOperator : public RelationalOperator {
       num_workorders_generated_in_partition_.resize(num_partitions);
       num_workorders_generated_in_partition_.assign(num_partitions, 0);
       for (int part_id = 0; part_id < num_partitions; ++part_id) {
-        hash_table_index_[part_id] = hash_table_index[part_id];
+        hash_table_indices_[part_id] = hash_table_indices[part_id];
         if (probe_relation_is_stored) {
           probe_relation_block_ids_in_partition_[part_id] = part_scheme.getBlocksInPartition(part_id);
         } else {
@@ -232,6 +232,7 @@ class HashJoinOperator : public RelationalOperator {
                      const std::vector<std::unique_ptr<const Scalar>> &selection,
                      InsertDestination *output_destination);
 
+#ifdef QUICKSTEP_HAVE_LIBNUMA
   template <class JoinWorkOrderClass>
   void addPartitionAwareWorkOrders(WorkOrdersContainer *container,
                                    QueryContext *query_context,
@@ -239,6 +240,8 @@ class HashJoinOperator : public RelationalOperator {
                                    const Predicate *predicate,
                                    const std::vector<std::unique_ptr<const Scalar>> &selection,
                                    InsertDestination *output_destination);
+#endif
+
  private:
   template <class JoinWorkOrderClass>
   bool getAllNonOuterJoinWorkOrders(WorkOrdersContainer *container,
@@ -256,7 +259,7 @@ class HashJoinOperator : public RelationalOperator {
   const bool any_join_key_attributes_nullable_;
   const CatalogRelation &output_relation_;
   const QueryContext::insert_destination_id output_destination_index_;
-  std::vector<QueryContext::join_hash_table_id> hash_table_index_;
+  std::vector<QueryContext::join_hash_table_id> hash_table_indices_;
   const QueryContext::predicate_id residual_predicate_index_;
   const QueryContext::scalar_group_id selection_index_;
   const std::vector<bool> is_selection_on_build_;

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -104,7 +104,7 @@ class HashJoinOperator : public RelationalOperator {
    * @param output_relation The output relation.
    * @param output_destination_index The index of the InsertDestination in the
    *        QueryContext to insert the join results.
-   * @param hash_table_indices The index of the JoinHashTable in QueryContext.
+   * @param hash_table_index The index of the JoinHashTable in QueryContext.
    * @param residual_predicate_index If not kInvalidPredicateId, apply as an
    *        additional filter to pairs of tuples that match the hash-join (i.e.
    *        key equality) predicate. Effectively, this makes the join predicate
@@ -126,7 +126,7 @@ class HashJoinOperator : public RelationalOperator {
                    const bool any_join_key_attributes_nullable,
                    const CatalogRelation &output_relation,
                    const QueryContext::insert_destination_id output_destination_index,
-                   const std::vector<QueryContext::join_hash_table_id> &hash_table_indices,
+                   const QueryContext::join_hash_table_group_id hash_table_group_index,
                    const QueryContext::predicate_id residual_predicate_index,
                    const QueryContext::scalar_group_id selection_index,
                    const std::vector<bool> *is_selection_on_build = nullptr,
@@ -138,6 +138,7 @@ class HashJoinOperator : public RelationalOperator {
         any_join_key_attributes_nullable_(any_join_key_attributes_nullable),
         output_relation_(output_relation),
         output_destination_index_(output_destination_index),
+        hash_table_group_index_(hash_table_group_index),
         residual_predicate_index_(residual_predicate_index),
         selection_index_(selection_index),
         is_selection_on_build_(is_selection_on_build == nullptr
@@ -161,8 +162,7 @@ class HashJoinOperator : public RelationalOperator {
       probe_relation_block_ids_in_partition_.resize(num_partitions);
       num_workorders_generated_in_partition_.resize(num_partitions);
       num_workorders_generated_in_partition_.assign(num_partitions, 0);
-      for (int part_id = 0; part_id < num_partitions; ++part_id) {
-        hash_table_indices_[part_id] = hash_table_indices[part_id];
+      for (std::size_t part_id = 0; part_id < num_partitions; ++part_id) {
         if (probe_relation_is_stored) {
           probe_relation_block_ids_in_partition_[part_id] = part_scheme.getBlocksInPartition(part_id);
         } else {
@@ -260,7 +260,7 @@ class HashJoinOperator : public RelationalOperator {
   const bool any_join_key_attributes_nullable_;
   const CatalogRelation &output_relation_;
   const QueryContext::insert_destination_id output_destination_index_;
-  std::vector<QueryContext::join_hash_table_id> hash_table_indices_;
+  const QueryContext::join_hash_table_group_id hash_table_group_index_;
   const QueryContext::predicate_id residual_predicate_index_;
   const QueryContext::scalar_group_id selection_index_;
   const std::vector<bool> is_selection_on_build_;

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -318,7 +318,7 @@ class HashInnerJoinWorkOrder : public WorkOrder {
                          const JoinHashTable &hash_table,
                          InsertDestination *output_destination,
                          StorageManager *storage_manager,
-                         const numa_node_id numa_node = 0)
+                         const numa_node_id numa_node = -1)
       : build_relation_(build_relation),
         probe_relation_(probe_relation),
         join_key_attributes_(join_key_attributes),
@@ -329,7 +329,9 @@ class HashInnerJoinWorkOrder : public WorkOrder {
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   /**
@@ -364,7 +366,7 @@ class HashInnerJoinWorkOrder : public WorkOrder {
                          const JoinHashTable &hash_table,
                          InsertDestination *output_destination,
                          StorageManager *storage_manager,
-                         const numa_node_id numa_node = 0)
+                         const numa_node_id numa_node = -1)
       : build_relation_(build_relation),
         probe_relation_(probe_relation),
         join_key_attributes_(std::move(join_key_attributes)),
@@ -375,7 +377,9 @@ class HashInnerJoinWorkOrder : public WorkOrder {
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   ~HashInnerJoinWorkOrder() override {}
@@ -447,7 +451,7 @@ class HashSemiJoinWorkOrder : public WorkOrder {
                         const JoinHashTable &hash_table,
                         InsertDestination *output_destination,
                         StorageManager *storage_manager,
-                        const numa_node_id numa_node = 0)
+                        const numa_node_id numa_node = -1)
       : build_relation_(build_relation),
         probe_relation_(probe_relation),
         join_key_attributes_(join_key_attributes),
@@ -458,7 +462,9 @@ class HashSemiJoinWorkOrder : public WorkOrder {
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   /**
@@ -493,7 +499,7 @@ class HashSemiJoinWorkOrder : public WorkOrder {
                         const JoinHashTable &hash_table,
                         InsertDestination *output_destination,
                         StorageManager *storage_manager,
-                        const numa_node_id numa_node = 0)
+                        const numa_node_id numa_node = -1)
       : build_relation_(build_relation),
         probe_relation_(probe_relation),
         join_key_attributes_(std::move(join_key_attributes)),
@@ -504,7 +510,9 @@ class HashSemiJoinWorkOrder : public WorkOrder {
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   ~HashSemiJoinWorkOrder() override {}
@@ -569,7 +577,7 @@ class HashAntiJoinWorkOrder : public WorkOrder {
                         const JoinHashTable &hash_table,
                         InsertDestination *output_destination,
                         StorageManager *storage_manager,
-                        const numa_node_id numa_node = 0)
+                        const numa_node_id numa_node = -1)
       : build_relation_(build_relation),
         probe_relation_(probe_relation),
         join_key_attributes_(join_key_attributes),
@@ -580,7 +588,9 @@ class HashAntiJoinWorkOrder : public WorkOrder {
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   /**
@@ -615,7 +625,7 @@ class HashAntiJoinWorkOrder : public WorkOrder {
                         const JoinHashTable &hash_table,
                         InsertDestination *output_destination,
                         StorageManager *storage_manager,
-                        const numa_node_id numa_node = 0)
+                        const numa_node_id numa_node = -1)
       : build_relation_(build_relation),
         probe_relation_(probe_relation),
         join_key_attributes_(std::move(join_key_attributes)),
@@ -626,7 +636,9 @@ class HashAntiJoinWorkOrder : public WorkOrder {
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   ~HashAntiJoinWorkOrder() override {}

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -32,6 +32,7 @@
 #include "catalog/NUMAPlacementScheme.hpp"
 #endif
 
+#include "catalog/PartitionSchemeHeader.hpp"
 #include "query_execution/QueryContext.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"

--- a/relational_operators/SelectOperator.cpp
+++ b/relational_operators/SelectOperator.cpp
@@ -168,17 +168,13 @@ bool SelectOperator::getAllWorkOrders(
 }
 
 void SelectWorkOrder::execute() {
-  BlockReference block(
-      storage_manager_->getBlock(input_block_id_, input_relation_, getPreferredNUMANodes()[0]));
+  BlockReference block(storage_manager_->getBlock(
+      input_block_id_, input_relation_, getPreferredNUMANodes().empty() ? -1 : getPreferredNUMANodes()[0]));
 
   if (simple_projection_) {
-    block->selectSimple(simple_selection_,
-                        predicate_,
-                        output_destination_);
+    block->selectSimple(simple_selection_, predicate_, output_destination_);
   } else {
-    block->select(*DCHECK_NOTNULL(selection_),
-                  predicate_,
-                  output_destination_);
+    block->select(*DCHECK_NOTNULL(selection_), predicate_, output_destination_);
   }
 }
 

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -293,7 +293,7 @@ class SelectWorkOrder : public WorkOrder {
                   const std::vector<std::unique_ptr<const Scalar>> *selection,
                   InsertDestination *output_destination,
                   StorageManager *storage_manager,
-                  const numa_node_id numa_node = 0)
+                  const numa_node_id numa_node = -1)
       : input_relation_(input_relation),
         input_block_id_(input_block_id),
         predicate_(predicate),
@@ -302,7 +302,9 @@ class SelectWorkOrder : public WorkOrder {
         selection_(selection),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   /**
@@ -332,7 +334,7 @@ class SelectWorkOrder : public WorkOrder {
                   const std::vector<std::unique_ptr<const Scalar>> *selection,
                   InsertDestination *output_destination,
                   StorageManager *storage_manager,
-                  const numa_node_id numa_node = 0)
+                  const numa_node_id numa_node = -1)
       : input_relation_(input_relation),
         input_block_id_(input_block_id),
         predicate_(predicate),
@@ -341,7 +343,9 @@ class SelectWorkOrder : public WorkOrder {
         selection_(selection),
         output_destination_(DCHECK_NOTNULL(output_destination)),
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {
-    preferred_numa_nodes_.push_back(numa_node);
+    if (numa_node != -1) {
+      preferred_numa_nodes_.push_back(numa_node);
+    }
   }
 
   ~SelectWorkOrder() override {}

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -65,9 +65,9 @@ message BuildHashWorkOrder {
     optional int32 relation_id = 32;
     repeated int32 join_key_attributes = 33;
     optional bool any_join_key_attributes_nullable = 34;
-    optional uint32 join_hash_table_index = 35;
-    optional fixed64 block_id = 36;
-    optional uint32 join_hash_table_part_index = 37;
+    optional uint32 join_hash_table_group_index = 35;
+    optional uint32 join_hash_table_index = 36;
+    optional fixed64 block_id = 37;
   }
 }
 
@@ -85,8 +85,7 @@ message DestroyHashWorkOrder {
   extend WorkOrder {
     // All required.
     optional int32 relation_id = 112;
-    optional uint32 join_hash_table_index = 113;
-    optional uint32 join_hash_table_part_index = 114;
+    optional uint32 join_hash_table_group_index = 113;
   }
 }
 
@@ -123,15 +122,15 @@ message HashJoinWorkOrder {
     repeated int32 join_key_attributes = 163;
     optional bool any_join_key_attributes_nullable = 164;
     optional int32 insert_destination_index = 165;
-    optional uint32 join_hash_table_index = 166;
-    optional int32 selection_index = 167;
-    optional fixed64 block_id = 168;
+    optional uint32 join_hash_table_group_index = 166;
+    optional uint32 join_hash_table_index = 167;
+    optional int32 selection_index = 168;
+    optional fixed64 block_id = 169;
 
     // Used by all but HashOuterJoinWorkOrder.
-    optional int32 residual_predicate_index = 169;
+    optional int32 residual_predicate_index = 170;
     // Used by HashOuterJoinWorkOrder only.
-    repeated bool is_selection_on_build = 170;
-    optional uint32 join_hash_table_part_index = 171;
+    repeated bool is_selection_on_build = 171;
   }
 }
 

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -67,6 +67,7 @@ message BuildHashWorkOrder {
     optional bool any_join_key_attributes_nullable = 34;
     optional uint32 join_hash_table_index = 35;
     optional fixed64 block_id = 36;
+    optional uint32 join_hash_table_part_index = 37;
   }
 }
 
@@ -83,7 +84,9 @@ message DeleteWorkOrder {
 message DestroyHashWorkOrder {
   extend WorkOrder {
     // All required.
-    optional uint32 join_hash_table_index = 112;
+    optional int32 relation_id = 112;
+    optional uint32 join_hash_table_index = 113;
+    optional uint32 join_hash_table_part_index = 114;
   }
 }
 
@@ -128,6 +131,7 @@ message HashJoinWorkOrder {
     optional int32 residual_predicate_index = 169;
     // Used by HashOuterJoinWorkOrder only.
     repeated bool is_selection_on_build = 170;
+    optional uint32 join_hash_table_part_index = 171;
   }
 }
 

--- a/relational_operators/WorkOrderFactory.cpp
+++ b/relational_operators/WorkOrderFactory.cpp
@@ -93,8 +93,8 @@ WorkOrder* WorkOrderFactory::ReconstructFromProto(const serialization::WorkOrder
           proto.GetExtension(serialization::BuildHashWorkOrder::any_join_key_attributes_nullable),
           proto.GetExtension(serialization::BuildHashWorkOrder::block_id),
           query_context->getJoinHashTable(
-              proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_index),
-              proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_part_index)),
+              proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_group_index),
+              proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_index)),
           storage_manager);
     }
     case serialization::DELETE: {
@@ -113,8 +113,8 @@ WorkOrder* WorkOrderFactory::ReconstructFromProto(const serialization::WorkOrder
     case serialization::DESTROY_HASH: {
       LOG(INFO) << "Creating DestroyHashWorkOrder";
       return new DestroyHashWorkOrder(
-          catalog_database->getRelationSchemaById(proto.GetExtension(serialization::DestroyHashWorkOrder::relation_id))
-          proto.GetExtension(serialization::DestroyHashWorkOrder::join_hash_table_index),
+          *(catalog_database->getRelationById(proto.GetExtension(serialization::DestroyHashWorkOrder::relation_id))),
+          proto.GetExtension(serialization::DestroyHashWorkOrder::join_hash_table_group_index),
           query_context);
     }
     case serialization::DROP_TABLE: {
@@ -177,8 +177,8 @@ WorkOrder* WorkOrderFactory::ReconstructFromProto(const serialization::WorkOrder
               proto.GetExtension(serialization::HashJoinWorkOrder::selection_index));
       const JoinHashTable &hash_table =
           *query_context->getJoinHashTable(
-              proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_index),
-              proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_part_index));
+              proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_group_index),
+              proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_index));
       InsertDestination *output_destination =
           query_context->getInsertDestination(
               proto.GetExtension(serialization::HashJoinWorkOrder::insert_destination_index));
@@ -455,9 +455,9 @@ bool WorkOrderFactory::ProtoIsValid(const serialization::WorkOrder &proto,
 
       return proto.HasExtension(serialization::BuildHashWorkOrder::any_join_key_attributes_nullable) &&
              proto.HasExtension(serialization::BuildHashWorkOrder::block_id) &&
-             proto.HasExtension(serialization::BuildHashWorkOrder::join_hash_table_index) &&
+             proto.HasExtension(serialization::BuildHashWorkOrder::join_hash_table_group_index) &&
              query_context.isValidJoinHashTableId(
-                 proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_index));
+                 proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_group_index));
     }
     case serialization::DELETE: {
       return proto.HasExtension(serialization::DeleteWorkOrder::relation_id) &&
@@ -470,9 +470,9 @@ bool WorkOrderFactory::ProtoIsValid(const serialization::WorkOrder &proto,
              proto.HasExtension(serialization::DeleteWorkOrder::operator_index);
     }
     case serialization::DESTROY_HASH: {
-      return proto.HasExtension(serialization::DestroyHashWorkOrder::join_hash_table_index) &&
+      return proto.HasExtension(serialization::DestroyHashWorkOrder::join_hash_table_group_index) &&
              query_context.isValidJoinHashTableId(
-                 proto.GetExtension(serialization::DestroyHashWorkOrder::join_hash_table_index)) &&
+                 proto.GetExtension(serialization::DestroyHashWorkOrder::join_hash_table_group_index)) &&
              proto.HasExtension(serialization::DestroyHashWorkOrder::relation_id);
     }
     case serialization::DROP_TABLE: {
@@ -541,9 +541,9 @@ bool WorkOrderFactory::ProtoIsValid(const serialization::WorkOrder &proto,
              proto.HasExtension(serialization::HashJoinWorkOrder::insert_destination_index) &&
              query_context.isValidInsertDestinationId(
                  proto.GetExtension(serialization::HashJoinWorkOrder::insert_destination_index)) &&
-             proto.HasExtension(serialization::HashJoinWorkOrder::join_hash_table_index) &&
+             proto.HasExtension(serialization::HashJoinWorkOrder::join_hash_table_group_index) &&
              query_context.isValidJoinHashTableId(
-                 proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_index)) &&
+                 proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_group_index)) &&
              proto.HasExtension(serialization::HashJoinWorkOrder::selection_index) &&
              query_context.isValidScalarGroupId(
                  proto.GetExtension(serialization::HashJoinWorkOrder::selection_index)) &&

--- a/relational_operators/WorkOrderFactory.cpp
+++ b/relational_operators/WorkOrderFactory.cpp
@@ -457,7 +457,10 @@ bool WorkOrderFactory::ProtoIsValid(const serialization::WorkOrder &proto,
              proto.HasExtension(serialization::BuildHashWorkOrder::block_id) &&
              proto.HasExtension(serialization::BuildHashWorkOrder::join_hash_table_group_index) &&
              query_context.isValidJoinHashTableId(
-                 proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_group_index));
+                 proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_group_index)) &&
+             proto.HasExtension(serialization::BuildHashWorkOrder::join_hash_table_index) &&
+             query_context.isValidJoinHashTableId(
+                 proto.GetExtension(serialization::BuildHashWorkOrder::join_hash_table_index));
     }
     case serialization::DELETE: {
       return proto.HasExtension(serialization::DeleteWorkOrder::relation_id) &&
@@ -544,6 +547,9 @@ bool WorkOrderFactory::ProtoIsValid(const serialization::WorkOrder &proto,
              proto.HasExtension(serialization::HashJoinWorkOrder::join_hash_table_group_index) &&
              query_context.isValidJoinHashTableId(
                  proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_group_index)) &&
+             proto.HasExtension(serialization::HashJoinWorkOrder::join_hash_table_index) &&
+             query_context.isValidJoinHashTableId(
+                 proto.GetExtension(serialization::HashJoinWorkOrder::join_hash_table_index)) &&
              proto.HasExtension(serialization::HashJoinWorkOrder::selection_index) &&
              query_context.isValidScalarGroupId(
                  proto.GetExtension(serialization::HashJoinWorkOrder::selection_index)) &&

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -294,12 +294,11 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
-  join_hash_table_indices.resize(1);
-  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index =
+      query_context_proto.join_hash_table_groups_size();
 
   serialization::HashTable *hash_table_proto =
-      query_context_proto.add_join_hash_tables();
+      query_context_proto.add_join_hash_table_groups()->add_join_hash_tables();
   switch (GetParam()) {
     case HashTableImplType::kLinearOpenAddressing:
       hash_table_proto->set_hash_table_impl_type(
@@ -337,7 +336,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_long.getID()),
                             dim_col_long.getType().isNullable(),
-                            join_hash_table_indices));
+                            join_hash_table_group_index));
 
   // Create the prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -367,7 +366,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
                            fact_col_long.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_indices,
+                           join_hash_table_group_index,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -422,7 +421,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(*dim_table_, join_hash_table_group_index));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -433,12 +432,11 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
-  join_hash_table_indices.resize(1);
-  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index =
+      query_context_proto.join_hash_table_groups_size();
 
   serialization::HashTable *hash_table_proto =
-      query_context_proto.add_join_hash_tables();
+      query_context_proto.add_join_hash_table_groups()->add_join_hash_tables();
   switch (GetParam()) {
     case HashTableImplType::kLinearOpenAddressing:
       hash_table_proto->set_hash_table_impl_type(
@@ -479,7 +477,7 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_int.getID()),
                             dim_col_int.getType().isNullable(),
-                            join_hash_table_indices));
+                            join_hash_table_group_index));
 
   // Create the prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -514,7 +512,7 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
                            fact_col_int.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_indices,
+                           join_hash_table_group_index,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -590,7 +588,7 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(*dim_table_, join_hash_table_group_index));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -601,12 +599,11 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
-  join_hash_table_indices.resize(1);
-  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index =
+      query_context_proto.join_hash_table_groups_size();
 
   serialization::HashTable *hash_table_proto =
-      query_context_proto.add_join_hash_tables();
+      query_context_proto.add_join_hash_table_groups()->add_join_hash_tables();
   switch (GetParam()) {
     case HashTableImplType::kLinearOpenAddressing:
       hash_table_proto->set_hash_table_impl_type(
@@ -639,7 +636,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_char.getID()),
                             dim_col_char.getType().isNullable(),
-                            join_hash_table_indices));
+                            join_hash_table_group_index));
 
   // Create prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -669,7 +666,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
                            fact_col_char.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_indices,
+                           join_hash_table_group_index,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -724,7 +721,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(*dim_table_, join_hash_table_group_index));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -735,12 +732,11 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
-  join_hash_table_indices.resize(1);
-  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index =
+      query_context_proto.join_hash_table_groups_size();
 
   serialization::HashTable *hash_table_proto =
-      query_context_proto.add_join_hash_tables();
+      query_context_proto.add_join_hash_table_groups()->add_join_hash_tables();
   switch (GetParam()) {
     case HashTableImplType::kLinearOpenAddressing:
       hash_table_proto->set_hash_table_impl_type(
@@ -774,7 +770,7 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_varchar.getID()),
                             dim_col_varchar.getType().isNullable(),
-                            join_hash_table_indices));
+                            join_hash_table_group_index));
 
   // Create prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -809,7 +805,7 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
                            fact_col_varchar.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_indices,
+                           join_hash_table_group_index,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -889,7 +885,7 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
   }
 
   // Create the cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(*dim_table_, join_hash_table_group_index));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -900,12 +896,11 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
-  join_hash_table_indices.resize(1);
-  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index =
+      query_context_proto.join_hash_table_groups_size();
 
   serialization::HashTable *hash_table_proto =
-      query_context_proto.add_join_hash_tables();
+      query_context_proto.add_join_hash_table_groups()->add_join_hash_tables();
   switch (GetParam()) {
     case HashTableImplType::kLinearOpenAddressing:
       hash_table_proto->set_hash_table_impl_type(
@@ -944,7 +939,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
                             true /* is_stored */,
                             dim_key_attrs,
                             dim_col_long.getType().isNullable() || dim_col_varchar.getType().isNullable(),
-                            join_hash_table_indices));
+                            join_hash_table_group_index));
 
   // Create the prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -983,7 +978,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
                            fact_col_long.getType().isNullable() || fact_col_varchar.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_indices,
+                           join_hash_table_group_index,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -1063,7 +1058,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(*dim_table_, join_hash_table_group_index));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -1075,12 +1070,11 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
-  join_hash_table_indices.resize(1);
-  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
+  const QueryContext::join_hash_table_group_id join_hash_table_group_index =
+      query_context_proto.join_hash_table_groups_size();
 
   serialization::HashTable *hash_table_proto =
-      query_context_proto.add_join_hash_tables();
+      query_context_proto.add_join_hash_table_groups()->add_join_hash_tables();
   switch (GetParam()) {
     case HashTableImplType::kLinearOpenAddressing:
       hash_table_proto->set_hash_table_impl_type(
@@ -1119,7 +1113,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
                             true /* is_stored */,
                             dim_key_attrs,
                             dim_col_long.getType().isNullable() || dim_col_varchar.getType().isNullable(),
-                            join_hash_table_indices));
+                            join_hash_table_group_index));
 
   // Create prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -1168,7 +1162,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
                            fact_col_long.getType().isNullable() || fact_col_varchar.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_indices,
+                           join_hash_table_group_index,
                            residual_pred_index,
                            selection_index));
 
@@ -1248,7 +1242,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(*dim_table_, join_hash_table_group_index));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -294,8 +294,9 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  const QueryContext::join_hash_table_id join_hash_table_index =
-      query_context_proto.join_hash_tables_size();
+  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
+  join_hash_table_indices.resize(1);
+  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
 
   serialization::HashTable *hash_table_proto =
       query_context_proto.add_join_hash_tables();
@@ -336,7 +337,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_long.getID()),
                             dim_col_long.getType().isNullable(),
-                            join_hash_table_index));
+                            join_hash_table_indices));
 
   // Create the prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -366,7 +367,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
                            fact_col_long.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_index,
+                           join_hash_table_indices,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -421,7 +422,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_index));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -432,8 +433,9 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  const QueryContext::join_hash_table_id join_hash_table_index =
-      query_context_proto.join_hash_tables_size();
+  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
+  join_hash_table_indices.resize(1);
+  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
 
   serialization::HashTable *hash_table_proto =
       query_context_proto.add_join_hash_tables();
@@ -477,7 +479,7 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_int.getID()),
                             dim_col_int.getType().isNullable(),
-                            join_hash_table_index));
+                            join_hash_table_indices));
 
   // Create the prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -512,7 +514,7 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
                            fact_col_int.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_index,
+                           join_hash_table_indices,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -588,7 +590,7 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_index));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -599,8 +601,9 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  const QueryContext::join_hash_table_id join_hash_table_index =
-      query_context_proto.join_hash_tables_size();
+  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
+  join_hash_table_indices.resize(1);
+  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
 
   serialization::HashTable *hash_table_proto =
       query_context_proto.add_join_hash_tables();
@@ -636,7 +639,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_char.getID()),
                             dim_col_char.getType().isNullable(),
-                            join_hash_table_index));
+                            join_hash_table_indices));
 
   // Create prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -666,7 +669,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
                            fact_col_char.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_index,
+                           join_hash_table_indices,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -721,7 +724,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_index));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -732,8 +735,9 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  const QueryContext::join_hash_table_id join_hash_table_index =
-      query_context_proto.join_hash_tables_size();
+  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
+  join_hash_table_indices.resize(1);
+  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
 
   serialization::HashTable *hash_table_proto =
       query_context_proto.add_join_hash_tables();
@@ -770,7 +774,7 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
                             true /* is_stored */,
                             std::vector<attribute_id>(1, dim_col_varchar.getID()),
                             dim_col_varchar.getType().isNullable(),
-                            join_hash_table_index));
+                            join_hash_table_indices));
 
   // Create prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -805,7 +809,7 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
                            fact_col_varchar.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_index,
+                           join_hash_table_indices,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -885,7 +889,7 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
   }
 
   // Create the cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_index));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -896,8 +900,9 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  const QueryContext::join_hash_table_id join_hash_table_index =
-      query_context_proto.join_hash_tables_size();
+  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
+  join_hash_table_indices.resize(1);
+  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
 
   serialization::HashTable *hash_table_proto =
       query_context_proto.add_join_hash_tables();
@@ -939,7 +944,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
                             true /* is_stored */,
                             dim_key_attrs,
                             dim_col_long.getType().isNullable() || dim_col_varchar.getType().isNullable(),
-                            join_hash_table_index));
+                            join_hash_table_indices));
 
   // Create the prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -978,7 +983,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
                            fact_col_long.getType().isNullable() || fact_col_varchar.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_index,
+                           join_hash_table_indices,
                            QueryContext::kInvalidPredicateId /* residual_predicate_index */,
                            selection_index));
 
@@ -1058,7 +1063,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_index));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
@@ -1070,8 +1075,9 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
   // Setup the hash table proto in the query context proto.
   serialization::QueryContext query_context_proto;
 
-  const QueryContext::join_hash_table_id join_hash_table_index =
-      query_context_proto.join_hash_tables_size();
+  std::vector<QueryContext::join_hash_table_id> join_hash_table_indices;
+  join_hash_table_indices.resize(1);
+  join_hash_table_indices[0] = query_context_proto.join_hash_tables_size();
 
   serialization::HashTable *hash_table_proto =
       query_context_proto.add_join_hash_tables();
@@ -1113,7 +1119,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
                             true /* is_stored */,
                             dim_key_attrs,
                             dim_col_long.getType().isNullable() || dim_col_varchar.getType().isNullable(),
-                            join_hash_table_index));
+                            join_hash_table_indices));
 
   // Create prober operator with two selection attributes.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
@@ -1162,7 +1168,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
                            fact_col_long.getType().isNullable() || fact_col_varchar.getType().isNullable(),
                            *result_table,
                            output_destination_index,
-                           join_hash_table_index,
+                           join_hash_table_indices,
                            residual_pred_index,
                            selection_index));
 
@@ -1242,7 +1248,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
   }
 
   // Create cleaner operator.
-  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_index));
+  unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(join_hash_table_indices));
   cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 


### PR DESCRIPTION
I have made some initial changes to the HashJoinOperator.

It seems that the HashJoin code has changed a lot from what we had for before, when Harshad and I worked on making it partition-aware for the quickstep group paper.

So, I would like to get some initial feedback from @hbdeshmukh and @zuyu before making any more changes.

NOTE: I haven't updated the tests yet and so the travis builds would fail.
