### PR TITLE
Print number of rows in the output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,7 +712,8 @@ target_link_libraries(quickstep_cli_shell
                       quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
-                      quickstep_utility_SqlError)
+                      quickstep_utility_SqlError
+                      quickstep_utility_StringUtil)
 if (ENABLE_HDFS)
   target_link_libraries(quickstep_cli_shell
                         quickstep_storage_FileManagerHdfs)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(quickstep_cli_PrintToScreen
                       quickstep_storage_StorageManager
                       quickstep_storage_TupleIdSequence
                       quickstep_storage_TupleStorageSubBlock
+                      quickstep_types_IntType
                       quickstep_types_Type
                       quickstep_types_TypedValue
                       quickstep_utility_Macros)

--- a/cli/PrintToScreen.cpp
+++ b/cli/PrintToScreen.cpp
@@ -162,9 +162,11 @@ std::size_t PrintToScreen::GetNumTuplesInRelation(
 void PrintToScreen::PrintOutputSize(const CatalogRelation &relation,
                                     StorageManager *storage_manager,
                                     FILE *out) {
+  const std::size_t num_rows = GetNumTuplesInRelation(relation, storage_manager);
   fprintf(out,
-          "( %lu rows )\n",
-          GetNumTuplesInRelation(relation, storage_manager));
+          "(%lu %s)\n",
+          num_rows,
+          (num_rows == 1) ? "row" : "rows");
 }
 
 }  // namespace quickstep

--- a/cli/PrintToScreen.cpp
+++ b/cli/PrintToScreen.cpp
@@ -29,6 +29,7 @@
 #include "storage/StorageManager.hpp"
 #include "storage/TupleIdSequence.hpp"
 #include "storage/TupleStorageSubBlock.hpp"
+#include "types/IntType.hpp"
 #include "types/Type.hpp"
 #include "types/TypedValue.hpp"
 #include "utility/Macros.hpp"
@@ -145,6 +146,25 @@ void PrintToScreen::printTuple(const TupleStorageSubBlock &tuple_store,
     fputc('|', out);
   }
   fputc('\n', out);
+}
+
+std::size_t PrintToScreen::GetNumTuplesInRelation(
+    const CatalogRelation &relation, StorageManager *storage_manager) {
+  const std::vector<block_id> &blocks = relation.getBlocksSnapshot();
+  std::size_t total_num_tuples = 0;
+  for (block_id block : blocks) {
+    total_num_tuples +=
+        storage_manager->getBlock(block, relation)->getNumTuples();
+  }
+  return total_num_tuples;
+}
+
+void PrintToScreen::PrintOutputSize(const CatalogRelation &relation,
+                                    StorageManager *storage_manager,
+                                    FILE *out) {
+  fprintf(out,
+          "( %lu rows )\n",
+          GetNumTuplesInRelation(relation, storage_manager));
 }
 
 }  // namespace quickstep

