### PR TITLE
Resolves SMA bugs revealed by TPCH.

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1451,6 +1451,7 @@ target_link_libraries(SMAIndexSubBlock_unittest
                       quickstep_types_CharType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
+                      quickstep_types_IntType
                       quickstep_types_LongType
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID

--- a/storage/SMAIndexSubBlock.hpp
+++ b/storage/SMAIndexSubBlock.hpp
@@ -120,7 +120,6 @@ struct SMAPredicate {
   // that the predicate had not been used previously.
   Selectivity selectivity;
 
- private:
   SMAPredicate(const attribute_id attr,
                const ComparisonID comp,
                const TypedValue lit)
@@ -376,7 +375,7 @@ class SMAIndexSubBlock : public IndexSubBlock {
  private:
   bool requiresRebuild() const;
 
-  inline sma_internal::Selectivity getSelectivityForPredicate(const ComparisonPredicate &predicate) const;
+  sma_internal::Selectivity getSelectivityForPredicate(const ComparisonPredicate &predicate) const;
 
   // Retrieves an entry, first checking if the given attribute is indexed.
   inline const sma_internal::SMAEntry* getEntryChecked(attribute_id attribute) const {


### PR DESCRIPTION
Running the TPCH queries revealed some bugs in SMA.
**Bugfix 1**
This resolves the issue where predicates which are not of the form 'Attribute comparison literal' (Ex. `lo_orderkey > 100000`) cause a GLOG(FATAL) when really, they can just be ignored by the SMA.

The commit `eb6fecd` resolves this.

**Bugfix 2**
There is another issue with SMA to do with conversion of TypedValues. For example on a simplified version of TPCH query 6:
```SQL
SELECT sum(l_extendedprice * l_discount) AS revenue 
FROM lineitem
WHERE l_quantity < 24;
```
The literal value `24` is integer type compared to the double type which l_quantity is stored as.

The commit `824efaa` fixes this.