### PR TITLE
Fix bug in the SMA code

### DIFF
--- a/storage/SMAIndexSubBlock.cpp
+++ b/storage/SMAIndexSubBlock.cpp
@@ -621,9 +621,14 @@ Selectivity SMAIndexSubBlock::getSelectivityForPredicate(const ComparisonPredica
 predicate_cost_t SMAIndexSubBlock::estimatePredicateEvaluationCost(
     const ComparisonPredicate &predicate) const {
   DCHECK(initialized_);
-  Selectivity selectivity = getSelectivityForPredicate(predicate);
-  if (selectivity == Selectivity::kAll || selectivity == Selectivity::kNone) {
-    return predicate_cost::kConstantTime;
+
+  // Check that at least one of the operands has a static values.
+  if (predicate.getRightOperand().hasStaticValue() ||
+      predicate.getLeftOperand().hasStaticValue()) {
+    Selectivity selectivity = getSelectivityForPredicate(predicate);
+    if (selectivity == Selectivity::kAll || selectivity == Selectivity::kNone) {
+      return predicate_cost::kConstantTime;
+    }
   }
   return predicate_cost::kInfinite;
 }

--- a/storage/SMAIndexSubBlock.cpp
+++ b/storage/SMAIndexSubBlock.cpp
@@ -622,9 +622,9 @@ predicate_cost_t SMAIndexSubBlock::estimatePredicateEvaluationCost(
     const ComparisonPredicate &predicate) const {
   DCHECK(initialized_);
 
-  // Check that at least one of the operands has a static values.
-  if (predicate.getRightOperand().hasStaticValue() ||
-      predicate.getLeftOperand().hasStaticValue()) {
+  // Check that at least one of the operands has a static value.
+  if (predicate.getLeftOperand().hasStaticValue() ||
+      predicate.getRightOperand().hasStaticValue()) {
     Selectivity selectivity = getSelectivityForPredicate(predicate);
     if (selectivity == Selectivity::kAll || selectivity == Selectivity::kNone) {
       return predicate_cost::kConstantTime;


### PR DESCRIPTION
Fix bug in the SMA code so that the SMA predicate evaluation is only applied if at least one of the operands in the predicate is a static value. Thus, queries like: `select * from foo where foo.int1 < foo.int2;`