--- a/cli/PrintToScreen.hpp
+++ b/cli/PrintToScreen.hpp
@@ -46,6 +46,29 @@ class PrintToScreen {
 
   static void printHBar(const std::vector<int> &column_widths,
                         FILE *out);
+
+  /**
+   * @brief Get the total number of tuples in the given relation.
+   *
+   * @param relation The given relation.
+   * @param storage_manager The storage manager.
+   *
+   * @return The total number of tuples in the relation.
+   **/
+  static std::size_t GetNumTuplesInRelation(const CatalogRelation &relation,
+                                            StorageManager *storage_manager);
+
+  /**
+   * @brief Print the size of the output (i.e. number of rows in the relation).
+   *
+   * @param relation The given relation.
+   * @param storage_manager The storage manager.
+   * @param out The output stream.
+   **/
+  static void PrintOutputSize(const CatalogRelation &relation,
+                              StorageManager *storage_manager,
+                              FILE *out);
+
  private:
   // Undefined default constructor. Class is all-static and should not be
   // instantiated.

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -72,6 +72,7 @@ typedef quickstep::LineReaderDumb LineReaderImpl;
 #include "utility/Macros.hpp"
 #include "utility/PtrVector.hpp"
 #include "utility/SqlError.hpp"
+#include "utility/StringUtil.hpp"
 
 #include "gflags/gflags.h"
 
@@ -399,6 +400,10 @@ int main(int argc, char* argv[]) {
             PrintToScreen::PrintRelation(*query_result_relation,
                                          query_processor->getStorageManager(),
                                          stdout);
+            PrintToScreen::PrintOutputSize(
+                *query_result_relation,
+                query_processor->getStorageManager(),
+                stdout);
 
             DropRelation::Drop(*query_result_relation,
                                query_processor->getDefaultDatabase(),
@@ -406,13 +411,14 @@ int main(int argc, char* argv[]) {
           }
 
           query_processor->saveCatalog();
-          printf("Execution time: %g seconds\n",
-                 std::chrono::duration<double>(end - start).count());
+          std::chrono::duration<double, std::milli> time_ms = end - start;
+          printf("Time: %s ms\n",
+                 quickstep::DoubleToStringWithSignificantDigits(
+                     time_ms.count(), 3).c_str());
         } catch (const std::exception &e) {
           fprintf(stderr, "QUERY EXECUTION ERROR: %s\n", e.what());
           break;
         }
-        printf("Query Complete\n");
       } else {
         if (result.condition == ParseResult::kError) {
           fprintf(stderr, "%s", result.error_message.c_str());

--- a/storage/StorageBlock.cpp
+++ b/storage/StorageBlock.cpp
@@ -1361,4 +1361,9 @@ void StorageBlock::invalidateAllIndexes() {
   }
 }
 
+const std::size_t StorageBlock::getNumTuples() const {
+  DCHECK(tuple_store_ != nullptr);
+  return tuple_store_->numTuples();
+}
+
 }  // namespace quickstep

--- a/storage/StorageBlock.hpp
+++ b/storage/StorageBlock.hpp
@@ -311,17 +311,17 @@ class StorageBlock : public StorageBlockBase {
       ValueAccessor *accessor);
 
   /**
-   * @brief Perform a random sampling of data on  the StorageBlock. The number 
+   * @brief Perform a random sampling of data on  the StorageBlock. The number
    *       of records sampled is determined by the sample percentage in case of
    *       tuple sample. For block sample all the records in a block are taken.
    *
    * @param is_block_sample Flag to indicate if the Sampling method is a tuple
    *                        sample or block sample.
    * @param percentage The percentage of tuples to be sampled.Used only when the
-   *                   sampling method is tuple sample.            
+   *                   sampling method is tuple sample.
    * @param destination Where to insert the tuples resulting from the SAMPLE.
    *
-   * @return Randomly sampled tuples whose count is determined by the  
+   * @return Randomly sampled tuples whose count is determined by the
    *         sampling percentage. In the case of block sample the entire
    *         block is returned.
    **/
@@ -582,6 +582,11 @@ class StorageBlock : public StorageBlockBase {
     tuple_store_->rebuild();
     return rebuildIndexes(false);
   }
+
+  /**
+   * @brief Get the number of tuples in this storage block.
+   **/
+  const std::size_t getNumTuples() const;
 
  private:
   static TupleStorageSubBlock* CreateTupleStorageSubBlock(


### PR DESCRIPTION
- Provide an API to calculate the number of rows in a table.
- Print output time in milliseconds, upto 3 decimal places, similar to what Postgres does.
- Simplify output messages.

Sample output on a table with only one column and two rows: 
```
quickstep> select * from r;
+-----------+
|id         |
+-----------+
|          3|
|          5|
+-----------+
( 2 rows )
Time: 2.315 ms
quickstep> select count(*) from r;
+--------------------+
|count(*)            |
+--------------------+
|                   2|
+--------------------+
( 1 rows )
Time: 0.879 ms
quickstep> select count(*) from r where r.id < 4;
+--------------------+
|count(*)            |
+--------------------+
|                   1|
+--------------------+
( 1 rows )
Time: 0.879 ms
quickstep> select count(*) from r where r.id < 2;
+--------------------+
|count(*)            |
+--------------------+
|                   0|
+--------------------+
( 1 rows )
Time: 0.748 ms
```

I also tried running queries on larger tables and it worked correctly. 