### PR TITLE
Fixes a g++ compiler warning

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -588,8 +588,8 @@ void ExecutionGenerator::convertHashJoin(const P::HashJoinPtr &physical_plan) {
   std::vector<attribute_id> probe_original_attribute_ids;
   std::vector<attribute_id> build_original_attribute_ids;
 
-  const CatalogRelation *referenced_stored_probe_relation;
-  const CatalogRelation *referenced_stored_build_relation;
+  const CatalogRelation *referenced_stored_probe_relation = nullptr;
+  const CatalogRelation *referenced_stored_build_relation = nullptr;
 
   bool any_probe_attributes_nullable = false;
   bool any_build_attributes_nullable = false;


### PR DESCRIPTION
Fixes a compiler warning for g++ 4.9.2:

```bash
Scanning dependencies of target quickstep_queryoptimizer_ExecutionGenerator
[100%] Building CXX object query_optimizer/CMakeFiles/quickstep_queryoptimizer_ExecutionGenerator.dir/ExecutionGenerator.cpp.o
In file included from /home/spehlmann/qs/query_optimizer/ExecutionGenerator.hpp:36:0,
                 from /home/spehlmann/qs/query_optimizer/ExecutionGenerator.cpp:20:
/home/spehlmann/qs/query_optimizer/ExecutionHeuristics.hpp: In member function ‘void quickstep::optimizer::ExecutionGenerator::convertHashJoin(const HashJoinPtr&)’:
/home/spehlmann/qs/query_optimizer/ExecutionHeuristics.hpp:63:10: error: ‘referenced_stored_build_relation’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   struct HashJoinInfo {
          ^
/home/spehlmann/qs/query_optimizer/ExecutionGenerator.cpp:592:26: note: ‘referenced_stored_build_relation’ was declared here
   const CatalogRelation *referenced_stored_build_relation;
                          ^
cc1plus: all warnings being treated as errors
```

by initializing the pointers.