### PR TITLE
URL Cleanup

### DIFF
--- a/third_party/gperftools/ltmain.sh
+++ b/third_party/gperftools/ltmain.sh
@@ -24,7 +24,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GNU Libtool; see the file COPYING.  If not, a copy
-# can be downloaded from http://www.gnu.org/licenses/gpl.html,
+# can be downloaded from https://www.gnu.org/licenses/gpl.html,
 # or obtained by writing to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
@@ -75,8 +75,8 @@
 #         autoconf:	$autoconf_version
 #
 # Report bugs to <bug-libtool@gnu.org>.
-# GNU libtool home page: <http://www.gnu.org/software/libtool/>.
-# General help using GNU software: <http://www.gnu.org/gethelp/>.
+# GNU libtool home page: <https://www.gnu.org/software/libtool/>.
+# General help using GNU software: <https://www.gnu.org/gethelp/>.
 
 PROGRAM=libtool
 PACKAGE=libtool

--- a/third_party/tmb/third_party/gtest/build-aux/ltmain.sh
+++ b/third_party/tmb/third_party/gtest/build-aux/ltmain.sh
@@ -24,7 +24,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GNU Libtool; see the file COPYING.  If not, a copy
-# can be downloaded from http://www.gnu.org/licenses/gpl.html,
+# can be downloaded from https://www.gnu.org/licenses/gpl.html,
 # or obtained by writing to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
@@ -75,8 +75,8 @@
 #         autoconf:	$autoconf_version
 #
 # Report bugs to <bug-libtool@gnu.org>.
-# GNU libtool home page: <http://www.gnu.org/software/libtool/>.
-# General help using GNU software: <http://www.gnu.org/gethelp/>.
+# GNU libtool home page: <https://www.gnu.org/software/libtool/>.
+# General help using GNU software: <https://www.gnu.org/gethelp/>.
 
 PROGRAM=libtool
 PACKAGE=libtool


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.gnu.org/gethelp/ with 2 occurrences migrated to:  
  https://www.gnu.org/gethelp/ ([https](https://www.gnu.org/gethelp/) result 200).
* http://www.gnu.org/licenses/gpl.html with 2 occurrences migrated to:  
  https://www.gnu.org/licenses/gpl.html ([https](https://www.gnu.org/licenses/gpl.html) result 200).
* http://www.gnu.org/software/libtool/ with 2 occurrences migrated to:  
  https://www.gnu.org/software/libtool/ ([https](https://www.gnu.org/software/libtool/) result 200).